### PR TITLE
Avoid linkification of bot user name in comment

### DIFF
--- a/.github/workflows/manage-prs.yml
+++ b/.github/workflows/manage-prs.yml
@@ -361,7 +361,7 @@ jobs:
             After resolving the issue, trigger this check again by doing one of the following:
 
             - Commit the required change to the branch you submitted this pull request from.
-            - Comment here, mentioning @ArduinoBot in the comment
+            - Comment here, mentioning `@ArduinoBot` in the comment
 
             More information:
             https://github.com/${{ github.repository }}/blob/main/README.md#if-the-problem-is-with-the-pull-request


### PR DESCRIPTION
In the event the checks on a submission PR fails, the bot comments with instructions for how the checks can be triggered
to run again once the user has resolved the issue. One option is to comment on the PR thread, mentioning ArduinoBot.

GitHub automatically linkifies mentions to the user's profile page, which occurs in these instructions. The ArduinoBot
profile page is not of relevance or interest in this context, so there is no benefit to providing a one click path for
its access. In addition, the link makes the text more difficult to copy. So it's better to prevent its linkification,
which is achieved by wrapping the text in backticks.