### PR TITLE
Remove "UltraDistSensor"

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -3203,7 +3203,6 @@ https://github.com/shashikg/PixhawkArduinoMAVLink
 https://github.com/shielddx/oatmeal-protocol
 https://github.com/shortbloke/Arduino_SNMP_Manager
 https://github.com/ShubhamAnnigeri/tinyECC-ArduinoIDE
-https://github.com/shubhamtivedi95/UltraDistSensor
 https://github.com/shurillu/CTBot
 https://github.com/shuvangkar/RingEEPROM
 https://github.com/siara-cc/esp_arduino_sqlite3_lib


### PR DESCRIPTION
This library is being removed from Library Manager by Arduino due to security concerns.

Although there are no concerns about [the library code itself](https://github.com/shubhamtrivedi95/UltraDistSensor), the library.properties metadata file contains [an unfortunate typo in the `url` field](https://github.com/shubhamtrivedi95/UltraDistSensor/blob/1.0/library.properties#L8). This causes the "More Info" link provided by the Library Manager to take the user to a misspelling of github.com owned by a typo squatter. The library author has already corrected this error (https://github.com/shubhamtrivedi95/UltraDistSensor/commit/fea546bd86619f17ee40e133ff6dc24652bb6a25), but there has not been a release of the library in the ~4 years since that time, and no response to an inquiry about the situation made ~3.5 years ago (https://github.com/shubhamtrivedi95/UltraDistSensor/issues/1).

This was surely an honest mistake, without any malicious intent on the library author's part, but we need to resolve the situation. @shubhamtrivedi95 we will be happy to add the library back once you have done the following:

- Create a new release or tag in the library's repository with the corrected `url` value.
- Delete the `1.0` tag that has the bad URL from the library's repository.

You can open a pull request to this repository to add the library back, following the standard process described here:
https://github.com/arduino/library-registry#adding-a-library-to-library-manager