### PR TITLE
Use squash merge for submission PRs

### DIFF
--- a/.github/workflows/manage-prs.yml
+++ b/.github/workflows/manage-prs.yml
@@ -310,6 +310,7 @@ jobs:
           owner: ${{ github.repository_owner }}
           repo: ${{ github.event.repository.name }}
           pull_number: ${{ github.event.pull_request.number }}${{ github.event.issue.number }}
+          merge_method: squash
 
       - name: Checkout index source branch
         uses: actions/checkout@v2


### PR DESCRIPTION
There is no good reason for a submission to consist of more than one commit.

As the submitter works with the bot to produce a compliant submission, they will sometimes end up with PRs that consist
of multiple non-atomic commits, which would pollute the repository's commit history if not squashed at the time of the
merge.

Demo: https://github.com/per1234/library-registry/pull/27

GitHub API Reference:
https://docs.github.com/en/rest/reference/pulls#merge-a-pull-request