### PR TITLE
Add Ethernet_Generic Library

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -4785,3 +4785,4 @@ https://github.com/climateguard/CG-Anem
 https://github.com/suratin27/ESP32_Control
 https://github.com/chcbaram/HS_JOY_ESP32
 https://github.com/ArtronShop/KidMotorV4-Arduino
+https://github.com/khoih-prog/Ethernet_Generic


### PR DESCRIPTION
### Releases v2.0.0

1. Initial porting and coding to merge, as many as possible, the features of the following libraries :
	- [**Ethernet**](https://github.com/arduino-libraries/Ethernet)
	- [**EthernetLarge**](https://github.com/OPEnSLab-OSU/EthernetLarge)
	- [**Ethernet2**](https://github.com/adafruit/Ethernet2)
	- [**Ethernet3**](https://github.com/sstaub/Ethernet3)
2. Add support to ESP32 **SPI2**
3. Convert to **h-only** library
4. Add debug feature
5. Optimize code to reduce compiled binary size
6. Add `Packages' Patches`