### PR TITLE
Add Artron_DS1338 lib

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -4376,3 +4376,4 @@ https://github.com/Jueff/SoftwareSerialTX
 https://github.com/0neblock/Arduino_SNMP
 https://github.com/stm32duino/VL53L5CX
 https://github.com/stm32duino/X-NUCLEO-53L5A1
+https://github.com/ArtronShop/Artron_DS1338


### PR DESCRIPTION
DS1338 is RTC ic, use it library with Arduino IDE and any Arduino board