### PR TITLE
Update URL and name of "Blinkenlight

### DIFF
--- a/registry.txt
+++ b/registry.txt
@@ -4465,7 +4465,7 @@ https://github.com/cygig/MonteCarloPi.git|Contributed|MonteCarloPi
 https://github.com/ProjectoOfficial/Oscup.git|Contributed|Oscup
 https://github.com/Franzininho/Franzininho_LiquidCrystal.git|Contributed|Franzininho_LiquidCrystal
 https://github.com/0neblock/Arduino_SNMP.git|Contributed|SNMP_Agent
-https://github.com/tfeldmann/Arduino-Indicator.git|Contributed|Indicator
+https://github.com/tfeldmann/Arduino-Blinkenlight.git|Contributed|Indicator
 https://github.com/GerLech/AsyncWebConfig.git|Contributed|AsyncWebConfig
 https://github.com/ohad32/FireBase32.git|Contributed|FireBase32
 https://github.com/ruiseixasm/Robust-EEPROM.git|Contributed|Robust-EEPROM

--- a/registry.txt
+++ b/registry.txt
@@ -4465,7 +4465,7 @@ https://github.com/cygig/MonteCarloPi.git|Contributed|MonteCarloPi
 https://github.com/ProjectoOfficial/Oscup.git|Contributed|Oscup
 https://github.com/Franzininho/Franzininho_LiquidCrystal.git|Contributed|Franzininho_LiquidCrystal
 https://github.com/0neblock/Arduino_SNMP.git|Contributed|SNMP_Agent
-https://github.com/tfeldmann/Arduino-Blinkenlight.git|Contributed|Indicator
+https://github.com/tfeldmann/Arduino-Blinkenlight.git|Contributed|Blinkenlight
 https://github.com/GerLech/AsyncWebConfig.git|Contributed|AsyncWebConfig
 https://github.com/ohad32/FireBase32.git|Contributed|FireBase32
 https://github.com/ruiseixasm/Robust-EEPROM.git|Contributed|Robust-EEPROM


### PR DESCRIPTION
This combines two changes:

- URL from https://github.com/tfeldmann/Arduino-Indicator.git to https://github.com/tfeldmann/Arduino-Blinkenlight.git
- Name from "Indicator" to "Blinkenlight"

Since the name change operation on the database is actually a removal followed by automated reindexing on the next job run, the URL update will occur as a matter of course and so the only thing required from the DB maintainer is the name change procedure.

Follow-up to https://github.com/arduino/library-registry/pull/801
Resolves https://github.com/arduino/library-registry/issues/800