### PR TITLE
Update URL and name of "dWin"

### DIFF
--- a/registry.txt
+++ b/registry.txt
@@ -4783,7 +4783,7 @@ https://github.com/akkoyun/I2C_Scanner.git|Contributed|I2C_Scanner
 https://github.com/DFRobot/DFRobot_PH.git|Contributed|DFRobot_PH
 https://github.com/DFRobot/DFRobot_BC20_Gravity.git|Contributed|DFRobot_BC20_Gravity
 https://github.com/skathir38/Rotary.git|Contributed|Rotary
-https://github.com/akkoyun/dWin.git|Contributed|Dwin HMI LCD Screen Library
+https://github.com/akkoyun/dWin.git|Contributed|dWin
 https://github.com/stm32duino/ISM330DHCX.git|Contributed|STM32duino ISM330DHCX
 https://github.com/bitbank2/SLIC.git|Contributed|SLIC
 https://github.com/vChavezB/SimpleJ1939.git|Contributed|SimpleJ1939

--- a/registry.txt
+++ b/registry.txt
@@ -4783,7 +4783,7 @@ https://github.com/akkoyun/I2C_Scanner.git|Contributed|I2C_Scanner
 https://github.com/DFRobot/DFRobot_PH.git|Contributed|DFRobot_PH
 https://github.com/DFRobot/DFRobot_BC20_Gravity.git|Contributed|DFRobot_BC20_Gravity
 https://github.com/skathir38/Rotary.git|Contributed|Rotary
-https://github.com/akkoyun/dWin_Arduino.git|Contributed|Dwin HMI LCD Screen Library
+https://github.com/akkoyun/dWin.git|Contributed|Dwin HMI LCD Screen Library
 https://github.com/stm32duino/ISM330DHCX.git|Contributed|STM32duino ISM330DHCX
 https://github.com/bitbank2/SLIC.git|Contributed|SLIC
 https://github.com/vChavezB/SimpleJ1939.git|Contributed|SimpleJ1939


### PR DESCRIPTION
This PR consists of two changes:

- Change URL from `https://github.com/akkoyun/dWin_Arduino.git` to `https://github.com/akkoyun/dWin.git`
- Change name from `Dwin HMI LCD Screen Library` to `dWin`

Since the name change operation on the database is actually a removal followed by automated reindexing on the next job run, the URL update will occur as a matter of course and so the only thing required from the backend maintainer is the name change procedure.

Resolves https://github.com/arduino/library-registry/issues/1112