### PR TITLE
Delete diff artifact after use in "Manage PRs" workflow

### DIFF
--- a/.github/workflows/manage-prs.yml
+++ b/.github/workflows/manage-prs.yml
@@ -109,6 +109,11 @@ jobs:
           path: ${{ needs.diff.outputs.path }}
           name: ${{ needs.diff.outputs.artifact }}
 
+      - name: Remove no longer needed artifact
+        uses: geekyeggo/delete-artifact@v1
+        with:
+          name: ${{ needs.diff.outputs.artifact }}
+
       - name: Parse request
         id: parse-request
         run: |


### PR DESCRIPTION
A workflow artifact is used to transfer the PR diff file from the `diff` job to the `parse` job. Once the artifact has been downloaded by the `parse` job, it no longer serves any purpose.

It's possible the artifact might serve as a vector for exporting secrets from the workflow. Even though I don't have any specific reasons to believe it is possible to cause secrets to be written to the artifact and the repository doesn't currently have any secrets beyond `GITHUB_TOKEN`, nor need for any, it's still best to remove the unnecessary artifact.

We have been using the `geekyeggo/delete-artifact` action with good success in the `arduino/arduino-ide` repository for some time now: https://github.com/arduino/arduino-ide/blob/0dd1e/.github/workflows/build.yml#L232

Demo: https://github.com/per1234/library-registry/pull/38
(note lack of artifact here: https://github.com/per1234/library-registry/runs/2463658819)