### PR TITLE
Removal request for "FireBase32"

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -3,7 +3,6 @@ https://github.com/ncmreynolds/TapCode
 https://github.com/NeMaksym/Arduino-EasySevenSeg
 https://github.com/ArduinoGetStarted/Analog-Keypad
 https://github.com/GerLech/AsyncWebConfig
-https://github.com/ohad32/FireBase32
 https://github.com/Franzininho/Franzininho_LiquidCrystal
 https://github.com/ProjectoOfficial/Oscup
 https://github.com/cygig/MonteCarloPi


### PR DESCRIPTION
Remove the fake and junk library that will never test and doesn't work from someone that doesn't know the basic of C or C++ programming.

This is the library repository.
https://github.com/ohad32/FireBase32

Here is why it should remove.
https://github.com/ohad32/FireBase32/blob/main/src/FireBase32.h#L24-L34

I hope that the Arduino team should have the process for preliminary testing or validating the library prior to accept the submission.