### PR TITLE
Add explanatory comment re: not using actions/checkout

### DIFF
--- a/.github/workflows/manage-prs.yml
+++ b/.github/workflows/manage-prs.yml
@@ -208,6 +208,7 @@ jobs:
           BINDIR="${{ env.ARDUINO_LINT_INSTALLATION_PATH }}" \
           sh
 
+      # actions/checkout can't be used because it only supports GitHub repos, while libraries may use other Git hosts
       - name: Clone submission
         run: |
           git clone \


### PR DESCRIPTION
We are accustomed to using the `actions/checkout` GitHub Action action in workflows whenever a repository needs to be
installed into the runner. So it may be quite unexpected to see `git clone` used.

In this case, it was necessary to do so in order to clone the library repository to run Arduino Lint on it because
`actions/checkout` can only be used with GitHub repositories, whereas multiple major Git hosts are supported for
submissions to Library Manager. This might not be obvious to those working on the workflow in the future, so it's worth
leaving a comment to avoid confusion.