### PR TITLE
Added the LithiumPowered Library

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -4213,3 +4213,4 @@ https://github.com/stm32duino/ST25R3911B
 https://github.com/stm32duino/X-NUCLEO-NFC05A1
 https://github.com/natnqweb/SkyMap
 https://github.com/andhieSetyabudi/hx710b_arduino
+https://github.com/Flowduino/LithiumPowered


### PR DESCRIPTION
Library specifically to simplify the use of Lithium Batteries for Arduino and ESP-powered projects (using a Coulomb Counter such as LTC4150)