### PR TITLE
Update URL of "dWin"

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -4684,7 +4684,7 @@ https://github.com/fellipecouto/MillisTimerLib
 https://github.com/ruiseixasm/Versatile_RotaryEncoder
 https://github.com/akkoyun/Console
 https://github.com/akkoyun/I2C_Scanner
-https://github.com/akkoyun/dWin_Arduino
+https://github.com/akkoyun/dWin
 https://github.com/stm32duino/ISM330DHCX
 https://github.com/bitbank2/SLIC
 https://github.com/vChavezB/SimpleJ1939


### PR DESCRIPTION
Resolves (partially) https://github.com/arduino/library-registry/issues/1112

**NOTE**:

The error reported by the bot:

```text
ERROR: Library name dWin not found in the Library Manager index.
```

is expected. The name change is provided by https://github.com/arduino/library-registry/pull/1114