### PR TITLE
Add AsyncHTTPSRequest_Generic Library

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -4317,3 +4317,4 @@ https://github.com/rei-vilo/PDLS_EXT3_Basic_Fast
 https://github.com/A-Vision-Software/AVision_ESP8266
 https://gitlab.com/yanranxiaoxi/AntiKeyRepetition.h
 https://github.com/khoih-prog/AsyncTCP_SSL
+https://github.com/khoih-prog/AsyncHTTPSRequest_Generic


### PR DESCRIPTION
### Releases v1.0.0

1. Initial coding to support **Async HTTPS** to **ESP32, ESP32_S2 and ESP32_C3** using built-in WiFi