### PR TITLE
Add MBED_RP2040_PWM Library

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -4640,3 +4640,4 @@ https://github.com/chrmlinux/tinyI2S
 https://github.com/EmotiBit/EmotiBit_External_EEPROM
 https://github.com/khoih-prog/nRF52_MBED_PWM
 https://github.com/EmotiBit/EmotiBit_ADS1X15
+https://github.com/khoih-prog/MBED_RP2040_PWM


### PR DESCRIPTION
### Initial Releases v1.0.0

1. Initial coding to support RP2040-based boards such as **Nano_RP2040_Connect and RASPBERRY_PI_PICO**, etc. using [**Arduino-mbed** core](https://github.com/arduino/ArduinoCore-mbed)