### PR TITLE
Added the LiquidCrystal NKC library GitHub URL

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -4333,3 +4333,4 @@ https://github.com/stm32duino/ST25R95
 https://github.com/natnqweb/Functional_button
 https://github.com/natnqweb/Mapf
 https://github.com/nitz/Cie1931
+https://github.com/domiluci/LiquidCrystal_NKC


### PR DESCRIPTION
The official GitHub URL of the **[LiquidCrystal NKC](https://github.com/domiluci/LiquidCrystal_NKC)** library for the Arduino IDE, developed by [Dominic Luciano](https://github.com/domiluci), was added on line 4336. This library is Arduino 2.0+ ready