### PR TITLE
Add FlashStorage_STM32F1 Library

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -4149,3 +4149,4 @@ https://github.com/khoih-prog/ESP32_New_TimerInterrupt
 https://github.com/khoih-prog/ESP32_New_ISR_Servo
 https://github.com/BEAT-System/SerialCom
 https://github.com/SchooMyDevelopment/SchooMyUtilities
+https://github.com/khoih-prog/FlashStorage_STM32F1


### PR DESCRIPTION
### Features

The FlashStorage_STM32F1 library, inspired by [Cristian Maglie's FlashStorage](https://github.com/cmaglie/FlashStorage), provides a convenient way to store and retrieve user's data using emulated-EEPROM, from the non-volatile flash memory of STM32F1/F3, including non-genuine CH32F103xx, CS32F103xx, etc. boards.

The flash memory, generally used to store the firmware code, can also be used to store / retrieve more user's data and faster than from EEPROM. Thanks to the **buffered data writing and reading**, the flash access time is greatly reduced to **increase the life of the flash**.

Currently, the library supports both new [**STM32 core v2.0.0**](https://github.com/stm32duino/Arduino_Core_STM32/releases/tag/2.0.0) and previous [**STM32 core v1.9.0**](https://github.com/stm32duino/Arduino_Core_STM32/releases/tag/1.9.0)