### PR TITLE
Add SAMD_Slow_PWM Library

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -4280,3 +4280,4 @@ https://github.com/khoih-prog/STM32_Slow_PWM
 https://github.com/shkoo/MeshGnome
 https://github.com/khoih-prog/STM32_PWM
 https://github.com/michpro/XTEA-Cipher
+https://github.com/khoih-prog/SAMD_Slow_PWM


### PR DESCRIPTION
### Initial Releases v1.0.0

1. Initial coding to support **SAMD21/SAMD51 boards** such as NANO_33_IOT, ITSYBITSY_M4, SEEED_XIAO_M0, SparkFun_SAMD51_Thing_Plus, etc. using Arduino, Adafruit or Sparkfun core
2. The hybrid ISR-based PWM channels can generate from very low (much less than **1Hz**) to highest PWM frequencies up to **1000Hz** with acceptable accuracy.