### PR TITLE
More clearly communicate that new PR is not required to resolve submission problem

### DIFF
--- a/.github/workflows/manage-prs.yml
+++ b/.github/workflows/manage-prs.yml
@@ -408,8 +408,10 @@ jobs:
 
             After resolving the issue, trigger this check again by doing one of the following:
 
-            - Commit the required change to the branch you submitted this pull request from.
-            - Comment here, mentioning `@ArduinoBot` in the comment
+            - **Commit the required change to the branch you submitted this pull request from.**
+            - **Comment here, mentioning `@ArduinoBot` in the comment.**
+
+            :exclamation: **NOTE**: It is not necessary to open a new pull request. :exclamation:
 
             More information:
             https://github.com/${{ github.repository }}/blob/main/README.md#if-the-problem-is-with-the-pull-request


### PR DESCRIPTION
The system is designed to allow a submission to be accomplished in a single pull request. This is the case even when
initial passes of checks reveal problems that block acceptance. The checks will automatically re-run any time the PR
author pushes to the PR's branch or mentions the bot.

Although the submitters are welcome to submit a new PR if that is their preference, it is a less efficient approach, both
for them and the maintainer. So it's important to clearly communicate that the submission process can be continued via
the current PR if that is convenient to them.

Usage patterns indicate that this is not clearly communicated via the current messaging from the bot, so perhaps an
additional note with some styling to give it emphasis will improve on the user experience:

>Thanks for your interest in contributing to the Arduino Library Manager index @...
Please resolve the error(s) mentioned in the previous comment.
>
>After resolving the issue, trigger this check again by doing one of the following:
>
>- **Commit the required change to the branch you submitted this pull request from.**
>- **Comment here, mentioning `@ArduinoBot` in the comment.**
>
>:exclamation: **NOTE**: It is not necessary to open a new pull request. :exclamation:
>
>More information:
https://github.com/arduino/library-registry#if-the-problem-is-with-the-pull-request
