### PR TITLE
Revert "Add submission # 880"

### DIFF
--- a/registry.txt
+++ b/registry.txt
@@ -4636,4 +4636,3 @@ https://github.com/DFRobot/DFRobot_TMF8x01.git|Contributed|DFRobot_TMF8x01
 https://github.com/makerspaceleiden/tee-log.git|Contributed|TLog
 https://github.com/cafeiot/CafeIOT_Arduino.git|Contributed|CafeIot_Arduino
 https://github.com/cafeiot/CafeIOT_Esp8266.git|Contributed|CafeIOT
-https://github.com/cafeiot/CafeIOT_Esp32.git|Contributed|CafeIOT


### PR DESCRIPTION
This reverts commit cb660bc85b35723481d7d5659f67a73623097eb2.

This registration is invalid due to having the same "CafeIOT" name as another library already in the registry.

The registration will be added back once the name collision has been resolved.

The submission system is designed to block this from happening but it failed in this case.