### PR TITLE
Configure Dependabot for updates to production branch workflows

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,3 +10,10 @@ updates:
       interval: daily
     labels:
       - "topic: infrastructure"
+  - package-ecosystem: github-actions
+    target-branch: production
+    directory: /
+    schedule:
+      interval: daily
+    labels:
+      - "topic: infrastructure"


### PR DESCRIPTION
Dependabot will periodically check the versions of all actions used in the GitHub Actions workflows of the `production`
branch. If any are found to be outdated, it will submit a pull request to update them.

We are already using Dependabot to help maintain the workflows of the `main` branch, but because the `production` branch has an independent commit history and CI system, it is necessary to add an additional Dependabot configuration for that branch. This will not affect the existing configuration (the configuration applies to the repository's default branch when no [`target-branch` key](https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/configuration-options-for-dependency-updates#target-branch) is specified).

NOTE: Dependabot's PRs will occasionally propose to pin to the patch version of the action (e.g., updating `uses: foo/bar@v1` to `uses: foo/bar@v2.3.4`). When the action author has [provided a major version ref](https://docs.github.com/en/actions/creating-actions/about-actions#using-release-management-for-actions), use that instead (e.g., `uses: foo/bar@v2`). Once the major version has been updated in the workflow, Dependabot should not submit an update PR again until the next major version bump.

So even when the PRs from Dependabot are not exactly correct, they still have value in bringing the maintainer's attention to the fact that the action version in use is outdated. Dependabot will automatically close its PR once the workflow has been updated.

More information:
https://docs.github.com/en/github/administering-a-repository/keeping-your-actions-up-to-date-with-dependabot
