### PR TITLE
Add ESP8266_PWM Library

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -4243,3 +4243,4 @@ https://github.com/FeralAI/MPG/
 https://github.com/winner10920/ESPSerialFlasher
 https://github.com/khoih-prog/ESP32_PWM
 https://gitlab.com/tamctec/ft62x6-arduino
+https://github.com/khoih-prog/ESP8266_PWM


### PR DESCRIPTION
### Releases v1.0.0

1. Initial coding for ESP8266 boards using [ESP8266 core v3.0.2+](https://github.com/esp8266/Arduino/releases/tag/3.0.2)