### PR TITLE
Add the ContinuousStepper library

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -943,6 +943,7 @@ https://github.com/barisdinc/LibAPRS_Tracker
 https://github.com/bartoszbielawski/AJSP
 https://github.com/bartoszbielawski/C-Tasks
 https://github.com/bartoszbielawski/LEDMatrixDriver
+https://github.com/bblanchon/ArduinoContinuousStepper
 https://github.com/bblanchon/ArduinoJson
 https://github.com/bblanchon/ArduinoStreamUtils
 https://github.com/bblanchon/ArduinoTrace


### PR DESCRIPTION
An Arduino library to spin stepper motors in continuous motions.

Contrary to other stepper libraries, this one doesn't provide any function to move the shaft at a specific angle. Instead, it provides one function to spin the shaft at a specific speed. It smoothly accelerates and decelerates when the speed changes.