### PR TITLE
Remove `notes` field from label configuration file

### DIFF
--- a/.github/label-configuration-files/labels.yml
+++ b/.github/label-configuration-files/labels.yml
@@ -25,12 +25,11 @@
 - name: "topic: rename"
   color: "00ffff"
   description: Change registered library name
+# Vulnerability disclosures are made following the procedure at:
+# https://github.com/arduino/.github/blob/master/SECURITY.md
 - name: "topic: security"
   color: "ff0000"
   description: Related to the protection of user data
-  notes: |
-    Vulnerability disclosures are made following the procedure at:
-    https://github.com/arduino/.github/blob/master/SECURITY.md
 - name: "topic: submission"
   color: "00ffff"
   description: Add library to the list


### PR DESCRIPTION
At the time the reference configuration file was developed, it was in JSON, which does not support comments. I found the need to add some internal explanatory commentary to some of the labels, so I added an arbitrary `notes` key as a container for this information, and our JSON schema was also configured to accept this field.

I later decided to convert the files to YAML, since that is the language used by the majority of the asset configuration files. At this point it became possible to use comments, but the `notes` field was already in place so it seemed pointless to change it.

Validation of the configuration file [was added](https://github.com/Financial-Times/github-label-sync/pull/158) to the "**GitHub Label Sync**" tool in [the recent 2.1.0 release](https://github.com/Financial-Times/github-label-sync/releases/tag/v2.1.0). Before 2.1.0, the tool ignored any additional properties in the label configuration objects. It now errors if there are any unexpected properties.

This `notes` field now causes the label configuration files that contain it to be considered invalid by the tool, and by our custom JSON schema:

https://github.com/arduino/library-registry/runs/5767344401?check_suite_focus=true#step:5:13

```
.github/label-configuration-files/labels.yml invalid
[
  {
    instancePath: '/8',
    schemaPath: '#/items/additionalProperties',
    keyword: 'additionalProperties',
    params: { additionalProperty: 'notes' },
    message: 'must NOT have additional properties'
  }
]
```

So the `notes` field is hereby removed, with the contents moved to comments.