### PR TITLE
Sync CI configuration files with templates

### DIFF
--- a/.github/.markdownlint.yml
+++ b/.github/.markdownlint.yml
@@ -1,3 +1,4 @@
+# Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/assets/check-markdown/.markdownlint.yml
 # See: https://github.com/DavidAnson/markdownlint/blob/main/doc/Rules.md
 # The code style defined in this file is the official standardized style to be used in all Arduino projects and should
 # not be modified.

--- a/.github/.yamllint.yml
+++ b/.github/.yamllint.yml
@@ -1,6 +1,7 @@
+# Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/assets/check-yaml/.yamllint.yml
 # See: https://yamllint.readthedocs.io/en/stable/configuration.html
-# The code style defined in this file is the official standardized style to be used in all Arduino projects and should
-# not be modified.
+# The code style defined in this file is the official standardized style to be used in all Arduino tooling projects and
+# should not be modified.
 # Note: Rules disabled solely because they are redundant to Prettier are marked with a "Prettier" comment.
 
 rules:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,9 +1,10 @@
-# See: https://docs.github.com/en/github/administering-a-repository/configuration-options-for-dependency-updates#about-the-dependabotyml-file
+# See: https://docs.github.com/en/code-security/supply-chain-security/configuration-options-for-dependency-updates#about-the-dependabotyml-file
 version: 2
 
 updates:
   # Configure check for outdated GitHub Actions actions in workflows.
-  # See: https://docs.github.com/en/github/administering-a-repository/keeping-your-actions-up-to-date-with-dependabot
+  # Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/assets/dependabot/README.md
+  # See: https://docs.github.com/en/code-security/supply-chain-security/keeping-your-actions-up-to-date-with-dependabot
   - package-ecosystem: github-actions
     directory: / # Check the repository's workflows under /.github/workflows/
     schedule:


### PR DESCRIPTION
Some minor adjustments to the comments in the configuration files for the tools used by the repository's CI system to
bring them into sync with the upstream "template" assets.