### PR TITLE
Add Portenta_H7_TimerInterrupt Library

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -4229,3 +4229,4 @@ https://github.com/Open-Acidification/TankController
 https://github.com/khoih-prog/WiFiManager_Portenta_H7_Lite
 https://github.com/khoih-prog/Ethernet_Manager_Portenta_H7
 https://github.com/andriell/arduino-library-WT2003M02-mp3-decoder
+https://github.com/khoih-prog/Portenta_H7_TimerInterrupt


### PR DESCRIPTION
### Initial Releases v1.2.1

1. Initial coding to support **Portenta_H7 boards** such as Portenta_H7 Rev2 ABX00042, etc., using [**ArduinoCore-mbed mbed_portenta** core](https://github.com/arduino/ArduinoCore-mbed)
2. Permit up to 16 super-long-time, super-accurate ISR-based timers to avoid being blocked
3. Using cpp code besides Impl.h code to use if Multiple-Definition linker error.
4. Bump version to v1.2.1 to sync with [STM32_TimerInterrupt library](https://github.com/khoih-prog/STM32_TimerInterrupt)