### PR TITLE
Add WiFiMulti_Generic Library

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -4655,3 +4655,4 @@ https://github.com/creatingnull/null-packet-comms-arduino
 https://github.com/arduino-libraries/Arduino_Braccio_plusplus
 https://github.com/PushDisDev/PushDis-cpp-client-library
 https://github.com/chrmlinux/tinyESPNow
+https://github.com/khoih-prog/WiFiMulti_Generic


### PR DESCRIPTION
#### Releases v1.0.0

1. Initial coding to support **ESP32, ESP8266, WiFiNINA and ESP8266_AT and ESP32_AT WiFi** for many boards (nRF52, SAMD, Teensy, RP2040, SAM-DUE, ESP32, ESP8266, etc.)