### PR TITLE
Add data file to "Check Registry Data File" workflow's paths filter

### DIFF
--- a/.github/workflows/check-registry.yml
+++ b/.github/workflows/check-registry.yml
@@ -13,6 +13,7 @@ on:
       - "**.go"
       - "**/go.mod"
       - "**/go.sum"
+      - "registry.txt"
   pull_request:
     paths:
       - ".github/workflows/check-registry.ya?ml"
@@ -20,6 +21,7 @@ on:
       - "**.go"
       - "**/go.mod"
       - "**/go.sum"
+      - "registry.txt"
   workflow_dispatch:
   repository_dispatch:
 


### PR DESCRIPTION
GitHub Actions workflows can be configured to run only when files under specific paths are modified. This makes the CI system more efficient by avoiding pointless workflow runs. [The paths filter](https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#onpushpull_requestpaths) must be carefully configured to cover all relevant files. In this case, the file that is the whole point of the workflow's existence was missing from the list!