### PR TITLE
Rename "I2C_Functions"

### DIFF
--- a/registry.txt
+++ b/registry.txt
@@ -4742,7 +4742,7 @@ https://github.com/EmotiBit/EmotiBit_ADS1X15.git|Contributed|EmotiBit ADS1X15
 https://github.com/khoih-prog/MBED_RP2040_PWM.git|Contributed|MBED_RP2040_PWM
 https://github.com/cyijun/HAMqttDiscoveryHandler.git|Contributed|HAMqttDiscoveryHandler
 https://github.com/akkoyun/MAX78630.git|Contributed|MAX78630 Polyphase Energy Meter
-https://github.com/akkoyun/I2C_Functions.git|Contributed|Generic I2C Functions
+https://github.com/akkoyun/I2C_Functions.git|Contributed|I2C_Functions
 https://github.com/DFRobot/DFRobot_BMP280.git|Contributed|DFRobot_BMP280
 https://github.com/DFRobot/DFRobot_DHT11.git|Contributed|DFRobot_DHT11
 https://bitbucket.org/David_Such/nexgen_timer.git|Contributed|NexgenTimer


### PR DESCRIPTION
As requested at https://github.com/arduino/library-registry/pull/1084#issuecomment-1046244629