### PR TITLE
Bump submission parser version to 1.0.0

### DIFF
--- a/.github/workflows/manage-prs.yml
+++ b/.github/workflows/manage-prs.yml
@@ -1,7 +1,7 @@
 name: Manage PRs
 
 env:
-  SUBMISSION_PARSER_VERSION: 1.0.0-rc6 # See: https://github.com/arduino/library-manager-submission-parser/releases
+  SUBMISSION_PARSER_VERSION: 1.0.0 # See: https://github.com/arduino/library-manager-submission-parser/releases
   MAINTAINERS: |
     # GitHub user names to request reviews from in cases where PRs can't be managed automatically.
     - per1234


### PR DESCRIPTION
There has been [a 1.0.0 release](https://github.com/arduino/library-registry-submission-parser/releases/tag/1.0.0) of arduino/library-registry-submission-parser, so the "Manage PRs" workflow should use it.