### PR TITLE
Update URL of "SparkFun Si7021 Humidity and Temperature Sensor"

### DIFF
--- a/registry.txt
+++ b/registry.txt
@@ -1178,7 +1178,7 @@ https://github.com/Isaac100/TMP36.git|Contributed|TMP36
 https://github.com/andium/hueDino.git|Contributed|hueDino
 https://github.com/VittorioEsposito/J1850-Arduino-Transceiver-Library.git|Contributed|J1850 Arduino Transceiver Library
 https://github.com/Industruino/FRAM.git|Contributed|Fram
-https://github.com/sparkfun/SparkFun_Si701_Breakout_Arduino_Library.git|Contributed|SparkFun Si7021 Humidity and Temperature Sensor
+https://github.com/sparkfun/SparkFun_Si7021_Arduino_Library.git|Contributed|SparkFun Si7021 Humidity and Temperature Sensor
 https://github.com/OpenBCI/OpenBCI_WIFI.git|Contributed|OpenBCI_Wifi
 https://github.com/OpenBCI/OpenBCI_Wifi_Master_Library.git|Contributed|OpenBCI_Wifi_Master
 https://github.com/Infineon/DC-Motor-Control-TLE94112EL.git|Contributed|TLE94112


### PR DESCRIPTION
Resolves https://github.com/arduino/library-registry/issues/998

This is the first of two PRs to update to the new repository URL. This is the one for the `repositories.txt` change, which will require a parallel backend operation, and so should not be merged until that is completed.