### PR TITLE
Configure manager workflow to prevent parallel runs for one PR

### DIFF
--- a/.github/workflows/manage-prs.yml
+++ b/.github/workflows/manage-prs.yml
@@ -24,6 +24,10 @@ on:
       - created
       - edited
 
+concurrency:
+  group: ${{ github.event.pull_request.number }}${{ github.event.issue.number }}
+  cancel-in-progress: true
+
 jobs:
   diff:
     if: >


### PR DESCRIPTION
It was previously possible to trigger the "Manage PRs" workflow for a pull request while a previous run for that PR is
already in process.

When that happens, it can result in erroneous bot comments. For example:

1. Workflow run is automatically triggered by a push.
2. Contributor does not notice this and comments a mention of the bot to trigger the workflow.
3. The first workflow run finds the PR is compliant and merges it.
4. The second workflow run finds the PR is compliant and attempts to merge it.
5. The second workflow run fails the merge (because it is already merged) and informs the contributor that there was a
   merge conflict they must resolve.
6. The contributor is not able to resolve the non-existent conflict and is left wondering whether their submission was
   successful.

Some actual occurrences of this:

- https://github.com/arduino/library-registry/pull/296#issuecomment-889251721
- https://github.com/arduino/library-registry/pull/502#issuecomment-923114949

The solution is to configure the "Manage PRs" workflow so that a workflow run in progress is canceled if the workflow is
triggered again for that PR. The "concurrency group" name is the PR number, so workflow runs in progress for other PRs
would not be affected:

https://docs.github.com/en/actions/learn-github-actions/workflow-syntax-for-github-actions#concurrency

---
Demonstration PR in my fork: https://github.com/per1234/library-registry/pull/47

The workflow run that was automatically canceled: https://github.com/per1234/library-registry/actions/runs/1493743516
The workflow run that superseded the canceled workflow run: https://github.com/per1234/library-registry/actions/runs/1493744935

Manual test suite run against this version of the workflow in my fork: https://github.com/per1234/library-registry/pull/46