### PR TITLE
Restrict failure handling job runs to specific job failure

### DIFF
--- a/.github/workflows/manage-prs.yml
+++ b/.github/workflows/manage-prs.yml
@@ -256,7 +256,8 @@ jobs:
   check-submissions-fail:
     needs:
       - check-submissions
-    if: failure() # This job will only run if the submission checks failed
+    # Only run if the check-submissions job failed
+    if: failure() && needs.check-submissions.result == 'failure'
     runs-on: ubuntu-latest
 
     steps:
@@ -342,7 +343,8 @@ jobs:
   merge-fail:
     needs:
       - merge
-    if: failure()
+    # Only run if the merge job failed
+    if: failure() && needs.merge.result == 'failure'
     runs-on: ubuntu-latest
     steps:
       - name: Comment on merge failure


### PR DESCRIPTION
GitHub Actions workflow jobs default to the `if: success()` configuration. In this configuration, the job only runs when
the result of its job dependencies was success. When configuring a job to run on a failure result with `if: failure()` it
is logical to assume that the behavior would be inverted: the job would run only when the result of its dependency job
was failure. It does this, but also runs when its dependency job was canceled due to a failure of its own dependency.

This behavior of GitHub Actions resulted in the failure handling jobs running when they were not intended to. That is
avoided by specifying the exact job whose failure they were intended to handle in the conditional. It is still necessary
to use `failure()` in the conditional, otherwise they retain the default `success()` configuration and never run on a failure.

### Demos

- Handling of a simulated unexpected workflow failure (404 on the GitHub API) before this change: https://github.com/per1234/library-registry/pull/29
  (note the spurious "Please resolve the error(s) mentioned in the previous comment." and "Please follow this guide to resolve a merge conflict:" comments)
- Handling of a simulated unexpected workflow failure (404 on the GitHub API) after this change: https://github.com/per1234/library-registry/pull/30
  (note the lack of spurious comments)
- Workflow from this PR put through the full manual testing procedure: https://github.com/per1234/library-registry/pull/31/
