### PR TITLE
Please add SimpleFOCDrivers library

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -788,6 +788,7 @@ https://github.com/RodolfoPrieto/MCP3208
 https://github.com/arsalmaner/Arduino-Libraries
 https://github.com/AshleyF/BriefEmbedded
 https://github.com/askuric/Arduino-FOC
+https://github.com/simplefoc/Arduino-FOC-drivers
 https://github.com/aspenforest/SIM800
 https://github.com/aster94/GoProControl
 https://github.com/aster94/Keyword-Protocol-2000


### PR DESCRIPTION
SimpleFOCDrivers library is a set of drivers for things like motor driver ICs, magnetic encoders and comms. It supports the existing SimpleFOC library already part of the library registry.