### PR TITLE
Add "pending backend" repository label

### DIFF
--- a/.github/label-configuration-files/labels.yml
+++ b/.github/label-configuration-files/labels.yml
@@ -4,6 +4,9 @@
 - name: "status: maintenance required"
   color: "ff0000"
   description: Infrastructure failure unrelated to request
+- name: "status: pending backend"
+  color: "0000ff"
+  description: Depends on backend maintenance operations
 - name: "topic: invalid"
   color: "ff0000"
   description: Request could not be processed


### PR DESCRIPTION
Although the submission process is completely automated, [other requests](https://github.com/arduino/library-registry#changing-the-url-of-a-library-already-in-library-manager) (e.g., library repository URL update) are still handled manually due to requiring additional operations on the backend

The changes to the data files stored in this repository must be coordinated with the associated changes to the Library Manager database and/or storage systems.

The dedicated "status: pending backend" repository label will be added to the issues and PRs which can be resolved only after those external operations have been completed; in this manner indicating their status in a clear and machine readable manner.