### PR TITLE
Add DEVFULL

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -3208,6 +3208,7 @@ https://github.com/RobTillaart/DAC8550
 https://github.com/RobTillaart/DAC8551
 https://github.com/RobTillaart/DAC8552
 https://github.com/RobTillaart/DAC8554
+https://github.com/RobTillaart/DEVFULL
 https://github.com/RobTillaart/DEVNULL
 https://github.com/RobTillaart/DEVRANDOM
 https://github.com/RobTillaart/DHT12


### PR DESCRIPTION
DEVFULL mimics the /dev/full device of Linux, can be used for testing.