### PR TITLE
Add megaAVR_Slow_PWM Library

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -4267,3 +4267,4 @@ https://github.com/khoih-prog/nRF52_MBED_Slow_PWM
 https://github.com/khoih-prog/nRF52_Slow_PWM
 https://github.com/Wh1teRabbitHU/ADS1115-Driver
 https://github.com/khoih-prog/AVR_Slow_PWM
+https://github.com/khoih-prog/megaAVR_Slow_PWM


### PR DESCRIPTION
### Initial Releases v1.0.0

1. Initial coding to support **Arduino megaAVR boards, such as UNO WiFi Rev2, AVR_Nano_Every, etc.**, etc. using [`Arduino megaAVR core`](https://github.com/arduino/ArduinoCore-megaavr)

2. The hybrid ISR-based PWM channels can generate from very low (much less than **1Hz**) to highest PWM frequencies up to **500Hz** with acceptable accuracy.