### PR TITLE
Add STM32_PWM Library

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -4277,3 +4277,4 @@ https://github.com/khoih-prog/Teensy_Slow_PWM
 https://github.com/khoih-prog/SAMDUE_Slow_PWM
 https://github.com/khoih-prog/STM32_Slow_PWM
 https://github.com/shkoo/MeshGnome
+https://github.com/khoih-prog/STM32_PWM


### PR DESCRIPTION
1. Initial coding to support **STM32F/L/H/G/WB/MP1 boards** such as NUCLEO_H743ZI2, NUCLEO_L552ZE_Q, NUCLEO_F767ZI, BLUEPILL_F103CB, etc., using [`Arduino Core for STM32`](https://github.com/stm32duino/Arduino_Core_STM32)
2. The hardware-based PWM channels can generate very high PWM frequencies up with high accuracy.