### PR TITLE
Update URL of "SparkFun Si7021 Humidity and Temperature Sensor"

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -3697,7 +3697,7 @@ https://github.com/sparkfun/SparkFun_SerLCD_Arduino_Library
 https://github.com/sparkfun/SparkFun_SGP30_Arduino_Library
 https://github.com/sparkfun/SparkFun_SGP40_Arduino_Library
 https://github.com/sparkfun/SparkFun_SHTC3_Arduino_Library
-https://github.com/sparkfun/SparkFun_Si701_Breakout_Arduino_Library
+https://github.com/sparkfun/SparkFun_Si7021_Arduino_Library
 https://github.com/sparkfun/SparkFun_Simultaneous_RFID_Tag_Reader_Library
 https://github.com/sparkfun/SparkFun_smol_Power_Board_Arduino_Library
 https://github.com/sparkfun/SparkFun_SPI_SerialFlash_Arduino_Library


### PR DESCRIPTION
As requested at https://github.com/arduino/library-registry/issues/998

This is the first of two PRs to update to the new repository URL. This is the one for the `repositories.txt` change, which does not require any backend operation, and so can be merged immediately upon a PR approval.