### PR TITLE
Move comment re: "Unexpected input(s)" warnings for `octokit/request-action` to first usage

### DIFF
--- a/.github/workflows/manage-prs.yml
+++ b/.github/workflows/manage-prs.yml
@@ -49,6 +49,8 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
+          # NOTE: "Unexpected input(s) ..." warnings for the arbitrary octokit/request-action inputs are normal and
+          # expected.
           route: POST /repos/{owner}/{repo}/issues/{issue_number}/comments
           owner: ${{ github.repository_owner }}
           repo: ${{ github.event.repository.name }}
@@ -167,8 +169,6 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          # NOTE: "Unexpected input(s) ..." warnings for the arbitrary octokit/request-action inputs are normal and
-          # expected.
           route: POST /repos/{owner}/{repo}/issues/{issue_number}/comments
           owner: ${{ github.repository_owner }}
           repo: ${{ github.event.repository.name }}


### PR DESCRIPTION
The `octokit/request-action` GitHub Actions action is designed to accept API request parameters as arbitrary action
inputs in the workflow. Because they have made no attempt to define all possible input keys in the action metadata,
normal and correct usage of the action cases GitHub Actions to display warnings in the workflow run log and summary. For
example:

>Unexpected input(s) 'owner', 'repo', 'issue_number', 'labels', valid inputs are ['route', 'mediaType']

This has the potential to cause confusion, so I added a comment to the workflow explaining that this warning is expected
and doesn't indicate a problem. That comment somehow ended on a random occurence of `octokit/request-action` in the
workflow. It makes most sense to put it on the first usage of the action in the workflow, to make the information easy to
find.