### PR TITLE
Update name and URL of "MovingAveragePlus"

### DIFF
--- a/registry.txt
+++ b/registry.txt
@@ -2952,7 +2952,7 @@ https://github.com/RobTillaart/Complex.git|Contributed|Complex
 https://github.com/RobTillaart/BoolArray.git|Contributed|BoolArray
 https://github.com/RobTillaart/BitArray.git|Contributed|BitArray
 https://github.com/NathanBak/astra_esp8266.git|Contributed|astra_esp8266
-https://github.com/AlexandreHiroyuki/MovingAverage_ArduinoLibrary.git|Contributed|Moving Average Plus
+https://github.com/AlexandreHiroyuki/MovingAveragePlus.git|Contributed|Moving Average Plus
 https://github.com/LennartHennigs/ESPBattery.git|Contributed|ESP Battery
 https://github.com/LennartHennigs/ESPTelnet.git|Contributed|ESP Telnet
 https://github.com/RobTillaart/BH1750FVI_RT.git|Contributed|BH1750FVI_RT

--- a/registry.txt
+++ b/registry.txt
@@ -2952,7 +2952,7 @@ https://github.com/RobTillaart/Complex.git|Contributed|Complex
 https://github.com/RobTillaart/BoolArray.git|Contributed|BoolArray
 https://github.com/RobTillaart/BitArray.git|Contributed|BitArray
 https://github.com/NathanBak/astra_esp8266.git|Contributed|astra_esp8266
-https://github.com/AlexandreHiroyuki/MovingAveragePlus.git|Contributed|Moving Average Plus
+https://github.com/AlexandreHiroyuki/MovingAveragePlus.git|Contributed|MovingAveragePlus
 https://github.com/LennartHennigs/ESPBattery.git|Contributed|ESP Battery
 https://github.com/LennartHennigs/ESPTelnet.git|Contributed|ESP Telnet
 https://github.com/RobTillaart/BH1750FVI_RT.git|Contributed|BH1750FVI_RT


### PR DESCRIPTION
This PR consists of two changes:

- Change URL from `https://github.com/AlexandreHiroyuki/MovingAverage_ArduinoLibrary.git` to `https://github.com/AlexandreHiroyuki/MovingAveragePlus.git` (companion to https://github.com/arduino/library-registry/pull/1247)
- Change name from `Moving Average Plus` to `MovingAveragePlus`

Since the name change operation on the database is actually a removal followed by automated reindexing on the next job run, the URL update will occur as a matter of course and so the only thing required from the backend maintainer is the name change procedure.

Resolves https://github.com/arduino/library-registry/issues/1249