### PR TITLE
Change library name

### DIFF
--- a/registry.txt
+++ b/registry.txt
@@ -4161,4 +4161,4 @@ https://github.com/Abdurraziq/ZMPT101B-arduino.git|Contributed|ZMPT101B
 https://github.com/khoih-prog/AsyncUDP_WT32_ETH01.git|Contributed|AsyncUDP_WT32_ETH01
 https://github.com/Zerfoinder/EasyPin.git|Contributed|EasyPin
 https://github.com/bitbank2/PNGenc.git|Contributed|PNGenc
-https://github.com/tfeldmann/Arduino-SchmittTrigger.git|Contributed|Schmitt trigger
+https://github.com/tfeldmann/Arduino-SchmittTrigger.git|Contributed|SchmittTrigger


### PR DESCRIPTION
Changed from "Schmitt trigger" to "SchmittTrigger".
This change is also done in the library's properties.