### PR TITLE
Fix bugs in dry run determination code for "Sync Labels" workflow

### DIFF
--- a/.github/workflows/sync-labels.yml
+++ b/.github/workflows/sync-labels.yml
@@ -92,7 +92,13 @@ jobs:
         id: dry-run
         if: >
           github.event_name == 'pull_request' ||
-          github.ref != format('refs/heads/{0}', github.event.repository.default_branch)
+          (
+            (
+              github.event_name == 'push' ||
+              github.event_name == 'workflow_dispatch'
+            ) &&
+            github.ref != format('refs/heads/{0}', github.event.repository.default_branch)
+          )
         run: |
           # Use of this flag in the github-label-sync command will cause it to only check the validity of the
           # configuration.


### PR DESCRIPTION
This PR pulls in fixes to the "Sync Labels" workflow from its upstream "template".

### Correct context key name in "Sync Labels" workflow

Incorrect context key name resulted in impossible to satisfy conditional, meaning the dry run determination code was
solely dependent on the check for whether the workflow was triggered from the default branch name.

### Sync labels in write mode on schedule trigger

In order to facilitate the testing and review of proposed changes to the repository label infrastructure, the
"Sync Labels" template workflow does a dry run when triggered under conditions that indicate it would not be appropriate
to make real changes to the repository's labels. The changes that would have resulted are printed to the log, but not
actually made.

One of the criteria used to determine "dry run" mode usage is whether the event occurred on the repository's default
branch. A trigger on a development branch or for a pull request should not result in a change to the labels.
It turns out that GitHub does not define a `github.event.repository.default_branch` context item when a workflow is
triggered by a `schedule` event. This resulted in the workflow always running in "dry run" mode on a `schedule` trigger.
Since `schedule` and `repository_dispatch` triggers are only permitted for the default branch, there is no need to check
whether the event's ref matches the default branch and it is safe to always run in write mode on these events.