### PR TITLE
Add Ethernet_Manager_Portenta_H7 Library

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -4224,3 +4224,4 @@ https://github.com/someweisguy/esp_dmx
 https://github.com/jaredliw/PikaBot
 https://github.com/Open-Acidification/TankController
 https://github.com/khoih-prog/WiFiManager_Portenta_H7_Lite
+https://github.com/khoih-prog/Ethernet_Manager_Portenta_H7


### PR DESCRIPTION
### Initial Release v1.6.0

1. Add support to Portenta_H7 boards, using [`ArduinoCore-mbed mbed_portenta core`](https://github.com/arduino/ArduinoCore-mbed)
2. Add `Packages' Patches`
3. Add `LibraryPatches` for [**Adafruit_MQTT_Library**](https://github.com/adafruit/Adafruit_MQTT_Library) to fix compiler error for Portenta_H7 and many other boards.
4. Bump version to v1.6.0 to sync with [Ethernet_Manager library](https://github.com/khoih-prog/Ethernet_Manager)