### PR TITLE
Added simple collections library in the davetcc repository

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -1105,6 +1105,7 @@ https://github.com/datacute/TinyOLED-Fonts
 https://github.com/DatavenueLiveObjects/LiveObjects_SDK_for_Arduino
 https://github.com/davetcc/IoAbstraction
 https://github.com/davetcc/LiquidCrystalIO
+https://github.com/davetcc/SimpleCollections
 https://github.com/davetcc/TaskManagerIO
 https://github.com/davetcc/tcMenuLib
 https://github.com/david1983/eBtn


### PR DESCRIPTION
This adds SimpleCollections library - this code was previously part of IoAbstraction and has been broken out as it could be more generally useful. V1.0.1 has been built and tested on most Arduino and a few mbed platforms.

Once this library is available here, I will release a version of IoAbstraction that depends upon this library.