### PR TITLE
Add NST1001 driver library

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -4795,3 +4795,4 @@ https://github.com/chrmlinux/ArrayExt
 https://github.com/Pixelbo/Pelco_And_Arduino
 https://github.com/sitronlabs/SitronLabs_OPT3001_Arduino_Library
 https://github.com/luoluomeng/HUSB238Driver
+https://github.com/luoluomeng/NST1001Driver


### PR DESCRIPTION
This is a simple driver which allows ESP32 can communicate with the NST1001 temperature sensor.