### PR TITLE
Add RP2040_Slow_PWM Library

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -4256,3 +4256,4 @@ https://github.com/khoih-prog/Portenta_H7_Slow_PWM
 https://github.com/SpaceTrekKSC/EasyStarterKit
 https://github.com/khoih-prog/RP2040_PWM
 https://github.com/khoih-prog/MBED_RP2040_Slow_PWM
+https://github.com/khoih-prog/RP2040_Slow_PWM


### PR DESCRIPTION
### Initial Releases v1.0.0

1. Initial coding to support **RP2040-based boards** such as ADAFRUIT_FEATHER_RP2040, RASPBERRY_PI_PICO, etc. using [**Earle Philhower's arduino-pico core**](https://github.com/earlephilhower/arduino-pico)
2. The hybrid ISR-based PWM channels can generate from very low (much less than 1Hz) to highest PWM frequencies up to 1000Hz with acceptable accuracy.