### PR TITLE
Bump `arduino/library-manager-submission-parser` version

### DIFF
--- a/.github/workflows/manage-prs.yml
+++ b/.github/workflows/manage-prs.yml
@@ -1,7 +1,7 @@
 name: Manage PRs
 
 env:
-  SUBMISSION_PARSER_VERSION: 1.1.0 # See: https://github.com/arduino/library-manager-submission-parser/releases
+  SUBMISSION_PARSER_VERSION: 1.1.1 # See: https://github.com/arduino/library-manager-submission-parser/releases
   MAINTAINERS: |
     # GitHub user names to request reviews from in cases where PRs can't be managed automatically.
     - per1234


### PR DESCRIPTION
A new release of the `arduino/library-manager-submission-parser` tool used by the "Manage PRs" workflow has been made.
This release fixes (https://github.com/arduino/library-registry-submission-parser/pull/67) a bug that caused pull requests that consisted only of newlines to be incorrectly classified as "modification", resulting in an unexpected failure of the workflow run due to there being no library URLs to populate the `check-submissions` job matrix:

https://github.com/arduino/library-registry/actions/runs/1167544288 (https://github.com/arduino/library-registry/pull/404)
```
Error when evaluating 'strategy' for job 'check-submissions'. (Line: 219, Col: 21): Unexpected value ''
```

These pull requests will now be assigned the appropriate "other" request type and the workflow run will pass as expected,
requesting the necessary manual review from a maintainer.

Demo of the same diff handled correctly by the updated parser tool:
https://github.com/per1234/library-registry/runs/3429023708#step:2:119

Full test procedure run through with the new parser:
https://github.com/per1234/library-registry/pull/26