### PR TITLE
Remove "I2C_Functions"

### DIFF
--- a/registry.txt
+++ b/registry.txt
@@ -4737,7 +4737,6 @@ https://github.com/EmotiBit/EmotiBit_ADS1X15.git|Contributed|EmotiBit ADS1X15
 https://github.com/khoih-prog/MBED_RP2040_PWM.git|Contributed|MBED_RP2040_PWM
 https://github.com/cyijun/HAMqttDiscoveryHandler.git|Contributed|HAMqttDiscoveryHandler
 https://github.com/akkoyun/MAX78630.git|Contributed|MAX78630
-https://github.com/akkoyun/I2C_Functions.git|Contributed|I2C_Functions
 https://github.com/DFRobot/DFRobot_BMP280.git|Contributed|DFRobot_BMP280
 https://github.com/DFRobot/DFRobot_DHT11.git|Contributed|DFRobot_DHT11
 https://bitbucket.org/David_Such/nexgen_timer.git|Contributed|NexgenTimer


### PR DESCRIPTION
Companion to https://github.com/arduino/library-registry/pull/1154

Resolves https://github.com/arduino/library-registry/issues/1150