### PR TITLE
Bump submission parser version to 1.0.1

### DIFF
--- a/.github/workflows/manage-prs.yml
+++ b/.github/workflows/manage-prs.yml
@@ -1,7 +1,7 @@
 name: Manage PRs
 
 env:
-  SUBMISSION_PARSER_VERSION: 1.0.0 # See: https://github.com/arduino/library-manager-submission-parser/releases
+  SUBMISSION_PARSER_VERSION: 1.0.1 # See: https://github.com/arduino/library-manager-submission-parser/releases
   MAINTAINERS: |
     # GitHub user names to request reviews from in cases where PRs can't be managed automatically.
     - per1234


### PR DESCRIPTION
A new release of `arduino/library-registry-submission-parser` is out with some minor improvements to the error messages
the bot comments to a pull request when problems with a submission are found.

https://github.com/arduino/library-registry-submission-parser/releases/tag/1.0.1