### PR TITLE
Add STM32_ISR_Servo Library

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -4164,3 +4164,4 @@ https://github.com/BEAT-System/SerialCom
 https://github.com/SchooMyDevelopment/SchooMyUtilities
 https://github.com/khoih-prog/FlashStorage_STM32F1
 https://bitbucket.org/David_Such/nexgen_motorshield
+https://github.com/khoih-prog/STM32_ISR_Servo


### PR DESCRIPTION
### Releases v1.0.0

1. Basic 16 ISR-based servo controllers using 1 hardware timer for STM32F/L/H/G/WB/MP1-based board
2. Tested with **STM32L5 (NUCLEO_L552ZE_Q)** and **STM32H7 (NUCLEO_H743ZI2)**