### PR TITLE
Add CI workflow to check general file formatting in `production` branch

### DIFF
--- a/.ecrc
+++ b/.ecrc
@@ -1,0 +1,6 @@
+{
+  "Exclude": [
+    "LICENSE.txt",
+    "poetry.lock"
+  ]
+}

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,57 @@
+# Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/assets/general/.editorconfig
+# See: https://editorconfig.org/
+# The formatting style defined in this file is the official standardized style to be used in all Arduino Tooling
+# projects and should not be modified.
+# Note: indent style for each file type is defined even when it matches the universal config in order to make it clear
+# that this type has an official style.
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_size = 2
+indent_style = space
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.{adoc,asc,asciidoc}]
+indent_size = 2
+indent_style = space
+
+[*.{bash,sh}]
+indent_size = 2
+indent_style = space
+
+[*.{c,cc,cp,cpp,cxx,h,hh,hpp,hxx,ii,inl,ino,ixx,pde,tpl,tpp,txx}]
+indent_size = 2
+indent_style = space
+
+[*.{go,mod}]
+indent_style = tab
+
+[*.java]
+indent_size = 2
+indent_style = space
+
+[*.{js,jsx,json,jsonc,json5,ts,tsx}]
+indent_size = 2
+indent_style = space
+
+[*.{md,mdx,mkdn,mdown,markdown}]
+indent_size = unset
+indent_style = space
+
+[*.proto]
+indent_size = 2
+indent_style = space
+
+[*.py]
+indent_size = 4
+indent_style = space
+
+[*.svg]
+indent_size = 2
+indent_style = space
+
+[*.{yaml,yml}]
+indent_size = 2
+indent_style = space

--- a/.github/workflows/check-general-formatting-task.yml
+++ b/.github/workflows/check-general-formatting-task.yml
@@ -1,0 +1,53 @@
+# Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/check-general-formatting-task.md
+name: Check General Formatting
+
+# See: https://docs.github.com/en/actions/reference/events-that-trigger-workflows
+on:
+  push:
+  pull_request:
+  schedule:
+    # Run every Tuesday at 8 AM UTC to catch breakage caused by changes to tools.
+    - cron: "0 8 * * TUE"
+  workflow_dispatch:
+  repository_dispatch:
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Set environment variables
+        run: |
+          # See: https://docs.github.com/en/actions/reference/workflow-commands-for-github-actions#setting-an-environment-variable
+          echo "EC_INSTALL_PATH=${{ runner.temp }}/editorconfig-checker" >> "$GITHUB_ENV"
+
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Install Task
+        uses: arduino/setup-task@v1
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          version: 3.x
+
+      - name: Download latest editorconfig-checker release binary package
+        id: download
+        uses: MrOctopus/download-asset-action@1.0
+        with:
+          repository: editorconfig-checker/editorconfig-checker
+          excludes: prerelease, draft
+          asset: linux-amd64.tar.gz
+          target: ${{ env.EC_INSTALL_PATH }}
+
+      - name: Install editorconfig-checker
+        run: |
+          cd "${{ env.EC_INSTALL_PATH }}"
+          tar --extract --file="${{ steps.download.outputs.name }}"
+          # Give the binary a standard name
+          mv "${{ env.EC_INSTALL_PATH }}/bin/ec-linux-amd64" "${{ env.EC_INSTALL_PATH }}/bin/ec"
+          # Add installation to PATH:
+          # See: https://docs.github.com/en/actions/reference/workflow-commands-for-github-actions#adding-a-system-path
+          echo "${{ env.EC_INSTALL_PATH }}/bin" >> "$GITHUB_PATH"
+
+      - name: Check formatting
+        run: task --silent general:check-formatting

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -1,0 +1,14 @@
+# See: https://taskfile.dev/#/usage
+version: "3"
+
+tasks:
+  # Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/assets/check-general-formatting-task/Taskfile.yml
+  general:check-formatting:
+    desc: Check basic formatting style of all files
+    cmds:
+      - |
+        if ! which ec &>/dev/null; then
+          echo "ec not found or not in PATH. Please install: https://github.com/editorconfig-checker/editorconfig-checker#installation"
+          exit 1
+        fi
+      - ec


### PR DESCRIPTION
On every push, pull request, and periodically, use [editorconfig-checker](https://github.com/editorconfig-checker/editorconfig-checker) check whether the `production` branch's files are formatted according to [`.editorconfig`](https://editorconfig.org/).

Since it is consumed by the `arduino/libraries-repository-engine`, it is important that the registry.txt data file have a standardized format. Although the automated submission acceptance system's edits to this file are relatively safe, humans also need to touch it from time to time in order to accommodate registry modification or library removal requests. For this reason, it is helpful to have some automated checks on the formatting. The checks provided by editorconfig-checker are not at all comprehensive for this purpose, but the effort required to add this standardized workflow is insignificant, so might as well.