### PR TITLE
Use custom matrix job names in `check-submissions` job

### DIFF
--- a/.github/workflows/manage-prs.yml
+++ b/.github/workflows/manage-prs.yml
@@ -125,6 +125,7 @@ jobs:
             - ${{ needs.parse.outputs.type }}
 
   check-submissions:
+    name: Check ${{ matrix.submission.submissionURL }}
     needs:
       - enabled
       - parse


### PR DESCRIPTION
The "Manage PRs" GitHub Actions workflow generates a matrix job for each library submitted by the PR. The default job
name is generated from the job's matrix object. This contains the complete submission data, which results in a long and
somewhat cryptic job name that can make the workflow run more difficult to interpret.

The only necessary information is the description of the job's purpose ("check") and the submission URL (multiple URLs
per PR are supported). A custom job name allows for only using this information in the job name.

---
### Demo

Before: https://github.com/per1234/library-registry/actions/runs/746591458
After: https://github.com/per1234/library-registry/runs/2340979375