### PR TITLE
Add NRF52_ISR_Servo Library

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -4170,3 +4170,4 @@ https://github.com/khoih-prog/STM32_ISR_Servo
 https://github.com/edge-ml/arduino
 https://github.com/khoih-prog/RP2040_ISR_Servo
 https://github.com/khoih-prog/SAMD_ISR_Servo
+https://github.com/khoih-prog/NRF52_ISR_Servo


### PR DESCRIPTION
### Releases v1.0.0

1. Basic 16 ISR-based servo controllers using 1 hardware PWM module for nRF52-based board
2. Support to both nRF52832 and nRF52840