### PR TITLE
Update URL and name of "KerbalSimpit"

### DIFF
--- a/registry.txt
+++ b/registry.txt
@@ -1122,7 +1122,7 @@ https://github.com/DarkDust/MHGroveBLE.git|Contributed|MHGroveBLE
 https://github.com/SodaqMoja/Sodaq_LIS3DE.git|Contributed|Sodaq_LIS3DE
 https://github.com/connornishijima/TinySnore.git|Contributed|TinySnore
 https://github.com/kmackay/micro-ecc.git|Contributed|micro-ecc
-https://bitbucket.org/pjhardy/kerbalsimpit-arduino.git|Contributed|Kerbal Sim Pit
+https://github.com/Simpit-team/KerbalSimpitRevamped-Arduino.git|Contributed|Kerbal Sim Pit
 https://github.com/ghaemshop/ghaemShopSmSim.git|Contributed|ghaemShopSmSim
 https://github.com/ssuhrid/EmSevenSegment.git|Contributed|EmSevenSegment
 https://github.com/aelse/ArduinoStatsd.git|Contributed|StatsD

--- a/registry.txt
+++ b/registry.txt
@@ -1122,7 +1122,7 @@ https://github.com/DarkDust/MHGroveBLE.git|Contributed|MHGroveBLE
 https://github.com/SodaqMoja/Sodaq_LIS3DE.git|Contributed|Sodaq_LIS3DE
 https://github.com/connornishijima/TinySnore.git|Contributed|TinySnore
 https://github.com/kmackay/micro-ecc.git|Contributed|micro-ecc
-https://github.com/Simpit-team/KerbalSimpitRevamped-Arduino.git|Contributed|Kerbal Sim Pit
+https://github.com/Simpit-team/KerbalSimpitRevamped-Arduino.git|Contributed|KerbalSimpit
 https://github.com/ghaemshop/ghaemShopSmSim.git|Contributed|ghaemShopSmSim
 https://github.com/ssuhrid/EmSevenSegment.git|Contributed|EmSevenSegment
 https://github.com/aelse/ArduinoStatsd.git|Contributed|StatsD


### PR DESCRIPTION
https://github.com/arduino/library-registry/pull/496

Note this is the combination of two change requests:

- Change library URL from `https://bitbucket.org/pjhardy/kerbalsimpit-arduino.git` to `https://github.com/Simpit-team/KerbalSimpitRevamped-Arduino.git`
- Change library name from "Kerbal Sim Pit" to "KerbalSimpit"