### PR TITLE
Add TinyDebug library

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -3861,6 +3861,7 @@ https://github.com/Wiznet/WizFi250_arduino_library
 https://github.com/Wiznet/WizFi310_arduino_library
 https://github.com/wloche/LcdProgressBar
 https://github.com/wloche/LcdProgressBarDouble
+https://github.com/wokwi/TinyDebug
 https://github.com/wolfv6/keybrd
 https://github.com/Wolkabout/WolkConnect-Arduino
 https://github.com/wollewald/ADS1115_WE


### PR DESCRIPTION
Use this library to log debug information from your code while running ATtiny85 projects on the [Wokwi Arduino Simulator](https://wokwi.com). It provides a Stream interface, similar to the familiar `Serial` object.