### PR TITLE
Add prefix to error messages in bot comments

### DIFF
--- a/.github/workflows/manage-prs.yml
+++ b/.github/workflows/manage-prs.yml
@@ -205,7 +205,7 @@ jobs:
             |
             A problem was found with your submission ${{ matrix.submission.submissionURL }}
 
-            ${{ matrix.submission.error }}
+            :x: **ERROR:** ${{ matrix.submission.error }}
 
       - name: Fail on error detected while parsing
         if: matrix.submission.error != ''
@@ -291,7 +291,7 @@ jobs:
           issue_number: ${{ github.event.pull_request.number }}${{ github.event.issue.number }}
           body: |
             |
-            [Arduino Lint](https://github.com/arduino/arduino-lint) found errors with ${{ matrix.submission.submissionURL }}:
+            :x: **ERROR:** [Arduino Lint](https://github.com/arduino/arduino-lint) found errors with ${{ matrix.submission.submissionURL }}:
 
             ```
             ${{ steps.read-lint-report.outputs.text-report }}
@@ -420,7 +420,7 @@ jobs:
           issue_number: ${{ github.event.pull_request.number }}${{ github.event.issue.number }}
           body: |
             |
-            Your submission meets all requirements. However, the pull request could not be merged.
+            :x: **ERROR:** Your submission meets all requirements. However, the pull request could not be merged.
 
             Please follow this guide to resolve a merge conflict:
             https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/resolving-a-merge-conflict-on-github


### PR DESCRIPTION
In the event of a problem with a submission, the comments on the pull request thread. Due to the use of a matrix job to
support submissions of any number of libraries in a single PR, this might consist of multiple comments. Adding a standard
prominent prefix (:x: **ERROR:**) to all error messages will ensure that the most important part of this information is
not missed.

Demonstration of the prefix in action: https://github.com/per1234/library-registry/pull/1