### PR TITLE
Add official Microsoft Azure SDK for C Arduino library.

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -781,6 +781,7 @@ https://github.com/Azure/azure-iot-arduino-protocol-mqtt
 https://github.com/Azure/azure-iot-arduino-socket-esp32-wifi
 https://github.com/Azure/azure-iot-arduino-utility
 https://github.com/Azure/azure-iot-arduino
+https://github.com/Azure/azure-sdk-for-c-arduino
 https://github.com/BadASszZ/IoTWebConf_for_Visuino_modified_by_IoT_Jedi
 https://github.com/baggio63446333/QZQSM
 https://github.com/baghayi/Nokia_5110


### PR DESCRIPTION
From the library repo https://github.com/Azure/azure-sdk-for-c-arduino.

This new library maps to the new Azure SDK for C that is designed for
embedded development, published on
https://github.com/azure/azure-sdk-for-c.

This new azure-sdk-for-c-arduino library shall be prefered over the previous azure-iot-arduino
library and dependencies (azure-iot-arduino-utility,
azure-iot-arduino-protocol-http, azure-iot-arduino-protocol-mqtt,
azure-iot-arduino-socket-esp32-wifi).

For questions, please refer to maintainer of library.