### PR TITLE
Add Portenta_H7_Slow_PWM Library

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -4252,3 +4252,4 @@ https://github.com/khoih-prog/Portenta_H7_PWM
 https://github.com/tamctec/ft62x6-arduino
 https://github.com/awgrover/Every-for-arduino
 https://github.com/bobboteck/CWLibrary
+https://github.com/khoih-prog/Portenta_H7_Slow_PWM


### PR DESCRIPTION
1. Initial coding to support **Portenta_H7 boards** such as Portenta_H7 Rev2 ABX00042, etc., using [**ArduinoCore-mbed mbed_portenta** core](https://github.com/arduino/ArduinoCore-mbed). Max PWM frequency is limited at **1000Hz**.