### PR TITLE
Comment on submission acceptance

### DIFF
--- a/.github/workflows/manage-prs.yml
+++ b/.github/workflows/manage-prs.yml
@@ -1,7 +1,7 @@
 name: Manage PRs
 
 env:
-  SUBMISSION_PARSER_VERSION: 1.0.0-rc2 # See: https://github.com/arduino/library-manager-submission-parser/releases
+  SUBMISSION_PARSER_VERSION: 1.0.0-rc3 # See: https://github.com/arduino/library-manager-submission-parser/releases
 
 on:
   # pull_request_target trigger is used instead of pull_request so the token will have the write permissions needed to
@@ -80,6 +80,7 @@ jobs:
       type: ${{ steps.parse-request.outputs.type }}
       submissions: ${{ steps.parse-request.outputs.submissions }}
       index-entry: ${{ steps.parse-request.outputs.index-entry }}
+      indexer-logs-urls: ${{ steps.parse-request.outputs.indexer-logs-urls }}
 
     steps:
       - name: Checkout local repository
@@ -113,6 +114,7 @@ jobs:
           echo "::set-output name=type::$(echo "$REQUEST" | jq -r -c '.type')"
           echo "::set-output name=submissions::$(echo "$REQUEST" | jq -c '.submissions')"
           echo "::set-output name=index-entry::$(echo "$REQUEST" | jq -r -c '.indexEntry')"
+          echo "::set-output name=indexer-logs-urls::$(echo "$REQUEST" | jq -r -c '.indexerLogsURLs')"
 
   label:
     needs:
@@ -313,6 +315,24 @@ jobs:
               git commit \
                 --file -
           git push
+
+      - name: Comment that submission was accepted
+        uses: octokit/request-action@v2.x
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          route: POST /repos/{owner}/{repo}/issues/{issue_number}/comments
+          owner: ${{ github.repository_owner }}
+          repo: ${{ github.event.repository.name }}
+          issue_number: ${{ github.event.pull_request.number }}${{ github.event.issue.number }}
+          body: |
+            |
+            Your submission has now been accepted! Thanks for your contribution to the Arduino Library Manager index.
+
+            The library(s) will be available for installation via Library Manager within a day's time.
+
+            You can check the logs from the Library Manager indexer for your library(s) here:
+            ${{ needs.parse.outputs.indexer-logs-urls }}
 
   request-review:
     needs:


### PR DESCRIPTION
Previously, as soon as a submission was compliant, the PR was merged silently. This might leave the submitter wondering
whether the submission process is complete.

There is some uncertain delay for the library release to be added to the server, the index to be generated, and the index
to propagate through the CDN, which might result in an increased support burden as the submitters comment or open issues
asking what is happening.

This is avoided by making the bot comment on the PR thread after the PR is merged, notifying the submitter that the
process was successful and that there will be some delay before the library is available from Library Manager.

Indexer logs URLs are provided for each submission, allowing the submitter to monitor the indexing process, both
immediately after the acceptance, as well as after they make future releases.

Demo: https://github.com/per1234/library-registry/pull/20#issuecomment-826512894