### PR TITLE
Don't run "Manage PRs" workflow on draft PRs

### DIFF
--- a/.github/workflows/manage-prs.yml
+++ b/.github/workflows/manage-prs.yml
@@ -22,7 +22,10 @@ on:
 jobs:
   diff:
     if: >
-      github.event_name == 'pull_request_target' ||
+      (
+        github.event_name == 'pull_request_target' &&
+        github.event.pull_request.draft == false
+      ) ||
       (
         github.event_name == 'issue_comment' &&
         github.event.issue.pull_request != '' &&


### PR DESCRIPTION
The draft mode clearly indicates that the PR is not ready for processing, so having the submission system run on these
PRs would only be an annoyance.

The workflow will still be triggered if `@ArduinoBot` is mentioned in a draft PR comment thread, but if someone is doing that then they likely intend to trigger the workflow anyway.

---
- Demo of draft PR (note the workflow is triggered, but no jobs run): https://github.com/per1234/library-registry/pull/36
- Demo of normal PR (workflow runs as usual): https://github.com/per1234/library-registry/pull/37