### PR TITLE
Update URL of "Indicator"

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -102,7 +102,7 @@ https://github.com/bigsmalloverall/SimpleTaskManager
 https://github.com/Infineon/arduino-multi-half-bridge
 https://github.com/aikopras/RSbus
 https://github.com/tfeldmann/Arduino-SchmittTrigger
-https://github.com/tfeldmann/Arduino-Indicator
+https://github.com/tfeldmann/Arduino-Blinkenlight
 https://github.com/miathedev/KomootBLEConnect
 https://github.com/RobotGrrl/PolylineArduino
 https://github.com/Tinyu-Zhao/PCA9554


### PR DESCRIPTION
The repository name has been changed and the update was requested at https://github.com/arduino/library-registry/issues/800