### PR TITLE
Approve submission PRs before auto-merging

### DIFF
--- a/.github/workflows/manage-prs.yml
+++ b/.github/workflows/manage-prs.yml
@@ -342,6 +342,17 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Approve pull request
+        uses: octokit/request-action@v2.x
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          route: POST /repos/{owner}/{repo}/pulls/{pull_number}/reviews
+          owner: ${{ github.repository_owner }}
+          repo: ${{ github.event.repository.name }}
+          pull_number: ${{ github.event.pull_request.number }}${{ github.event.issue.number }}
+          event: APPROVE
+
       - name: Merge pull request
         uses: octokit/request-action@v2.x
         env:


### PR DESCRIPTION
This change to the "Manage PRs" workflow will cause the "github-actions" bot to add an approval [pull request review](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-request-reviews) to submission PRs after they have passed all compliance checks, but before merging.

This is necessary to allow us to instate the "Require pull request reviews before merging" [branch protection rule](https://docs.github.com/en/github/administering-a-repository/defining-the-mergeability-of-pull-requests/managing-a-branch-protection-rule) on `main`, which will protect the branch from accidental pushes by the maintainers and administrators with write permissions in the repository.

As an added benefit, this will more clearly indicate the status of a submission in the case where it is fully compliant with [the Library Manager requirements](https://github.com/arduino/library-registry/blob/main/FAQ.md#submission-requirements) but an automated merge is not possible due to a merge conflict. In this case, the bot will add an approval each time the workflow is triggered, but that is a reasonable behavior, and one permitted by the PR review system (i.e., subsequent approvals will not cause a spurious workflow run failure, with either [workflow trigger event type](https://docs.github.com/en/actions/reference/events-that-trigger-workflows)).