### PR TITLE
Update repositories.txt

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -1680,6 +1680,7 @@ https://github.com/ivanseidel/Gaussian
 https://github.com/ivanseidel/LinkedList
 https://github.com/J-Rios/uTLGBotLib-arduino
 https://github.com/Jaapdedood/ArxRobot-Library
+https://github.com/Jackal28/MCP3304
 https://github.com/jackrobotics/HONEYLemon
 https://github.com/jackrobotics/iSYNC_BC95_Arduino
 https://github.com/jackrobotics/iSYNC


### PR DESCRIPTION
MCP3304 library which does not require the use of SPI/ serial.
Has three different options: either pulling the raw number 0-4095, pulling the voltage input, or pulling an averaged voltage with the option to select the amount of times it is averaged 0-1000, and adding in one's own delay between each averaged amount.