### PR TITLE
Remove dependencies caching from workflows

### DIFF
--- a/.github/workflows/check-toc.yml
+++ b/.github/workflows/check-toc.yml
@@ -35,19 +35,6 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v2
 
-      - name: Get week number for use in cache key
-        id: get-date
-        run: |
-          echo "::set-output name=week-number::$(date --utc '+%V')"
-
-      - name: Load dependencies cache
-        uses: actions/cache@v2
-        with:
-          path: ~/.npm
-          key: ${{ runner.os }}-node-markdown-toc-${{ steps.get-date.outputs.week-number }}
-          restore-keys: |
-            ${{ runner.os }}-node-markdown-toc-
-
       - name: Install markdown-toc
         run: sudo npm install --global markdown-toc
 

--- a/.github/workflows/check-workflows.yml
+++ b/.github/workflows/check-workflows.yml
@@ -33,19 +33,6 @@ jobs:
           location: ${{ runner.temp }}/github-workflow-schema
           file-name: github-workflow.json
 
-      - name: Get week number for use in cache key
-        id: get-date
-        run: |
-          echo "::set-output name=week-number::$(date --utc '+%V')"
-
-      - name: Load dependencies cache
-        uses: actions/cache@v2
-        with:
-          path: ~/.npm
-          key: ${{ runner.os }}-node-ajv-cli-${{ steps.get-date.outputs.week-number }}
-          restore-keys: |
-            ${{ runner.os }}-node-ajv-cli-
-
       - name: Install JSON schema validator
         run: sudo npm install --global ajv-cli
 


### PR DESCRIPTION
After I set up caching in the template workflows, doubts were raised about whether it provided any benefits. I don't know
enough about this subject to make a call on that and I have been unable to get any more information on the subject.

Since the caching significantly increases the complexity of the workflows, which may make them more difficult to maintain
and contribute to, I think it's best to just remove all the caching for now. I hope to eventually be able to revisit this
topic and restore caching in any workflows where it is definitely beneficial.

I had intended to remove the caching before deploying the workflows, but then somehow forgot about it, so it slipped through with https://github.com/arduino/library-registry/pull/6

Resolves https://github.com/arduino/library-registry/pull/7 (this PR is the result of a very rare situation where the `actions/cache` maintainers intentionally neglected to move the major version ref due to accidental breakage introduced in the v2.1.4 release). If we were keeping the caching we could just disregard the Dependabot PR, but since we don't want the caching anyway the whole situation is irrelevant to this project.