### PR TITLE
Add AsyncWebServer_Ethernet Library

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -4812,3 +4812,4 @@ https://github.com/osteele/Arduino_SerialRecord
 https://github.com/arduino-libraries/Arduino_MultiWiFi
 https://github.com/GLEE2023/Beelan-LoRaWAN
 https://github.com/Invisibleman1002/dynaHTML
+https://github.com/khoih-prog/AsyncWebServer_Ethernet


### PR DESCRIPTION
#### Releases v1.4.1

1. Initial coding to port [**ESPAsyncWebServer**](https://github.com/me-no-dev/ESPAsyncWebServer) to **ESP8266** boards using **W5x00 / ENC28J60 Ethernet.**
2. Add more examples.
3. Add debugging features.
4. Bump up to v1.4.1 to sync with [**AsyncWebServer_WT32_ETH01** v1.4.1](https://github.com/khoih-prog/AsyncWebServer_WT32_ETH01).