### PR TITLE
Added MCUOS library to list

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -4449,3 +4449,4 @@ https://github.com/jpiat/PIOSpi
 https://github.com/mobizt/ESP-Line-Notify
 https://github.com/yourapiexpert/ATCommands
 https://github.com/kolabse/KolabseCarsCan
+https://github.com/Coder-X15/MCUOS.git


### PR DESCRIPTION
I am submitting this pull request alongside a doubt - I am not sure if I could complete putting all the code in their requisite places (i.e., function definitions in the .cpp files and the rest in .h) as I am having a hefty school schedule nowadays, so may I submit my contribution as in the present state? Also, I must have missed a few files possibly, so please let me know the names of those which I have missed. Also, I'd like to see the `configurable` branch to be the one made available in the Library Manager rather than the `main` branch.