### PR TITLE
Make submission instructions comprehensive

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ See the instructions below for detailed instructions on how to do this via the G
    GitHub web interface: https://github.com/arduino/library-registry/edit/main/repositories.txt
 1. Click the <kbd>Fork this repository</kbd> button.
 1. Add the library repository's URL to the list (it doesn't matter where in the list). This should be the URL of the repository home page. For example:
-   `https://github.com/arduino-libraries/Servo`.
+   `https://github.com/arduino-libraries/Servo`
 1. Click the <kbd>Propose changes</kbd> button.
 1. In the **"Comparing changes"** window that opens, click the <kbd>Create pull request</kbd> button.
 1. In the **"Open a pull request"** window that opens, click the <kbd>Create pull request</kbd> button.

--- a/README.md
+++ b/README.md
@@ -37,9 +37,11 @@ See the instructions below for detailed instructions on how to do this via the G
    compliance before being accepted.
 1. Open this link to fork this repository and edit the list via the
    GitHub web interface: https://github.com/arduino/library-registry/edit/main/repositories.txt
+1. Click the <kbd>Fork this repository</kbd> button.
 1. Add the library repository's URL to the list (it doesn't matter where in the list). This should be the URL of the repository home page. For example:
    `https://github.com/arduino-libraries/Servo`.
 1. Click the <kbd>Propose changes</kbd> button.
+1. In the **"Comparing changes"** window that opens, click the <kbd>Create pull request</kbd> button.
 1. In the **"Open a pull request"** window that opens, click the <kbd>Create pull request</kbd> button.
 
 The library will be automatically checked for compliance as soon as the pull request is submitted. If no problems were

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ See the instructions below for detailed instructions on how to do this via the G
    compliance before being accepted.
 1. Open this link to fork this repository and edit the list via the
    GitHub web interface: https://github.com/arduino/library-registry/edit/main/repositories.txt
-1. Add the library repository's URL to the list. This should be the URL of the repository home page. For example:
+1. Add the library repository's URL to the list (it doesn't matter where in the list). This should be the URL of the repository home page. For example:
    `https://github.com/arduino-libraries/Servo`.
 1. Click the <kbd>Propose changes</kbd> button.
 1. In the **"Open a pull request"** window that opens, click the <kbd>Create pull request</kbd> button.

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ See the instructions below for detailed instructions on how to do this via the G
 1. You may want to first take a look at
    [the requirements for admission into the Arduino Library Manager index](FAQ.md#submission-requirements). Each submission will be checked for
    compliance before being accepted.
-1. Open this link to [fork](https://guides.github.com/activities/forking/) this repository and edit the list via the
+1. Open this link to fork this repository and edit the list via the
    GitHub web interface: https://github.com/arduino/library-registry/edit/main/repositories.txt
 1. Add the library repository's URL to the list. This should be the URL of the repository home page. For example:
    `https://github.com/arduino-libraries/Servo`.


### PR DESCRIPTION
The library submission instructions were missing a couple steps in the GitHub web interface fork/edit/commit/PR workflow. I have also made some minor improvements to their readability.