### PR TITLE
Add WiFiManager_Portenta_H7_Lite Library

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -4223,3 +4223,4 @@ https://github.com/khoih-prog/LittleFS_Portenta_H7
 https://github.com/someweisguy/esp_dmx
 https://github.com/jaredliw/PikaBot
 https://github.com/Open-Acidification/TankController
+https://github.com/khoih-prog/WiFiManager_Portenta_H7_Lite


### PR DESCRIPTION
### Initial Release v1.4.0

1. Add support to Portenta_H7 boards, using [`ArduinoCore-mbed mbed_portenta core`](https://github.com/arduino/ArduinoCore-mbed)
2. Update `Packages' Patches`
3. Add `LibraryPatches` for [**Adafruit_MQTT_Library**](https://github.com/adafruit/Adafruit_MQTT_Library) to fix compiler error for Portenta_H7 and many other boards.
4. Bump version to v1.4.0 to sync with [WiFiManager_Generic_Lite library](https://github.com/khoih-prog/WiFiManager_Generic_Lite)