### PR TITLE
Rename Sqlite3 to Sqlite3 for ESP8266

### DIFF
--- a/registry.txt
+++ b/registry.txt
@@ -2211,7 +2211,7 @@ https://github.com/bogde/HX711.git|Contributed|HX711 Arduino Library
 https://github.com/PatternAgents/Haptic_DA7280.git|Contributed|Haptic_DA7280
 https://github.com/PatternAgents/Haptic_DRV2605.git|Contributed|Haptic_DRV2605
 https://github.com/siara-cc/Shox96_Arduino_Progmem_lib.git|Contributed|Shox96 Progmem Compression
-https://github.com/siara-cc/esp_arduino_sqlite3_lib.git|Contributed|Sqlite3
+https://github.com/siara-cc/esp_arduino_sqlite3_lib.git|Contributed|Sqlite3 for ESP8266
 https://github.com/M-tech-Creations/NoDelay.git|Contributed|NoDelay
 https://github.com/openmrn/OpenMRNLite.git|Contributed|OpenMRNLite
 https://github.com/Isaranu/IoTtweetSIEMENS_SIMATIC.git|Contributed|IoTtweetSIEMENS_SIMATIC


### PR DESCRIPTION
Fixes https://github.com/arduino/Arduino/issues/11573