### PR TITLE
Update repositories.txt - remove mcp23008 library

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -4132,4 +4132,3 @@ https://github.com/khoih-prog/ESP32_S2_ISR_Servo
 https://github.com/khoih-prog/ESP32_C3_ISR_Servo
 https://github.com/crmoratelli/SupmeaDO7016
 https://github.com/todd-herbert/heltec-eink-modules
-https://gitlab.com/F-Schmidt/uulm-mcp23008


### PR DESCRIPTION
Removed https://gitlab.com/F-Schmidt/uulm-mcp23008. This is my first library which will be renamed and restructured. The new libraries uulm-mcp23008-core and uulm-mcp23008-user (or similar) will follow soon. They will also provide examples and have a much better documentation.