### PR TITLE
Event driven Ethernet lib for Wiznet Pi Pico

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -4822,3 +4822,4 @@ https://github.com/khoih-prog/AsyncUDP_Ethernet
 https://github.com/Tost69/ConfigStorage
 https://github.com/edge-ml/edge-fel-lib
 https://github.com/chrmlinux/ThreeD
+https://github.com/teamprof/arduino-eventethernet


### PR DESCRIPTION
Add event driven Ethernet lib for Wiznet Pi Pico (W5100S)