### PR TITLE
Add MQTTPubSubClient_Generic Library

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -4765,3 +4765,4 @@ https://github.com/patricklaf/SNMP
 https://github.com/khoih-prog/AsyncDNSServer_Teensy41
 https://github.com/vurdalakov/radsensboard
 https://github.com/Kineis/KIM_Arduino_Library
+https://github.com/khoih-prog/MQTTPubSubClient_Generic


### PR DESCRIPTION
### Initial Releases v1.0.0

1. Initial porting and coding to support nRF52, SAMD21, SAMD51, STM32F/L/H/G/WB/MP1, Teensy, RP2040-based boards, besides ESP8266, ESP32 (ESP32, ESP32_S2, ESP32_S3 and ESP32_C3) and WT32_ETH01. Spporting Ethernet shields W5100, W5200, W5500, ENC28J60, Teensy 4.1 NativeEthernet/QNEthernet.