### PR TITLE
Add Portenta_H7_AsyncHTTPRequest Library

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -4299,3 +4299,4 @@ https://github.com/FrankBoesing/FastCRC
 https://github.com/Wh1teRabbitHU/SiC45x
 https://github.com/stm32duino/ST25R3916
 https://github.com/stm32duino/X-NUCLEO-NFC06A1
+https://github.com/khoih-prog/Portenta_H7_AsyncHTTPRequest


### PR DESCRIPTION
### Initial Releases v1.0.0

1. Initial coding to support **Portenta_H7 boards** such as Portenta_H7 Rev2 ABX00042, etc., using [**ArduinoCore-mbed mbed_portenta** core](https://github.com/arduino/ArduinoCore-mbed) with `Vision-shield Ethernet` ot `Murata WiFi`