### PR TITLE
Remove non-existent step from submission instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,8 +39,6 @@ See the instructions below for detailed instructions on how to do this via the G
    GitHub web interface: https://github.com/arduino/library-registry/edit/main/repositories.txt
 1. Add the library repository's URL to the list. This should be the URL of the repository home page. For example:
    `https://github.com/arduino-libraries/Servo`.
-1. At the bottom of the page, select the radio button next to **"Create a new branch for this commit and start a pull
-   request."**
 1. Click the <kbd>Propose changes</kbd> button.
 1. In the **"Open a pull request"** window that opens, click the <kbd>Create pull request</kbd> button.
 


### PR DESCRIPTION
The library submission instructions contained a step for selecting a radio button before committing. This radio button only exists when editing a file in a repository you have write access to, which is why I encountered it while developing the instructions.

Library submitters will not have these radio buttons and so instructions for using a non-existent UI element would cause confusion.