### PR TITLE
Don't request review for PRs from maintainer

### DIFF
--- a/.github/workflows/manage-prs.yml
+++ b/.github/workflows/manage-prs.yml
@@ -405,6 +405,7 @@ jobs:
             Once that is done, it will be merged automatically.
 
       - name: Request a review in case assistance is required
+        if: contains(toJSON(env.MAINTAINERS), github.actor) != true # Don't attempt to request review from PR author.
         uses: octokit/request-action@v2.x
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -423,6 +424,7 @@ jobs:
 
     steps:
       - name: Request pull request review
+        if: contains(toJSON(env.MAINTAINERS), github.actor) != true
         uses: octokit/request-action@v2.x
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -472,6 +474,7 @@ jobs:
             - "status: maintenance required"
 
       - name: Request pull request review
+        if: contains(toJSON(env.MAINTAINERS), github.actor) != true
         uses: octokit/request-action@v2.x
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Review requests to the PR author are not allowed. Previously, there would be a spurious workflow failure for every PR
from a user in the `env.MAINTAINERS` array.

When a maintainer is submitting a PR, they can request reviews as needed, so the automated review request can simply be
skipped in this case.

---
Demo of spurious workflow failure before this change: https://github.com/arduino/library-registry/pull/30/checks?check_run_id=2544515245#step:2:26
Demo of review request skipped after this change: https://github.com/per1234/library-registry/pull/62/checks?check_run_id=2544831623