### PR TITLE
Remove "BME33M251"

### DIFF
--- a/registry.txt
+++ b/registry.txt
@@ -4280,7 +4280,6 @@ https://github.com/RobTillaart/MTP40C.git|Contributed|MTP40C
 https://github.com/adrian200223/Simple5641AS.git|Contributed|Simple5641AS
 https://github.com/pablo-sampaio/easy_mfrc522.git|Contributed|Easy MFRC522
 https://github.com/bxparks/AceSorting.git|Contributed|AceSorting
-https://github.com/treeaa/BME33M251.git|Contributed|BME33M251
 https://github.com/lozziboy/arduino-serial-variable-table.git|Contributed|cSerialWatcher
 https://github.com/levkovigor/MMC34160PJ.git|Contributed|MMC34160PJ
 https://github.com/levkovigor/ppposclient.git|Contributed|PPPOSClient


### PR DESCRIPTION
Follow-up to: https://github.com/arduino/library-registry/pull/427

Resolves https://github.com/arduino/library-registry/issues/428