### PR TITLE
Use less ambiguous name for workflow job handling non-submission PRs

### DIFF
--- a/.github/workflows/manage-prs.yml
+++ b/.github/workflows/manage-prs.yml
@@ -375,7 +375,7 @@ jobs:
           team_reviewers: |
             - arduino/team_tooling
 
-  request-review:
+  not-submission:
     needs:
       - parse
     if: needs.parse.outputs.type != 'submission' # These request types can't be automatically approved.


### PR DESCRIPTION
In the event a PR is detected as something other than a library submission, a review is requested from the Tooling Team and a comment is made to the PR thread explaining the situation.

Previously, the job handling this was named `request-review`. However, there are other circumstances under which a review will be requested (e.g., merge conflict). So this was not a very good job name.

This job name is not referenced anywhere else in the workflow, so it currently only serves a documentation role and changing it has no functional effect.