### PR TITLE
Add nRF52_MBED_PWM

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -4636,3 +4636,4 @@ https://github.com/VassilyDev/TSBridge
 https://github.com/jcomas/S8_UART
 https://github.com/unref-ptr/lwIOLink
 https://github.com/chrmlinux/tinyI2S
+https://github.com/khoih-prog/nRF52_MBED_PWM


### PR DESCRIPTION
### Initial Releases v1.0.0

1. Initial coding to support **Nano_33_BLE boards**, using [**ArduinoCore-mbed mbed_nano** core](https://github.com/arduino/ArduinoCore-mbed)