### PR TITLE
Update URL and change name of "MaquinitasParameters"

### DIFF
--- a/registry.txt
+++ b/registry.txt
@@ -4131,7 +4131,7 @@ https://github.com/chochain/nanoFORTH.git|Contributed|nanoFORTH
 https://github.com/kevinstadler/TCS34725AutoGain.git|Contributed|TCS34725AutoGain
 https://github.com/arduino-libraries/Arduino_PortentaBreakout.git|Arduino|Arduino_PortentaBreakout
 https://github.com/Ant2000/CustomJWT.git|Contributed|CustomJWT
-https://github.com/maquinitas/MaquinitasParameters.git|Contributed|MaquinitasParams
+https://github.com/maquinitas/MaquinitasParams.git|Contributed|MaquinitasParams
 https://github.com/DavidArmstrong/SiderealPlanets.git|Contributed|SiderealPlanets
 https://github.com/rneurink/LP50XX.git|Contributed|LP50XX
 https://github.com/Treboada/Ds1302.git|Contributed|Ds1302

--- a/registry.txt
+++ b/registry.txt
@@ -4131,7 +4131,7 @@ https://github.com/chochain/nanoFORTH.git|Contributed|nanoFORTH
 https://github.com/kevinstadler/TCS34725AutoGain.git|Contributed|TCS34725AutoGain
 https://github.com/arduino-libraries/Arduino_PortentaBreakout.git|Arduino|Arduino_PortentaBreakout
 https://github.com/Ant2000/CustomJWT.git|Contributed|CustomJWT
-https://github.com/maquinitas/MaquinitasParameters.git|Contributed|MaquinitasParameters
+https://github.com/maquinitas/MaquinitasParameters.git|Contributed|MaquinitasParams
 https://github.com/DavidArmstrong/SiderealPlanets.git|Contributed|SiderealPlanets
 https://github.com/rneurink/LP50XX.git|Contributed|LP50XX
 https://github.com/Treboada/Ds1302.git|Contributed|Ds1302


### PR DESCRIPTION
This handles two separate modification request for the library:

- Change name from "MaquinitasParameters" to "MaquinitasParams".
- Change repository URL from `https://github.com/maquinitas/MaquinitasParameters.git` to `https://github.com/maquinitas/MaquinitasParams.git`

Follow-up to https://github.com/arduino/library-registry/pull/151

Fixes https://github.com/arduino/library-registry/issues/150