### PR TITLE
Add RP2040_RTC to Library Manager

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -3987,3 +3987,4 @@ https://github.com/grafana/arduino-prom-loki-transport
 https://github.com/grafana/loki-arduino
 https://github.com/grafana/prometheus-arduino
 https://github.com/fbiego/MpesaSTK
+https://github.com/khoih-prog/RP2040_RTC


### PR DESCRIPTION
### Initial Releases v1.0.0

1. Initial coding to support RP2040-based boards such as **NANO_RP2040_CONNECT, RASPBERRY_PI_PICO, ADAFRUIT_FEATHER_RP2040 and GENERIC_RP2040** using [**Arduino-mbed RP2040** core](https://github.com/arduino/ArduinoCore-mbed) or [**Earle Philhower's arduino-pico core**](https://github.com/earlephilhower/arduino-pico).