### PR TITLE
Added uc-OS3 Arduino Due Library

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -4453,4 +4453,4 @@ https://github.com/kolabse/KolabseCarsCan
 https://github.com/Coder-X15/MCUOS.git
 https://github.com/John-Karatka/24LC64F
 https://github.com/dndubins/QuickStats
-https://git.fh-aachen.de/embedded-arduino/uc-os3-arduino-due
+https://github.com/vChavezB/uc-os3-arduino-due.git

--- a/repositories.txt
+++ b/repositories.txt
@@ -4453,3 +4453,4 @@ https://github.com/kolabse/KolabseCarsCan
 https://github.com/Coder-X15/MCUOS.git
 https://github.com/John-Karatka/24LC64F
 https://github.com/dndubins/QuickStats
+https://git.fh-aachen.de/embedded-arduino/uc-os3-arduino-due


### PR DESCRIPTION
There is currently version [uc-OS2 ](https://github.com/Gibartes/uCOS-II-Arduino) but I created this library to use the features of uc-OS3.

https://git.fh-aachen.de/embedded-arduino/uc-os3-arduino-due