### PR TITLE
add TeensyVariablePlayback library

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -2402,6 +2402,7 @@ https://github.com/netpieio/microgear-esp8266-arduino
 https://github.com/netpieio/microgear-nbiot-arduino
 https://github.com/neu-rah/ArduinoMenu
 https://github.com/neu-rah/Dump
+https://github.com/newdigate/teensy-variable-playback
 https://github.com/NHBSystems/NHB_AD7794
 https://github.com/niccokunzmann/UC121902-TNARX-A
 https://github.com/NicholasBerryman/GenericMotorDriver


### PR DESCRIPTION
extends Audio library for teensy, adds pitch/playback rate controls for audio samples.