### PR TITLE
Add ESP32_PWM Library

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -4240,3 +4240,4 @@ https://github.com/Seeed-Studio/Seeed_Arduino_Sketchbook
 https://github.com/terrorsl/sMQTTBroker
 https://github.com/FeralAI/MPG/
 https://github.com/winner10920/ESPSerialFlasher
+https://github.com/khoih-prog/ESP32_PWM


### PR DESCRIPTION
### Releases v1.0.0

1. Initial coding for ESP32, ESP32_S2 boards using [ESP32 core v2.0.0+](https://github.com/espressif/arduino-esp32/releases/tag/2.0.0)