### PR TITLE
Bump library registry submission parser version used by "Manage PRs" workflow

### DIFF
--- a/.github/workflows/manage-prs.yml
+++ b/.github/workflows/manage-prs.yml
@@ -1,7 +1,7 @@
 name: Manage PRs
 
 env:
-  SUBMISSION_PARSER_VERSION: 1.0.1 # See: https://github.com/arduino/library-manager-submission-parser/releases
+  SUBMISSION_PARSER_VERSION: 1.1.0 # See: https://github.com/arduino/library-manager-submission-parser/releases
   MAINTAINERS: |
     # GitHub user names to request reviews from in cases where PRs can't be managed automatically.
     - per1234


### PR DESCRIPTION
A new 1.1.0 version of `arduino/library-registry-submission-parser` is now available for use by the "Manage PRs" workflow:
https://github.com/arduino/library-registry-submission-parser/releases/tag/1.1.0
