### PR TITLE
Add Z80 library for the Arduino Mega

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -4203,3 +4203,4 @@ https://github.com/natnqweb/Motor_PID
 https://github.com/natnqweb/Simpletimer
 https://github.com/natnqweb/SD_card_logger
 https://github.com/francobasaglia/MagicPot
+https://github.com/jkingsman/Z80Mega


### PR DESCRIPTION
The library at https://github.com/jkingsman/Z80Mega provides a fully featured Z80 core compatible with the Arduino Mega.