### PR TITLE
Sync CI assets to their "templates"

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -55,3 +55,6 @@ indent_style = space
 [*.{yaml,yml}]
 indent_size = 2
 indent_style = space
+
+[{.gitconfig,.gitmodules}]
+indent_style = tab

--- a/.github/workflows/assets/validate-registry/tests/__init__.py
+++ b/.github/workflows/assets/validate-registry/tests/__init__.py
@@ -4,7 +4,7 @@
 #
 # This software is released under the GNU General Public License version 3,
 # The terms of this license can be found at:
-# https: // www.gnu.org/licenses/gpl-3.0.en.html
+# https://www.gnu.org/licenses/gpl-3.0.en.html
 #
 # You can be released from the requirements of the above licenses by purchasing
 # a commercial license. Buying such a license is mandatory if you want to

--- a/.github/workflows/assets/validate-registry/tests/test_all.py
+++ b/.github/workflows/assets/validate-registry/tests/test_all.py
@@ -4,7 +4,7 @@
 #
 # This software is released under the GNU General Public License version 3,
 # The terms of this license can be found at:
-# https: // www.gnu.org/licenses/gpl-3.0.en.html
+# https://www.gnu.org/licenses/gpl-3.0.en.html
 #
 # You can be released from the requirements of the above licenses by purchasing
 # a commercial license. Buying such a license is mandatory if you want to

--- a/.github/workflows/check-yaml-task.yml
+++ b/.github/workflows/check-yaml-task.yml
@@ -1,6 +1,10 @@
 # Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/check-yaml-task.md
 name: Check YAML
 
+env:
+  # See: https://github.com/actions/setup-python/tree/v2#available-versions-of-python
+  PYTHON_VERSION: "3.9"
+
 # See: https://docs.github.com/en/actions/reference/events-that-trigger-workflows
 on:
   push:
@@ -65,7 +69,7 @@ jobs:
       - name: Install Python
         uses: actions/setup-python@v2
         with:
-          python-version: "3.9"
+          python-version: ${{ env.PYTHON_VERSION }}
 
       - name: Install Poetry
         run: pip install poetry

--- a/.github/workflows/test-go-integration-task.yml
+++ b/.github/workflows/test-go-integration-task.yml
@@ -53,7 +53,7 @@ jobs:
       - name: Install Poetry
         run: pip install poetry
 
-      - name: Install Taskfile
+      - name: Install Task
         uses: arduino/setup-task@v1
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
We have assembled a collection of reusable project assets:
https://github.com/arduino/tooling-project-assets
These will be used in the repositories of all Arduino tooling projects.

They are already in use in the `production` branch of this repository, but some minor improvements and standardizations have been made in the upstream "template" workflow, and those are introduced to this repository via this pull request.