### PR TITLE
Add nRF52_Slow_PWM Library

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -4260,3 +4260,4 @@ https://github.com/khoih-prog/RP2040_PWM
 https://github.com/khoih-prog/MBED_RP2040_Slow_PWM
 https://github.com/khoih-prog/RP2040_Slow_PWM
 https://github.com/khoih-prog/nRF52_MBED_Slow_PWM
+https://github.com/khoih-prog/nRF52_Slow_PWM


### PR DESCRIPTION
### Initial Releases v1.0.0

1. Initial coding to support **nRF52-based boards, such as AdaFruit Itsy-Bitsy nRF52840, Feather nRF52840 Express**, etc. using [`Adafruit nRF52 core`](https://github.com/adafruit/Adafruit_nRF52_Arduino)

2. The hybrid ISR-based PWM channels can generate from very low (much less than 1Hz) to highest PWM frequencies up to 1000Hz with acceptable accuracy.