### PR TITLE
Change of url to exiting library

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -3024,7 +3024,7 @@ https://github.com/RAKWireless/RAK12021-TCS37725
 https://github.com/RAKWireless/RAK12025-I3G4250D
 https://github.com/ramonheras/Pixel-and-Play-Arduino-Library
 https://github.com/rapifireio/rapifire-arduino-mqtt
-https://github.com/rasmushedeager/sducar
+https://github.com/sdutek/sducar
 https://github.com/ravelab/JsonLogger
 https://github.com/RB-ENantel/RC_ESC
 https://github.com/RealTadango/FrSky


### PR DESCRIPTION
As this library is a project in cooperation with the University of Southern Denmark, I have transferred the repository to the organization instead