### PR TITLE
Clone submission to folder named after repository

### DIFF
--- a/.github/workflows/manage-prs.yml
+++ b/.github/workflows/manage-prs.yml
@@ -1,7 +1,7 @@
 name: Manage PRs
 
 env:
-  SUBMISSION_PARSER_VERSION: 1.0.0-rc5 # See: https://github.com/arduino/library-manager-submission-parser/releases
+  SUBMISSION_PARSER_VERSION: 1.0.0-rc6 # See: https://github.com/arduino/library-manager-submission-parser/releases
 
 on:
   # pull_request_target trigger is used instead of pull_request so the token will have the write permissions needed to
@@ -214,7 +214,7 @@ jobs:
           git clone \
             --branch ${{ matrix.submission.tag }} \
             --depth 1 ${{ matrix.submission.normalizedURL }} \
-            "${{ matrix.submission.name }}"
+            "${{ matrix.submission.repositoryName }}"
 
       - name: Lint submission
         id: arduino-lint
@@ -229,7 +229,7 @@ jobs:
             --project-type=library \
             --recursive=false \
             --report-file="${{ env.JSON_REPORT_PATH }}" \
-            "${{ matrix.submission.name }}" > \
+            "${{ matrix.submission.repositoryName }}" > \
               "${{ env.TEXT_REPORT_PATH }}"
 
       - name: Read Arduino Lint reports


### PR DESCRIPTION
The library folder name is a factor in the Arduino Lint results. Although the library.properties `name` value is used for
the Library Manager installation path, Arduino Lint rules also consider manual installation of libraries. These results
will be most accurate if the library is located in a folder named after the repository.

---
Demo: https://github.com/per1234/library-registry/pull/50