### PR TITLE
Use unique name for index source file

### DIFF
--- a/.github/workflows/manage-prs.yml
+++ b/.github/workflows/manage-prs.yml
@@ -360,7 +360,7 @@ jobs:
 
       - name: Add index source file entry for submissions
         run: |
-          INDEX_SOURCE_FILE_PATH="${{ github.workspace }}/repositories.txt"
+          INDEX_SOURCE_FILE_PATH="${{ github.workspace }}/registry.txt"
           git config --global user.email "bot@arduino.cc"
           git config --global user.name "ArduinoBot"
           echo "${{ needs.parse.outputs.index-entry }}" >> "$INDEX_SOURCE_FILE_PATH"


### PR DESCRIPTION
Previously, the submission list and the Library Manager index source list were both named "repositories.txt". While writing developer documentation for the system, I found having two files with similar content, but different purposes makes the already complex system unnecessarily difficult to understand.

Unlike the index source list, [the submission list](https://github.com/arduino/library-registry/blob/main/repositories.txt) is solely a list of repositories, so its current "repositories.txt" name is appropriate.

The index source list (not yet added to the `arduino/library-registry` repo, but hosted [here](https://github.com/per1234/library-registry/blob/production/repositories.txt) in the test repo) contains other information unrelated to the library repository (locked library name, library type attributes), so the "repositories.txt" name is not so appropriate. Since this repository is named "library-registry", the filename "registry.txt" makes sense.