### PR TITLE
Use text format Arduino Lint report in comment

### DIFF
--- a/.github/workflows/manage-prs.yml
+++ b/.github/workflows/manage-prs.yml
@@ -169,7 +169,9 @@ jobs:
     steps:
       - name: Set environment variables
         run: |
-          echo "REPORT_PATH=${{ runner.temp }}/report.json" >> "$GITHUB_ENV"
+          echo "JSON_REPORT_PATH=${{ runner.temp }}/report.json" >> "$GITHUB_ENV"
+          echo "TEXT_REPORT_PATH=${{ runner.temp }}/report.txt" >> "$GITHUB_ENV"
+          echo "ARDUINO_LINT_INSTALLATION_PATH=${{ runner.temp }}/arduino-lint" >> "$GITHUB_ENV"
 
       - name: Comment on error detected while parsing submission
         if: matrix.submission.error != ''
@@ -193,6 +195,16 @@ jobs:
           echo "::error::Error found with submission"
           exit 1
 
+      - name: Install Arduino Lint
+        run: |
+          mkdir --parents "${{ env.ARDUINO_LINT_INSTALLATION_PATH }}"
+          curl \
+            -fsSL \
+            https://raw.githubusercontent.com/arduino/arduino-lint/main/etc/install.sh \
+          | \
+          BINDIR="${{ env.ARDUINO_LINT_INSTALLATION_PATH }}" \
+          sh
+
       - name: Clone submission
         run: |
           git clone \
@@ -202,25 +214,36 @@ jobs:
 
       - name: Lint submission
         id: arduino-lint
-        uses: arduino/arduino-lint-action@v1
         continue-on-error: true # Continue the job so the report can be commented to the PR
-        with:
-          library-manager: submit
-          project-type: library
-          compliance: permissive
-          official: ${{ matrix.submission.official }}
-          path: ${{ matrix.submission.name }}
-          report-file: ${{ env.REPORT_PATH }}
+        run: |
+          export ARDUINO_LINT_OFFICIAL="${{ matrix.submission.official }}"
 
-      - name: Read Arduino Lint report
+          "${{ env.ARDUINO_LINT_INSTALLATION_PATH }}/arduino-lint" \
+            --compliance=permissive \
+            --format=text \
+            --library-manager=submit \
+            --project-type=library \
+            --recursive=false \
+            --report-file="${{ env.JSON_REPORT_PATH }}" \
+            "${{ matrix.submission.name }}" > \
+              "${{ env.TEXT_REPORT_PATH }}"
+
+      - name: Read Arduino Lint reports
         id: read-lint-report
         run: |
-          echo "::set-output name=report::$(jq -c . "${{ env.REPORT_PATH }}")"
+          echo "::set-output name=json-report::$(jq -c . "${{ env.JSON_REPORT_PATH }}")"
+
+          # In order to use the text format report as a step output, it's necessary to do some character replacements.
+          TEXT_REPORT=$(cat "${{ env.TEXT_REPORT_PATH }}")
+          TEXT_REPORT="${TEXT_REPORT//'%'/'%25'}"
+          TEXT_REPORT="${TEXT_REPORT//$'\n'/'%0A'}"
+          TEXT_REPORT="${TEXT_REPORT//$'\r'/'%0D'}"
+          echo "::set-output name=text-report::$TEXT_REPORT"
 
       - name: Comment on Arduino Lint warning
         if: >
-          fromJson(steps.read-lint-report.outputs.report).summary.warningCount > 0
-          && fromJson(steps.read-lint-report.outputs.report).summary.errorCount == 0
+          fromJson(steps.read-lint-report.outputs.json-report).summary.warningCount > 0
+          && fromJson(steps.read-lint-report.outputs.json-report).summary.errorCount == 0
         uses: octokit/request-action@v2.x
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -233,12 +256,12 @@ jobs:
             |
             [Arduino Lint](https://github.com/arduino/arduino-lint) has suggestions for possible improvements to ${{ matrix.submission.submissionURL }}:
 
-            ```json
-            ${{ toJson(fromJson(steps.read-lint-report.outputs.report).projects) }}
+            ```
+            ${{ steps.read-lint-report.outputs.text-report }}
             ```
 
       - name: Comment on Arduino Lint error
-        if: fromJson(steps.read-lint-report.outputs.report).summary.errorCount > 0
+        if: fromJson(steps.read-lint-report.outputs.json-report).summary.errorCount > 0
         uses: octokit/request-action@v2.x
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -251,8 +274,8 @@ jobs:
             |
             [Arduino Lint](https://github.com/arduino/arduino-lint) found errors with ${{ matrix.submission.submissionURL }}:
 
-            ```json
-            ${{ toJson(fromJson(steps.read-lint-report.outputs.report).projects) }}
+            ```
+            ${{ steps.read-lint-report.outputs.text-report }}
             ```
 
       - name: Fail on Arduino Lint error


### PR DESCRIPTION
Arduino Lint prints a summary report of the result of linting Arduino projects to stdout. It also offers the option of saving a JSON formatted report to a file.

In addition to rejecting the submission on an error result from Arduino Lint, the workflow also advocates for best practices in the libraries of Library Manager by commenting a copy of the report to the PR thread if any warnings are generated.

The machine-readable JSON format of the report file makes it easy to parse in the workflow to determine the warning count. However, this JSON format is not terribly friendly to human readers. The `text` format report printed to stdout is intended for that purpose. Previously, the JSON formatted report was commented to the PR thread, resulting in an unpleasant experience for the submitter.

In the intended application of the [`arduino/arduino-lint-action` GitHub Actions action](https://github.com/arduino/arduino-lint-action), the report is printed to the log, the interested user can access the report in the workflow run log, and any machine applications use the report file. However, in this specialized use case, we need both a text format and a JSON format report file. Although that capability could be added to the action, it would not likely be of use for other applications. For this reason, it makes more sense to simply use the Arduino Lint application directly in the workflow. This really doesn't introduce any significant complexity, since the action is only a thin wrapper.

---
- Report comment from before this change: https://github.com/per1234/library-registry/pull/45#issuecomment-829856081
- Report comment from after this change: https://github.com/per1234/library-registry/pull/46#issuecomment-829857564