### PR TITLE
Initial release of Robbus Kidsy V1.0.0 library

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -4458,3 +4458,4 @@ https://github.com/vChavezB/uc-os3-arduino-due.git
 https://github.com/fabriziop/FIFOEE.git
 https://github.com/sparkfun/SparkFun_Qwiic_Fan_Arduino_Library
 https://github.com/viralinkio/ViraLink-MQTT-Client
+https://github.com/RocketLauncherCDMX/RocketLauncher_RobbusKidsy


### PR DESCRIPTION
This is the initial release of the Rocket Launcher - Robbus Kidsy library V1.0.0, compatible with hardware V3.2