### PR TITLE
Add AsyncUDP_Ethernet Library

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -4813,3 +4813,4 @@ https://github.com/arduino-libraries/Arduino_MultiWiFi
 https://github.com/GLEE2023/Beelan-LoRaWAN
 https://github.com/Invisibleman1002/dynaHTML
 https://github.com/khoih-prog/AsyncWebServer_Ethernet
+https://github.com/khoih-prog/AsyncUDP_Ethernet


### PR DESCRIPTION
### Releases v1.2.1

1. Initial porting and coding for **ESP8266 using W5x00 or ENC28J60 Ethernet**
2. Bump up version to v1.2.1 to sync with [AsyncUDP_STM32](https://github.com/khoih-prog/AsyncUDP_STM32) v1.2.1