### PR TITLE
Add Marlin U8glib-HAL. Modified U8glib for Marlin 2.0

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -4053,3 +4053,4 @@ https://github.com/radariq/arduino-library
 https://gitlab.com/riva-lab/fastIO
 https://gitlab.com/riva-lab/SevenSegmentPanel
 https://github.com/konikoni428/BM64_arduino
+https://github.com/MarlinFirmware/U8glib-HAL


### PR DESCRIPTION
Add Marlin U8glib-HAL. Modified  U8glib for Marlin 2.0 