### PR TITLE
Rename "RTTStream"

### DIFF
--- a/registry.txt
+++ b/registry.txt
@@ -4452,7 +4452,7 @@ https://github.com/SantiagoSaldana/SBC.git|Contributed|SBC
 https://github.com/AlexIII/incbin-arduino.git|Contributed|incbin
 https://github.com/monkcs/devuino.git|Contributed|Devuino
 https://github.com/sparkfun/SparkFun_VEML7700_Arduino_Library.git|Contributed|SparkFun VEML7700 Arduino Library
-https://github.com/koendv/Arduino-RTTStream.git|Contributed|RTT Stream
+https://github.com/koendv/Arduino-RTTStream.git|Contributed|RTTStream
 https://github.com/TheFidax/SusiOverI2c.git|Contributed|SusiOverI2c
 https://github.com/DFRobot/DFRobot_MLX90614.git|Contributed|DFRobot_MLX90614
 https://github.com/m5stack/M5Unified.git|Contributed|M5Unified

--- a/registry.txt
+++ b/registry.txt
@@ -4452,7 +4452,7 @@ https://github.com/SantiagoSaldana/SBC.git|Contributed|SBC
 https://github.com/AlexIII/incbin-arduino.git|Contributed|incbin
 https://github.com/monkcs/devuino.git|Contributed|Devuino
 https://github.com/sparkfun/SparkFun_VEML7700_Arduino_Library.git|Contributed|SparkFun VEML7700 Arduino Library
-https://github.com/koendv/Arduino-RttStream.git|Contributed|RTT Stream
+https://github.com/koendv/Arduino-RTTStream.git|Contributed|RTT Stream
 https://github.com/TheFidax/SusiOverI2c.git|Contributed|SusiOverI2c
 https://github.com/DFRobot/DFRobot_MLX90614.git|Contributed|DFRobot_MLX90614
 https://github.com/m5stack/M5Unified.git|Contributed|M5Unified


### PR DESCRIPTION
https://github.com/arduino/library-registry/pull/662

This PR makes two modifications to the library's registration entry:

- Update URL
- Change name

Note to DB maintainer: since the rename process causes a full replacement of the registration, the URL update will be handled by the system as a matter of course. So this can be treated as a rename operation alone.