### PR TITLE
Add SAMDUE_Slow_PWM Library

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -4271,3 +4271,4 @@ https://github.com/Wh1teRabbitHU/ADS1115-Driver
 https://github.com/khoih-prog/AVR_Slow_PWM
 https://github.com/khoih-prog/megaAVR_Slow_PWM
 https://github.com/khoih-prog/Teensy_Slow_PWM
+https://github.com/khoih-prog/SAMDUE_Slow_PWM


### PR DESCRIPTION
### Initial Releases v1.0.0

1. Initial coding to support **SAM_DUE**, etc. using [`Arduino SAM core`](https://github.com/arduino/ArduinoCore-sam)

2. The hybrid ISR-based PWM channels can generate from very low (much less than **1Hz**) to highest PWM frequencies up to **1000Hz** with acceptable accuracy.