### PR TITLE
Add DHTINT

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -3342,6 +3342,7 @@ https://github.com/RobTillaart/timing
 https://github.com/RobTillaart/tinySHT2x
 https://github.com/RobTillaart/TM1637_RT
 https://github.com/RobTillaart/Troolean
+https://github.com/RobTillaart/WaveMix
 https://github.com/RobTillaart/weight
 https://github.com/RobTillaart/X9C10X
 https://github.com/RobTillaart/XMLWriter

--- a/repositories.txt
+++ b/repositories.txt
@@ -3284,6 +3284,7 @@ https://github.com/RobTillaart/DHT12
 https://github.com/RobTillaart/DHT20
 https://github.com/RobTillaart/DHT2pin
 https://github.com/RobTillaart/DHTlib
+https://github.com/RobTillaart/DHTINT
 https://github.com/RobTillaart/DHTNew
 https://github.com/RobTillaart/DHTstable
 https://github.com/RobTillaart/DistanceTable

--- a/repositories.txt
+++ b/repositories.txt
@@ -3208,6 +3208,7 @@ https://github.com/RobTillaart/DAC8550
 https://github.com/RobTillaart/DAC8551
 https://github.com/RobTillaart/DAC8552
 https://github.com/RobTillaart/DAC8554
+https://github.com/RobTillaart/DEVFULL
 https://github.com/RobTillaart/DEVNULL
 https://github.com/RobTillaart/DEVRANDOM
 https://github.com/RobTillaart/DHT12


### PR DESCRIPTION
integer only version of the DHTNew library to save footprint on processors with less memory.