### PR TITLE
Add SAMD_ISR_Servo Library

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -4169,3 +4169,4 @@ https://bitbucket.org/David_Such/nexgen_motorshield
 https://github.com/khoih-prog/STM32_ISR_Servo
 https://github.com/edge-ml/arduino
 https://github.com/khoih-prog/RP2040_ISR_Servo
+https://github.com/khoih-prog/SAMD_ISR_Servo


### PR DESCRIPTION
### Releases v1.0.0

1. Basic 16 ISR-based servo controllers using 1 hardware timer for SAMD-based board
2. Support to both SAMD21 and SAMD51