### PR TITLE
Post notification to Slack in the event of an unexpected workflow failure

### DIFF
--- a/.github/workflows/manage-prs.yml
+++ b/.github/workflows/manage-prs.yml
@@ -513,3 +513,14 @@ jobs:
             This error is unrelated to the content of your pull request.
 
             A maintainer has been notified and will investigate as soon as possible.
+
+      - name: Slack notification of unexpected failure
+        uses: rtCamp/action-slack-notify@v2
+        env:
+          SLACK_WEBHOOK: ${{ secrets.TEAM_TOOLING_CHANNEL_SLACK_WEBHOOK }}
+          SLACK_MESSAGE: |
+            :warning::warning::warning::warning:
+            WARNING: ${{ github.repository }} ${{ github.workflow }} workflow run had an unexpected failure!!!
+            :warning::warning::warning::warning:
+          SLACK_COLOR: danger
+          MSG_MINIMAL: true


### PR DESCRIPTION
When the "Manage PRs" workflow fails in a manner that should not occur normally (as opposed by the expected failures in the event of a non-compliant library submission), a post will be made to the Slack channel defined by the `TEAM_TOOLING_CHANNEL_SLACK_WEBHOOK` repository secret.

---
Demo of a simulated unexpected failure:
PR: https://github.com/per1234/library-registry/pull/66
Workflow run logs: https://github.com/per1234/library-registry/pull/66/checks?check_run_id=2584944667#step:6:1

![Untitled](https://user-images.githubusercontent.com/8572152/118291347-59cd9b00-b48c-11eb-8ff4-915eb551af0b.png)

