### PR TITLE
adding https://github.com/noah1510/unit-system to library list

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -4117,4 +4117,4 @@ https://github.com/SergeSkor/SSVQueueStackArray
 https://github.com/SergeSkor/SSVWaitForStringInStream
 https://github.com/khoih-prog/ESP32_C3_TimerInterrupt
 https://github.com/guttih/DisplayMenu
-https://github.com/noah1510/unit-system
+https://github.com/noah1510/unit-system-adruino

--- a/repositories.txt
+++ b/repositories.txt
@@ -4117,3 +4117,4 @@ https://github.com/SergeSkor/SSVQueueStackArray
 https://github.com/SergeSkor/SSVWaitForStringInStream
 https://github.com/khoih-prog/ESP32_C3_TimerInterrupt
 https://github.com/guttih/DisplayMenu
+https://github.com/noah1510/unit-system


### PR DESCRIPTION
This adds https://github.com/noah1510/unit-system to the library list.

unit-system provides types for the SI units and allows conversions of units and combining them.
This can be a huge help for developers who want to reduce bugs caused by passing wrong variables (time instead of length).
Custom units can be created as needed and pull requests with more types are always welcome.