### PR TITLE
Add WiFiWebServer_RTL8720 library

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -4063,3 +4063,4 @@ https://github.com/bitbank2/PNGenc
 https://github.com/italo-coelho/pushButton
 https://github.com/Flinduino/Flinduino_SensorKit
 https://github.com/cotestatnt/AsyncTelegram2
+https://github.com/khoih-prog/WiFiWebServer_RTL8720


### PR DESCRIPTION
#### Initial Releases v1.0.0

This is simple yet complete WebServer library for `Realtek RTL8720DN, RTL8722DM and RTM8722CSM` boards. **The functions are similar and compatible to ESP8266/ESP32 WebServer libraries** to make life much easier to port sketches from ESP8266/ESP32.