### PR TITLE
Remove review requests when no longer needed

### DIFF
--- a/.github/workflows/manage-prs.yml
+++ b/.github/workflows/manage-prs.yml
@@ -179,6 +179,18 @@ jobs:
           echo "TEXT_REPORT_PATH=${{ runner.temp }}/report.txt" >> "$GITHUB_ENV"
           echo "ARDUINO_LINT_INSTALLATION_PATH=${{ runner.temp }}/arduino-lint" >> "$GITHUB_ENV"
 
+      # Submission PRs can be handled without maintainer involvement
+      - name: Remove prior review requests
+        uses: octokit/request-action@v2.x
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          route: DELETE /repos/{owner}/{repo}/pulls/{pull_number}/requested_reviewers
+          owner: ${{ github.repository_owner }}
+          repo: ${{ github.event.repository.name }}
+          pull_number: ${{ github.event.pull_request.number }}${{ github.event.issue.number }}
+          reviewers: ${{ env.MAINTAINERS }}
+
       - name: Comment on error detected while parsing submission
         if: matrix.submission.error != ''
         uses: octokit/request-action@v2.x


### PR DESCRIPTION
If the PR is detected as something other than a submission, review is requested from a maintainer. It might be that the
PR was intended to be a submission and the submitter is able to resolve whatever caused it to be detected as otherwise
on their own. In this case, the automated system can handle things and review is no longer needed.

---
Demo:
(reviewer changed to Ubi for the demo because you can't request a review from the PR author)
1. Review request added when PR detected as "other" type: https://github.com/per1234/library-registry/pull/60#event-4715741328
2. Review request removed when change to PR made it detect as "submission" type: https://github.com/per1234/library-registry/pull/60#event-4715753795
3. Review request added again when submission merge failed due to merge conflict: https://github.com/per1234/library-registry/pull/60#event-4715786403

---
Remove request has no harmful effect if there wasn't a prior request to remove: https://github.com/per1234/library-registry/pull/61/checks?check_run_id=2544553674#step:3:1