### PR TITLE
Add SwarmTile to Arduino Library Manager

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -4138,3 +4138,4 @@ https://github.com/khoih-prog/FlashStorage_RTL8720
 https://gitlab.com/F-Schmidt/uulm_mcp23008_core
 https://github.com/Basirk/I2CHelper
 https://github.com/khoih-prog/RTL8720_TimerInterrupt
+https://github.com/astuder/SwarmTile


### PR DESCRIPTION
This Arduino library wraps the API of the Swarm Tile satellite modems.