### PR TITLE
Add FS_Nano33BLE Library

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -4190,3 +4190,4 @@ https://github.com/iotkaran/Arduino
 https://github.com/levkovigor/LTR390
 https://github.com/1452206376/CH9328-Keyboard
 https://github.com/9glt/arduino-attiny85-mcp23017-library
+https://github.com/khoih-prog/FS_Nano33BLE


### PR DESCRIPTION
### Initial Releases v1.0.0

1. Initial coding to support MBED nRF52840-based boards such as **Nano_33_BLE, Nano_33_BLE_Sense**, etc. using [**Arduino-mbed mbed_nano** core](https://github.com/arduino/ArduinoCore-mbed)