### PR TITLE
Add AsyncMQTT_Generic Library

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -4728,4 +4728,4 @@ https://github.com/centaq/arduino-async-bmp180wrapper
 https://github.com/centaq/arduino-led-driver
 https://github.com/akkoyun/RV3028
 https://github.com/BeanieBob/GY26Compass
-
+https://github.com/khoih-prog/AsyncMQTT_Generic


### PR DESCRIPTION
### Initial Releases v1.0.0

1. Initial porting and coding to support **ESP32 (SSL and non-SSL) and ESP8266 (non-SSL)**