### PR TITLE
Remove https://github.com/DFRobot/DFRobot_A111

### DIFF
--- a/registry.txt
+++ b/registry.txt
@@ -4535,7 +4535,6 @@ https://github.com/bolderflight/filter.git|Contributed|Bolder Flight Systems Fil
 https://github.com/0015/ESP32-OV5640-AF.git|Contributed|OV5640 Auto Focus for ESP32 Camera
 https://github.com/bolderflight/excitation.git|Contributed|Bolder Flight Systems Excitation
 https://github.com/DFRobot/DFRobot_VEML7700.git|Contributed|DFRobot_VEML7700
-https://github.com/DFRobot/DFRobot_A111.git|Contributed|DFRobot_A111
 https://github.com/DFRobot/DFRobot_VisualRotaryEncoder.git|Contributed|DFRobot_VisualRotaryEncoder
 https://github.com/GyverLibs/GyverHTU21D.git|Contributed|GyverHTU21D
 https://github.com/kolabse/KolabseCarsCan.git|Contributed|KolabseCarsCan


### PR DESCRIPTION
This library has been renamed as "DFRobot_RS01" and moved to https://github.com/DFRobot/DFRobot_RS01.

There is an existing registration for "DFRobot_RS01" so the library will now be available for installation from Library Manager via that name.

Companion to https://github.com/arduino/library-registry/pull/1299