### PR TITLE
Add duplicate name check to registry data file validator

### DIFF
--- a/.github/workflows/assets/validate-registry/main.go
+++ b/.github/workflows/assets/validate-registry/main.go
@@ -39,7 +39,16 @@ func main() {
 	}
 
 	if !reflect.DeepEqual(rawRepos, filteredRepos) {
-		fmt.Fprintln(os.Stderr, "error: Registry data file contains duplicate entries")
+		fmt.Fprintln(os.Stderr, "error: Registry data file contains duplicate URLs")
 		os.Exit(1)
+	}
+
+	nameMap := make(map[string]bool)
+	for _, entry := range rawRepos {
+		if _, found := nameMap[entry.LibraryName]; found {
+			fmt.Fprintf(os.Stderr, "error: Registry data file contains duplicates of name %s\n", entry.LibraryName)
+			os.Exit(1)
+		}
+		nameMap[entry.LibraryName] = true
 	}
 }

--- a/.github/workflows/assets/validate-registry/tests/test_all.py
+++ b/.github/workflows/assets/validate-registry/tests/test_all.py
@@ -31,6 +31,7 @@ test_data_path = pathlib.Path(__file__).resolve().parent.joinpath("testdata")
         ("invalid-data-format.txt", False),
         ("invalid-url-format.txt", False),
         ("duplicate-url.txt", False),
+        ("duplicate-name.txt", False),
         ("valid.txt", True),
     ],
 )

--- a/.github/workflows/assets/validate-registry/tests/testdata/duplicate-name.txt
+++ b/.github/workflows/assets/validate-registry/tests/testdata/duplicate-name.txt
@@ -1,0 +1,4 @@
+https://github.com/arduino-libraries/Scheduler.git|Arduino|Scheduler
+https://github.com/arduino-libraries/SD.git|Partner|SD
+https://github.com/arduino-libraries/Servo.git|Recommended|Servo
+https://github.com/arduino-libraries/Foo.git|Contributed|SD

--- a/registry.txt
+++ b/registry.txt
@@ -701,7 +701,6 @@ https://github.com/finson-release/FirmataWithDeviceFeature.git|Contributed|Firma
 https://github.com/iotpipe/esp8266-arduino-iotpipe.git|Contributed|IoT Pipe
 https://github.com/olikraus/U8g2_Arduino.git|Contributed|U8g2
 https://github.com/abderraouf-adjal/ArduinoSpritzCipher.git|Contributed|SpritzCipher
-https://github.com/EscaVic/ROKduino.git|Contributed|ROKduino
 https://github.com/dxinteractive/ResponsiveAnalogRead.git|Contributed|ResponsiveAnalogRead
 https://github.com/FaBoPlatform/FaBoBLE-BLE113-Library.git|Contributed|FaBo 301 BLE SiliconLabs
 

--- a/registry.txt
+++ b/registry.txt
@@ -1595,7 +1595,7 @@ https://github.com/elhayra/Strober.git|Contributed|Strober
 https://github.com/elhayra/SandTimer.git|Contributed|SandTimer
 https://github.com/elhayra/MilliStopper.git|Contributed|MilliStopper
 https://github.com/mike-matera/FastPID.git|Contributed|FastPID
-https://github.com/ettoreleandrotognoli/ArcPID.git|Contributed|PID
+https://github.com/ettoreleandrotognoli/ArcPID.git|Contributed|ArcPID
 https://github.com/nathanRamaNoodles/MusicWithoutDelay-LIbrary.git|Contributed|MusicWithoutDelay
 https://github.com/eagleSIA/eBoard.git|Contributed|eBoard shackle the Arduino
 https://github.com/ssilverman/TeensyDMX.git|Contributed|TeensyDMX

--- a/registry.txt
+++ b/registry.txt
@@ -7,7 +7,6 @@ https://github.com/arduino-libraries/AudioZero.git|Arduino|AudioZero
 https://github.com/arduino-libraries/Bridge.git|Arduino|Bridge
 https://github.com/arduino-libraries/Esplora.git|Arduino|Esplora
 https://github.com/arduino-libraries/Ethernet.git|Arduino|Ethernet
-https://github.com/arduino-libraries/Firmata-Old.git|Arduino|Firmata
 https://github.com/arduino-libraries/GSM.git|Arduino|GSM
 https://github.com/arduino-libraries/LiquidCrystal.git|Arduino|LiquidCrystal
 https://github.com/arduino-libraries/Robot_Control.git|Arduino|Robot Control


### PR DESCRIPTION
The registry data file must be manually edited when a library name change request is received. Each library must have a
unique name, so it's important to verify that no duplicates are introduced through these edits.