### PR TITLE
Add AIS 4G Board library

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -4385,3 +4385,4 @@ https://github.com/ArtronShop/Artron_DS1338
 https://github.com/Matrix-Robotics/MatrixLaserSensor
 https://github.com/verdanatech/glpi_esp8266.git
 https://github.com/dl9sec/AioP13
+https://github.com/gravitech-engineer/AIS_IoT_4G


### PR DESCRIPTION
AIS 4G Board is a compact circuit board built for use in IoT development via 4G network using a market-leading microcontroller module from Espressif, model "ESP32-WROOM-32" and 4G communication module from SIMCom, model "SIM7600E-H1C", which supports LTE Cat 4 signals. This board has been designed and manufactured as a 4-Layer PCB according to engineering standards specified by IPC and includes built-in circuit protection in the form of transient-voltage-suppression of each I/O pins. The board itself has many incredible and useful functions. For example, there are two USB Type-C connectors: one for direct connection to SIM7600E-H1C, and the other for ESP32-WROOM-32 via the FTDI chip, which acts as a USB-to-Serial converter that is stable and supports all operating systems. There is an on-board temperature and humidity sensor, also includes several LED indicators, an RS485 port, GPS for location tracking, ESIM is pre-installed onto the board so no additional SIM installation is required, a MicroSD card slot for data logging. And the most unique thing about this product is its ability to promptly connect to the Microsoft Azure cloud services.

More info: https://devicecatalog.azure.com/devices/f772e8e6-d0c4-4d08-b5fc-9e4abfe712b2