### PR TITLE
Avoid manager workflow run cancelation by incidental events

### DIFF
--- a/.github/workflows/manage-prs.yml
+++ b/.github/workflows/manage-prs.yml
@@ -26,7 +26,19 @@ on:
 
 concurrency:
   group: ${{ github.event.pull_request.number }}${{ github.event.issue.number }}
-  cancel-in-progress: true
+  cancel-in-progress: >-
+    ${{
+    (
+    github.event_name == 'pull_request_target' &&
+    github.event.pull_request.draft == false
+    ) ||
+    (
+    github.event_name == 'issue_comment' &&
+    github.event.issue.pull_request != '' &&
+    github.event.issue.state == 'open' &&
+    contains(github.event.comment.body, 'ArduinoBot')
+    )
+    }}
 
 jobs:
   diff:


### PR DESCRIPTION
In order to prevent confusing feedback from the bot, parallel runs of the "Manage PRs" workflow for a given PR are prevented by canceling any in progress runs for that PR whenever it is triggered.

However, sometimes a trigger event does not result in a run. For example, the workflow is triggered by every comment on the PR thread, but only those containing the text "ArduinoBot" result in a run. With the previous workflow configuration, this meant that if anyone made an incidental comment on the PR during a workflow run, the true run was canceled by the otherwise ignored trigger event, causing a loss of automation.

The solution is to adjust the concurrency configuration so that prior runs in progress are canceled only if the current trigger event will result in a true run.

I did not indent the added expression because doing so caused validation against the community developed GitHub Actions workflow JSON schema from [the JSON Schema Store](https://www.schemastore.org/json/) to fail (this repository's [CI system](https://github.com/arduino/library-registry/blob/main/.github/workflows/check-workflows.yml) does validation on the workflows).
The reason is that lines with leading whitespace are not folded:
https://yaml.org/spec/1.2.2/#block-folding
Even though the resulting newlines in the expression don't cause any problems for GitHub Actions, the JSON Schema does not have support for them. Since there is no explicit specification in [the GitHub Actions documentation](https://docs.github.com/en/actions/learn-github-actions/expressions) that newlines in expressions are supported, I am hesitant to propose the necessary change to the schema.