### PR TITLE
Make "Check Go" workflow module path support extendable

### DIFF
--- a/.github/workflows/check-go-task.yml
+++ b/.github/workflows/check-go-task.yml
@@ -26,7 +26,15 @@ on:
 
 jobs:
   check-errors:
+    name: check-errors (${{ matrix.module.path }})
     runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+
+      matrix:
+        module:
+          - path: .github/workflows/assets/validate-registry/
 
     steps:
       - name: Checkout repository
@@ -44,10 +52,20 @@ jobs:
           version: 3.x
 
       - name: Check for errors
+        env:
+          GO_MODULE_PATH: ${{ matrix.module.path }}
         run: task go:vet
 
   check-outdated:
+    name: check-outdated (${{ matrix.module.path }})
     runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+
+      matrix:
+        module:
+          - path: .github/workflows/assets/validate-registry/
 
     steps:
       - name: Checkout repository
@@ -65,13 +83,23 @@ jobs:
           version: 3.x
 
       - name: Modernize usages of outdated APIs
+        env:
+          GO_MODULE_PATH: ${{ matrix.module.path }}
         run: task go:fix
 
       - name: Check if any fixes were needed
         run: git diff --color --exit-code
 
   check-style:
+    name: check-style (${{ matrix.module.path }})
     runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+
+      matrix:
+        module:
+          - path: .github/workflows/assets/validate-registry/
 
     steps:
       - name: Checkout repository
@@ -92,10 +120,20 @@ jobs:
         run: go install golang.org/x/lint/golint@latest
 
       - name: Check style
+        env:
+          GO_MODULE_PATH: ${{ matrix.module.path }}
         run: task --silent go:lint
 
   check-formatting:
+    name: check-formatting (${{ matrix.module.path }})
     runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+
+      matrix:
+        module:
+          - path: .github/workflows/assets/validate-registry/
 
     steps:
       - name: Checkout repository
@@ -113,13 +151,23 @@ jobs:
           version: 3.x
 
       - name: Format code
+        env:
+          GO_MODULE_PATH: ${{ matrix.module.path }}
         run: task go:format
 
       - name: Check formatting
         run: git diff --color --exit-code
 
   check-config:
+    name: check-config (${{ matrix.module.path }})
     runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+
+      matrix:
+        module:
+          - path: .github/workflows/assets/validate-registry/
 
     steps:
       - name: Checkout repository
@@ -137,6 +185,8 @@ jobs:
           version: 3.x
 
       - name: Run go mod tidy
+        env:
+          GO_MODULE_PATH: ${{ matrix.module.path }}
         run: task go:tidy
 
       - name: Check whether any tidying was needed

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -2,10 +2,11 @@
 version: "3"
 
 vars:
-  GO_PROJECT_PATH: .github/workflows/assets/validate-registry
   LDFLAGS:
+  DEFAULT_GO_MODULE_PATH: .github/workflows/assets/validate-registry/
   DEFAULT_GO_PACKAGES:
-    sh: cd "{{.GO_PROJECT_PATH}}" && echo $(go list ./... | tr '\n' ' ')
+    sh: |
+      echo $(cd {{default .DEFAULT_GO_MODULE_PATH .GO_MODULE_PATH}} && go list ./... | tr '\n' ' ' || echo '"ERROR: Unable to discover Go packages"')
 
 tasks:
   # Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/assets/check-workflows-task/Taskfile.yml
@@ -54,14 +55,13 @@ tasks:
   # Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/assets/go-task/Taskfile.yml
   go:build:
     desc: Build the Go code
-    dir: "{{.GO_PROJECT_PATH}}"
+    dir: "{{.DEFAULT_GO_MODULE_PATH}}"
     cmds:
       - go build -v {{.LDFLAGS}}
 
   # Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/assets/check-go-task/Taskfile.yml
   go:check:
     desc: Check for problems with Go code
-    dir: "{{.GO_PROJECT_PATH}}"
     deps:
       - task: go:vet
       - task: go:lint
@@ -69,21 +69,21 @@ tasks:
   # Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/assets/check-go-task/Taskfile.yml
   go:vet:
     desc: Check for errors in Go code
-    dir: "{{.GO_PROJECT_PATH}}"
+    dir: "{{default .DEFAULT_GO_MODULE_PATH .GO_MODULE_PATH}}"
     cmds:
       - go vet {{default .DEFAULT_GO_PACKAGES .GO_PACKAGES}}
 
   # Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/assets/check-go-task/Taskfile.yml
   go:fix:
     desc: Modernize usages of outdated APIs
-    dir: "{{.GO_PROJECT_PATH}}"
+    dir: "{{default .DEFAULT_GO_MODULE_PATH .GO_MODULE_PATH}}"
     cmds:
       - go fix {{default .DEFAULT_GO_PACKAGES .GO_PACKAGES}}
 
   # Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/assets/check-go-task/Taskfile.yml
   go:lint:
     desc: Lint Go code
-    dir: "{{.GO_PROJECT_PATH}}"
+    dir: "{{default .DEFAULT_GO_MODULE_PATH .GO_MODULE_PATH}}"
     cmds:
       - |
         if ! which golint &>/dev/null; then
@@ -98,20 +98,20 @@ tasks:
   # Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/assets/check-go-task/Taskfile.yml
   go:format:
     desc: Format Go code
-    dir: "{{.GO_PROJECT_PATH}}"
+    dir: "{{default .DEFAULT_GO_MODULE_PATH .GO_MODULE_PATH}}"
     cmds:
       - go fmt {{default .DEFAULT_GO_PACKAGES .GO_PACKAGES}}
 
   go:tidy:
     desc: Run go mod tidy
-    dir: "{{.GO_PROJECT_PATH}}"
+    dir: "{{default .DEFAULT_GO_MODULE_PATH .GO_MODULE_PATH}}"
     cmds:
       - go mod tidy
 
   # Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/assets/test-go-integration-task/Taskfile.yml
   go:test-integration:
     desc: Run integration tests
-    dir: "{{.GO_PROJECT_PATH}}"
+    dir: "{{.DEFAULT_GO_MODULE_PATH}}"
     deps:
       - task: go:build
       - task: poetry:install-deps
@@ -152,7 +152,7 @@ tasks:
       - task: go:build
     cmds:
       - |
-        "{{.GO_PROJECT_PATH}}/validate-registry" registry.txt
+        "{{.DEFAULT_GO_MODULE_PATH}}/validate-registry" registry.txt
 
   # Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/assets/check-yaml-task/Taskfile.yml
   yaml:lint:


### PR DESCRIPTION
Since it is not a primary component of the project, I puth the registry validator Go module in a subfolder of the
repository. The standardized Arduino tooling project "assets" at that time were designed for the more common project
structure of the module in the repository root. This meant some small modifications to the assets were required in order
to make them applicable to this repository's structure.

Since that time, the standardized assets have been improved so they can support arbitrary Go module locations, as is
needed here. A different approach was taken in order to also support any number of modules. Although this particular
repository is not likely to gain multiple modules, that is needed by other projects, and so it is a better approach in
general.