### PR TITLE
adding of STM32mcp4151

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -1,3 +1,4 @@
+https://github.com/gianni-carbone/STM32mcp4151
 https://github.com/wollewald/EEPROM_SPI_WE
 https://github.com/gianni-carbone/STM32ad9833
 https://github.com/kousheekc/Kinematics


### PR DESCRIPTION
Simple library for stm32 arch with small foot-print for driving mcp 4xxx series microchip digital pots.