### PR TITLE
Update repository URL for UbxGps library

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -43,7 +43,7 @@ https://github.com/107-systems/107-Arduino-NMEA-Parser
 https://github.com/107-systems/107-Arduino-TMF8801
 https://github.com/107-systems/107-Arduino-UAVCAN
 https://github.com/1IoT/cloud-connectivity-lib
-https://github.com/1oginov/UbxGps
+https://github.com/loginov-rocks/UbxGps
 https://github.com/256dpi/arduino-mqtt
 https://github.com/2dom/PxMatrix
 https://github.com/4-20ma/i2c_adc_ads7828


### PR DESCRIPTION
Hello!

I own the UbxGps library and it's been in the registry for a while, but with my previous GitHub username (1oginov).
I changed it to loginov-rocks and just aligning a link to the repository.
Link in the library.properties has already been updated: https://github.com/loginov-rocks/UbxGps/blob/main/library.properties#L8

Thank you!