### PR TITLE
Update name and URL of "CAN_BUS_Shield"

### DIFF
--- a/registry.txt
+++ b/registry.txt
@@ -1550,7 +1550,7 @@ https://github.com/fredilarsen/ModuleInterface.git|Contributed|ModuleInterface
 https://github.com/Seeed-Studio/Grove_3_Axis_Compass_V2.0_BMM150.git|Contributed|Grove 3Axis Compass V2.0 BMM150
 https://github.com/Seeed-Studio/Gesture_PAJ7620.git|Contributed|Gesture PAJ7620
 https://github.com/Seeed-Studio/Ethernet_Shield_W5200.git|Contributed|Ethernet_Shield_W5200
-https://github.com/Seeed-Studio/CAN_BUS_Shield.git|Contributed|CAN_BUS_Shield
+https://github.com/Seeed-Studio/Seeed_Arduino_CAN.git|Contributed|CAN_BUS_Shield
 https://github.com/Seeed-Studio/Digital_Infrared_Temperature_Sensor_MLX90615.git|Contributed|Digital Infrared Temperature Sensor MLX90615
 https://github.com/Seeed-Studio/Accelerometer_MMA7660.git|Contributed|Accelerometer_MMA7660
 https://github.com/Seeed-Studio/Accelerometer_H3LIS331DL.git|Contributed|Accelerometer_H3LIS331DL

--- a/registry.txt
+++ b/registry.txt
@@ -1550,7 +1550,7 @@ https://github.com/fredilarsen/ModuleInterface.git|Contributed|ModuleInterface
 https://github.com/Seeed-Studio/Grove_3_Axis_Compass_V2.0_BMM150.git|Contributed|Grove 3Axis Compass V2.0 BMM150
 https://github.com/Seeed-Studio/Gesture_PAJ7620.git|Contributed|Gesture PAJ7620
 https://github.com/Seeed-Studio/Ethernet_Shield_W5200.git|Contributed|Ethernet_Shield_W5200
-https://github.com/Seeed-Studio/CAN_BUS_Shield.git|Contributed|CAN-BUS Shield
+https://github.com/Seeed-Studio/CAN_BUS_Shield.git|Contributed|CAN_BUS_Shield
 https://github.com/Seeed-Studio/Digital_Infrared_Temperature_Sensor_MLX90615.git|Contributed|Digital Infrared Temperature Sensor MLX90615
 https://github.com/Seeed-Studio/Accelerometer_MMA7660.git|Contributed|Accelerometer_MMA7660
 https://github.com/Seeed-Studio/Accelerometer_H3LIS331DL.git|Contributed|Accelerometer_H3LIS331DL


### PR DESCRIPTION
This PR consists of two changes:

- Change URL from `https://github.com/Seeed-Studio/CAN_BUS_Shield.git` to `https://github.com/Seeed-Studio/Seeed_Arduino_CAN.git` (companion to https://github.com/arduino/library-registry/pull/1297)
- Change name from `CAN-BUS Shield` to `CAN_BUS_Shield`

Since the name change operation on the database is actually a removal followed by automated re-indexing on the next job run, the URL update will occur as a matter of course and so the only thing required from the backend maintainer is the name change procedure.

Resolves https://github.com/arduino/library-registry/issues/1295