### PR TITLE
Add LittleFS_Portenta_H7 Library

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -4215,3 +4215,4 @@ https://github.com/natnqweb/SkyMap
 https://github.com/andhieSetyabudi/hx710b_arduino
 https://github.com/Flowduino/LithiumPowered
 https://github.com/Z01NE/MyAlarm
+https://github.com/khoih-prog/LittleFS_Portenta_H7


### PR DESCRIPTION
### Initial Releases v1.0.0

1. Initial coding to support **Portenta_H7 boards** such as Portenta_H7 Rev2 ABX00042, etc., using [**ArduinoCore-mbed mbed_portenta** core](https://github.com/arduino/ArduinoCore-mbed)