### PR TITLE
Adding STM32encoder library

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -1,3 +1,4 @@
+https://github.com/gianni-carbone/STM32encoder
 https://github.com/bheesma-10/MCP23008_I2C
 https://github.com/hsfl/artemis-teensy
 https://github.com/MaiTheLord/BetterOTA


### PR DESCRIPTION
Arduino library for the management of rotary encoders with STM32. This Arduino library simplifies the use of rotary encoders. It works with stm32 platforms.