### PR TITLE
Add Teensy_Slow_PWM Library

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -4270,3 +4270,4 @@ https://github.com/khoih-prog/nRF52_Slow_PWM
 https://github.com/Wh1teRabbitHU/ADS1115-Driver
 https://github.com/khoih-prog/AVR_Slow_PWM
 https://github.com/khoih-prog/megaAVR_Slow_PWM
+https://github.com/khoih-prog/Teensy_Slow_PWM


### PR DESCRIPTION
### Initial Releases v1.0.0

1. Initial coding to support **Teensy boards, such as Teensy 2.x, Teensy LC, Teensy 3.x, Teensy 4.x, Teensy MicroMod, etc.**, using [Teensyduno core](https://www.pjrc.com/teensy/td_download.html)

2. The hybrid ISR-based PWM channels can generate from very low (much less than **1Hz**) to highest PWM frequencies up to **500-1000Hz** with acceptable accuracy.