### PR TITLE
Add nRF52_MBED_Slow_PWM Library

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -4259,3 +4259,4 @@ https://github.com/SpaceTrekKSC/EasyStarterKit
 https://github.com/khoih-prog/RP2040_PWM
 https://github.com/khoih-prog/MBED_RP2040_Slow_PWM
 https://github.com/khoih-prog/RP2040_Slow_PWM
+https://github.com/khoih-prog/nRF52_MBED_Slow_PWM


### PR DESCRIPTION
### Initial Releases v1.0.0

1. Initial coding to support **Nano-33-BLE or Nano-33-BLE_Sense boards** using 

- [`Arduino mbed_nano core 2.5.2+`](https://github.com/arduino/ArduinoCore-mbed) for NRF52-based board using mbed_nano core such as Nano-33-BLE if you don't use `NRF_TIMER_1`.
- [`Arduino mbed core v1.3.2-`](https://github.com/arduino/ArduinoCore-mbed/releases/tag/1.3.2) for NRF52-based board using mbed-RTOS such as Nano-33-BLE if you'd like to use `NRF_TIMER_1`.

2. The **hybrid ISR-based PWM channels** can generate from very low (much less than **1Hz**) to highest PWM frequencies up to **1000Hz** with acceptable accuracy.