### PR TITLE
Configure Dependabot for updates to `production` branch deps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,3 +17,17 @@ updates:
       interval: daily
     labels:
       - "topic: infrastructure"
+  - package-ecosystem: gomod
+    target-branch: production
+    directory: /.github/workflows/assets/validate-registry/
+    schedule:
+      interval: daily
+    labels:
+      - "topic: infrastructure"
+  - package-ecosystem: pip
+    target-branch: production
+    directory: /
+    schedule:
+      interval: daily
+    labels:
+      - "topic: infrastructure"


### PR DESCRIPTION
Since we already have the Dependabot infrastructure in place for managing dependencies of the project's Go code and
GitHub Actions workflows, it makes sense to do the same for the newly introduced Go and Python dependencies as well.

This configuration is applied to the `production` branch (using the `target-branch` key), but it must be added to the
configuration file in the default branch (`main`) because Dependabot only pays attention to the default branch's
configuration file.

Reference:
https://docs.github.com/en/code-security/supply-chain-security/configuration-options-for-dependency-updates#about-the-dependabotyml-file