### PR TITLE
Remove unnecessary property reference from issue number definition for comment feedback comment

### DIFF
--- a/.github/workflows/manage-prs.yml
+++ b/.github/workflows/manage-prs.yml
@@ -40,7 +40,7 @@ jobs:
           route: POST /repos/{owner}/{repo}/issues/{issue_number}/comments
           owner: ${{ github.repository_owner }}
           repo: ${{ github.event.repository.name }}
-          issue_number: ${{ github.event.pull_request.number }}${{ github.event.issue.number }}
+          issue_number: ${{ github.event.issue.number }}
           body: |
             |
             Hello! I'm checking your submission again.


### PR DESCRIPTION
The "Manage PRs" workflow can be triggered by either a `pull_request_target` or `issue_comment` event. This means that
the `issue_number` parameter of the GitHub API request must be defined using both the `github.event.pull_request.number`
and `github.event.issue.number` properties because a different one is defined depending on which event was the trigger.
The exception is the API request for the bot comment used to provide immediate feedback when the workflow is triggered by
a comment. This API request is only ever used with an `issue_comment` event trigger, so the
`github.event.pull_request.number` property is not needed.

Demo: https://github.com/per1234/library-registry/pull/25#issuecomment-827234233