### PR TITLE
Handle unexpected failures in "Manage PRs" workflow

### DIFF
--- a/.github/workflows/manage-prs.yml
+++ b/.github/workflows/manage-prs.yml
@@ -413,3 +413,52 @@ jobs:
 
             If you intended to submit a library, please check the instructions and update your pull request if necessary:
             https://github.com/${{ github.repository }}/blob/main/README.md#instructions
+
+  unexpected-fail:
+    needs:
+      - label
+    # Run if label or any of its job dependencies failed
+    if: failure()
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Label PR to indicate need for maintenance
+        uses: octokit/request-action@v2.x
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          route: PUT /repos/{owner}/{repo}/issues/{issue_number}/labels
+          owner: ${{ github.repository_owner }}
+          repo: ${{ github.event.repository.name }}
+          issue_number: ${{ github.event.pull_request.number }}${{ github.event.issue.number }}
+          labels: |
+            - "status: maintenance required"
+
+      - name: Request pull request review
+        uses: octokit/request-action@v2.x
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          route: POST /repos/{owner}/{repo}/pulls/{pull_number}/requested_reviewers
+          owner: ${{ github.repository_owner }}
+          repo: ${{ github.event.repository.name }}
+          pull_number: ${{ github.event.pull_request.number }}${{ github.event.issue.number }}
+          team_reviewers: |
+            - arduino/team_tooling
+
+      - name: Comment on unexpected failure
+        uses: octokit/request-action@v2.x
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          route: POST /repos/{owner}/{repo}/issues/{issue_number}/comments
+          owner: ${{ github.repository_owner }}
+          repo: ${{ github.event.repository.name }}
+          issue_number: ${{ github.event.pull_request.number }}${{ github.event.issue.number }}
+          body: |
+            |
+            Hi @${{ github.actor }}.
+            There was an unexpected failure during automated processing of your pull request.
+            This error is unrelated to the content of your pull request.
+
+            A maintainer has been notified and will investigate as soon as possible.


### PR DESCRIPTION
The workflow already handles all expected failures in a manner that is as automated and friendly to the submitter as
possible.

However, there is always the chance for unexpected failures caused by a bug or service outage, which are in no way the
fault of the submitter. In this event, the workflow would previously fail without any clear explanation of what had
happened. This would be likely to cause confusion to the submitter. Since the system is very automated, this failure
might also go unnoticed by the repository maintainers.

A better way to handle unexpected failures is to:

- Add a special label ("status: maintenance required").
- Request a review from the Tooling Team.
- Comment to explain to the submitter that something went wrong and we will investigate.

---
### Demos

- Behavior after https://github.com/arduino/library-registry/pull/20 but before the change in this PR: https://github.com/per1234/library-registry/pull/30
  (note silent failure) 
- Behavior after https://github.com/arduino/library-registry/pull/20 and this PR: https://github.com/per1234/library-registry/pull/33
  (note helpful label and comment)
- Workflow from this PR combined with https://github.com/arduino/library-registry/pull/20 put through the full manual testing procedure: https://github.com/per1234/library-registry/pull/32