### PR TITLE
Add HUSB238Driver library

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -4794,3 +4794,4 @@ https://github.com/chrmlinux/ArreyExt
 https://github.com/chrmlinux/ArrayExt
 https://github.com/Pixelbo/Pelco_And_Arduino
 https://github.com/sitronlabs/SitronLabs_OPT3001_Arduino_Library
+https://github.com/luoluomeng/HUSB238Driver


### PR DESCRIPTION
HUSB238Driver is a new library that allows ESP32 users to communicate with the new power chip HUSB238 via the I2C bus.