### PR TITLE
Add RP2040_PWM Library

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -4254,3 +4254,4 @@ https://github.com/awgrover/Every-for-arduino
 https://github.com/bobboteck/CWLibrary
 https://github.com/khoih-prog/Portenta_H7_Slow_PWM
 https://github.com/SpaceTrekKSC/EasyStarterKit
+https://github.com/khoih-prog/RP2040_PWM


### PR DESCRIPTION
### Initial Releases v1.0.0

1. Initial coding to support **RP2040-based boards** such as Nano_RP2040_Connect, RASPBERRY_PI_PICO, etc. using either RP2040 [**ArduinoCore-mbed mbed_nano or mbed_rp2040** core](https://github.com/arduino/ArduinoCore-mbed) or [**Earle Philhower's arduino-pico core**](https://github.com/earlephilhower/arduino-pico)
2. The purely hardware-based PWM channel can generate from very low (lowest is 7.5Hz) to very high PWM frequencies (in the **MHz** range, up to **62.5MHz**).