### PR TITLE
Remove workflow runs link from comment trigger reply

### DIFF
--- a/.github/workflows/manage-prs.yml
+++ b/.github/workflows/manage-prs.yml
@@ -66,9 +66,6 @@ jobs:
             |
             Hello! I'm checking your submission again.
 
-            You can see the progress here:
-            https://github.com/${{ github.repository_owner }}/${{ github.event.repository.name }}/actions/workflows/manage-prs.yml
-
       - name: Get PR diff
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
In the event the cause of a submission check failure is resolved externally, the user can trigger the "Manage PRs" workflow run by mentioning ArduinoBot in a reply to the PR thread. Unlike a workflow run triggered by a push to the pull request, GitHub Actions does not provide any visible indication on the PR page of the workflow run in progress. Instead, we have configured the workflow so that the bot immediately comments on the PR thread so that the user is not left wondering whether their comment had any effect as the longer process of the submission checks finishes before the feedback about their result can be provided.

With the idea that some users might like to get a progress indicator in the time between the initial comment and the final feedback from the workflow run, I added a link to[ the workflow runs page](https://github.com/arduino/library-registry/actions/workflows/manage-prs.yml). However, we received feedback from testers that encountering the fairly cryptic workflow run logs causes confusion. So we are trying to avoid leading users toward those logs. Since the link does just that and is not necessary, it's best to simply remove it.