### PR TITLE
Add Portenta_H7_PWM Library

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -4244,3 +4244,4 @@ https://github.com/winner10920/ESPSerialFlasher
 https://github.com/khoih-prog/ESP32_PWM
 https://gitlab.com/tamctec/ft62x6-arduino
 https://github.com/khoih-prog/ESP8266_PWM
+https://github.com/khoih-prog/Portenta_H7_PWM


### PR DESCRIPTION
### Initial Releases v1.0.0

1. Initial coding to support **Portenta_H7 boards** such as Portenta_H7 Rev2 ABX00042, etc., using [**ArduinoCore-mbed mbed_portenta** core](https://github.com/arduino/ArduinoCore-mbed)