### PR TITLE
Remove "artemis-arduino"

### DIFF
--- a/registry.txt
+++ b/registry.txt
@@ -4812,5 +4812,4 @@ https://github.com/DFRobot/DFRobot_HX711.git|Contributed|DFRobot_HX711
 https://github.com/DFRobot/DFRobot_BMI160.git|Contributed|DFRobot_BMI160
 https://github.com/DFRobot/DFRobot_MAX17043.git|Contributed|DFRobot_MAX17043
 https://github.com/akkoyun/MAX17055.git|Contributed|MAX17055
-https://github.com/hsfl/artemis-arduino.git|Contributed|artemis-arduino
 https://github.com/hsfl/artemis-teensy.git|Contributed|artemis-teensy


### PR DESCRIPTION
Companion to https://github.com/arduino/library-registry/pull/1147