### PR TITLE
Provide immediate response to comment trigger

### DIFF
--- a/.github/workflows/manage-prs.yml
+++ b/.github/workflows/manage-prs.yml
@@ -31,8 +31,23 @@ jobs:
       )
     runs-on: ubuntu-latest
     steps:
-      - name: Dummy step to make job valid
-        run: ""
+      - name: Comment on comment trigger to provide feedback
+        if: github.event_name == 'issue_comment'
+        uses: octokit/request-action@v2.x
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          route: POST /repos/{owner}/{repo}/issues/{issue_number}/comments
+          owner: ${{ github.repository_owner }}
+          repo: ${{ github.event.repository.name }}
+          issue_number: ${{ github.event.pull_request.number }}${{ github.event.issue.number }}
+          body: |
+            |
+            Hello! I'm checking your submission again.
+
+            You can see the progress here:
+            https://github.com/${{ github.repository_owner }}/${{ github.event.repository.name }}/actions/workflows/manage-prs.yml
+
   diff:
     needs:
       - enabled


### PR DESCRIPTION
When there is a problem with the submission that must be resolved in the library repository, a comment mentioning
`@ArduinoBot` is used to trigger the "Manage PRs" workflow.

We are accustomed to seeing the checks status in the PR thread when workflows are running. However, with a comment
triggered workflow this does not happen. The only indication of the workflow running is on the "Actions" tab. This can
leave the submitter wondering if their comment had any effect as the workflow takes some time to run before providing
feedback.

This uncertainty can be avoided by making the bot immediately comment to acknowledge that the check is in progress.

Demo: https://github.com/per1234/library-registry/pull/21#issuecomment-826548172