### PR TITLE
new entry: add Bluepad32 library to registry

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -4101,3 +4101,4 @@ https://github.com/DmytroKorniienko/EmbUI
 https://github.com/SergeSkor/SSVXYMatrixText
 https://github.com/danilopinotti/Battery18650Stats
 https://github.com/WonderCRM/CRMui3
+https://github.com/ricardoquesada/bluepad32-arduino


### PR DESCRIPTION
Add Bluepad32 library for Arduino to registry.
This library adds Bluetooth gamepad support for Arduino boards.
The boards must have a NINA co-processor.