### PR TITLE
Add type change repository label to configuration file

### DIFF
--- a/.github/label-configuration-files/labels.yml
+++ b/.github/label-configuration-files/labels.yml
@@ -31,6 +31,9 @@
 - name: "topic: submission"
   color: "00ffff"
   description: Add library to the list
+- name: "topic: type change"
+  color: "00ffff"
+  description: Change library types data
 - name: "topic: URL change"
   color: "00ffff"
   description: Change library repository URL


### PR DESCRIPTION
The repository contains labels for each of the distinct operations that may be requested for the library registrations or index data. These labels are defined in a local configuration file for management by the "Sync Labels" GitHub Actions work in combination with the shared universal Arduino tooling project repository labels configuration file.

Since there has not yet been an internal request for a type change operation, the associated "topic: type change" label was forgotten when creating the configuration file. It will be best to have the label in place so every standard operation can be accomplished without unnecessary complication.

---
If merged, the following change will be made to the repository labels:
https://github.com/arduino/library-registry/pull/579/checks?check_run_id=3872900319#step:9:15