### PR TITLE
Update URL and name of "ViraLink-MQTT-Client"

### DIFF
--- a/registry.txt
+++ b/registry.txt
@@ -4559,7 +4559,7 @@ https://github.com/dndubins/QuickStats.git|Contributed|QuickStats
 https://github.com/vChavezB/uc-os3-arduino-due.git|Contributed|uCOS-III_Due
 https://github.com/fabriziop/FIFOEE.git|Contributed|FIFOEE
 https://github.com/sparkfun/SparkFun_Qwiic_Fan_Arduino_Library.git|Contributed|SparkFun Qwiic Fan Arduino Library
-https://github.com/viralinkio/ViraLink-Arduino-SDK.git|Contributed|ViraLink-MQTT-CLient
+https://github.com/viralinkio/ViraLink-Arduino-SDK.git|Contributed|ViraLink-MQTT-Client
 https://github.com/ssilverman/QNEthernet.git|Contributed|QNEthernet
 https://github.com/RAKWireless/RAK13600-PN532.git|Contributed|RAKwireless RAK13600 RFID library
 https://github.com/RAKWireless/RAK12019_LTR390.git|Contributed|RAK12019_LTR390_UV_Light

--- a/registry.txt
+++ b/registry.txt
@@ -4559,7 +4559,7 @@ https://github.com/dndubins/QuickStats.git|Contributed|QuickStats
 https://github.com/vChavezB/uc-os3-arduino-due.git|Contributed|uCOS-III_Due
 https://github.com/fabriziop/FIFOEE.git|Contributed|FIFOEE
 https://github.com/sparkfun/SparkFun_Qwiic_Fan_Arduino_Library.git|Contributed|SparkFun Qwiic Fan Arduino Library
-https://github.com/viralinkio/ViraLink-MQTT-Client.git|Contributed|ViraLink-MQTT-CLient
+https://github.com/viralinkio/ViraLink-Arduino-SDK.git|Contributed|ViraLink-MQTT-CLient
 https://github.com/ssilverman/QNEthernet.git|Contributed|QNEthernet
 https://github.com/RAKWireless/RAK13600-PN532.git|Contributed|RAKwireless RAK13600 RFID library
 https://github.com/RAKWireless/RAK12019_LTR390.git|Contributed|RAK12019_LTR390_UV_Light


### PR DESCRIPTION
This combines two changes:

- URL from https://github.com/viralinkio/ViraLink-MQTT-Client.git to https://github.com/viralinkio/ViraLink-Arduino-SDK.git
- Name from "ViraLink-MQTT-CLient" to "ViraLink-MQTT-Client"

Since the name change operation on the database is actually a removal followed by automated reindexing on the next job run, the URL update will occur as a matter of course and so the only thing required from the DB maintainer is the name change procedure.

Follow-up to https://github.com/arduino/library-registry/pull/786