### PR TITLE
Add AVR_Slow_PWM Library

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -4265,3 +4265,4 @@ https://github.com/khoih-prog/RP2040_Slow_PWM
 https://github.com/khoih-prog/nRF52_MBED_Slow_PWM
 https://github.com/khoih-prog/nRF52_Slow_PWM
 https://github.com/Wh1teRabbitHU/ADS1115-Driver
+https://github.com/khoih-prog/AVR_Slow_PWM


### PR DESCRIPTION
### Initial Releases v1.0.0

1. Initial coding to support **AVR boards, such as Mega-2560, UNO,Nano, Leonardo, etc.**, etc. using AVR core

2. The hybrid ISR-based PWM channels can generate from very low (much less than 1Hz) to highest PWM frequencies up to 500Hz with acceptable accuracy.