### PR TITLE
add X9C10X - digital potentiometer classes

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -3290,6 +3290,7 @@ https://github.com/RobTillaart/tinySHT2x
 https://github.com/RobTillaart/TM1637_RT
 https://github.com/RobTillaart/Troolean
 https://github.com/RobTillaart/weight
+https://github.com/RobTillaart/X9C10X
 https://github.com/RobTillaart/XMLWriter
 https://github.com/rocketscream/Low-Power
 https://github.com/rocketscream/RocketScream_LowPowerAVRZero

--- a/repositories.txt
+++ b/repositories.txt
@@ -3265,6 +3265,7 @@ https://github.com/RobTillaart/ShiftInSlow
 https://github.com/RobTillaart/ShiftOutSlow
 https://github.com/RobTillaart/SHT2x
 https://github.com/RobTillaart/SHT31
+https://github.com/RobTillaart/Soundex
 https://github.com/RobTillaart/SHT85
 https://github.com/RobTillaart/SRF05
 https://github.com/RobTillaart/statHelpers

--- a/repositories.txt
+++ b/repositories.txt
@@ -3179,6 +3179,7 @@ https://github.com/RobTillaart/Max44007
 https://github.com/RobTillaart/Max44009
 https://github.com/RobTillaart/MCP_ADC
 https://github.com/RobTillaart/MCP_DAC
+https://github.com/RobTillaart/MCP23008
 https://github.com/RobTillaart/MCP23017_RT
 https://github.com/RobTillaart/MCP23S08
 https://github.com/RobTillaart/MCP23S17

--- a/repositories.txt
+++ b/repositories.txt
@@ -3177,6 +3177,7 @@ https://github.com/RobTillaart/FastShiftIn
 https://github.com/RobTillaart/FastShiftOut
 https://github.com/RobTillaart/FastTrig
 https://github.com/RobTillaart/FLE
+https://github.com/RobTillaart/Fletcher
 https://github.com/RobTillaart/float16
 https://github.com/RobTillaart/Fraction
 https://github.com/RobTillaart/FRAM_I2C

--- a/repositories.txt
+++ b/repositories.txt
@@ -3178,6 +3178,7 @@ https://github.com/RobTillaart/map2colour
 https://github.com/RobTillaart/MAX31855_RT
 https://github.com/RobTillaart/Max44007
 https://github.com/RobTillaart/Max44009
+https://github.com/RobTillaart/MAX6675
 https://github.com/RobTillaart/MCP_ADC
 https://github.com/RobTillaart/MCP_DAC
 https://github.com/RobTillaart/MCP23008

--- a/repositories.txt
+++ b/repositories.txt
@@ -3213,6 +3213,7 @@ https://github.com/RobTillaart/MCP9808_RT
 https://github.com/RobTillaart/MINMAX
 https://github.com/RobTillaart/ML8511
 https://github.com/RobTillaart/MS5611
+https://github.com/RobTillaart/MS5611_SPI
 https://github.com/RobTillaart/MT8870
 https://github.com/RobTillaart/MTP40C
 https://github.com/RobTillaart/MultiMap

--- a/repositories.txt
+++ b/repositories.txt
@@ -3133,6 +3133,7 @@ https://github.com/RobTillaart/AD5144A
 https://github.com/RobTillaart/AD520X
 https://github.com/RobTillaart/AD524X
 https://github.com/RobTillaart/AD985X
+https://github.com/RobTillaart/Adler
 https://github.com/RobTillaart/ADS1X15
 https://github.com/RobTillaart/ADT7470
 https://github.com/RobTillaart/AGS02MA

--- a/repositories.txt
+++ b/repositories.txt
@@ -3136,6 +3136,7 @@ https://github.com/RobTillaart/DAC8554
 https://github.com/RobTillaart/DEVNULL
 https://github.com/RobTillaart/DEVRANDOM
 https://github.com/RobTillaart/DHT12
+https://github.com/RobTillaart/DHT20
 https://github.com/RobTillaart/DHT2pin
 https://github.com/RobTillaart/DHTlib
 https://github.com/RobTillaart/DHTNew

--- a/repositories.txt
+++ b/repositories.txt
@@ -3169,6 +3169,7 @@ https://github.com/RobTillaart/Max44009
 https://github.com/RobTillaart/MCP_ADC
 https://github.com/RobTillaart/MCP_DAC
 https://github.com/RobTillaart/MCP23017_RT
+https://github.com/RobTillaart/MCP23S08
 https://github.com/RobTillaart/MCP23S17
 https://github.com/RobTillaart/MCP4725
 https://github.com/RobTillaart/MCP9808_RT


### PR DESCRIPTION
One base class and 4 specific derived classes for the X9C10X series digital potentiometers.