### PR TITLE
Use form-based issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -1,0 +1,47 @@
+# Source:
+# https://github.com/arduino/tooling-project-assets/blob/main/issue-templates/forms/platform-dependent/bug-report.md
+# See:
+# https://docs.github.com/communities/using-templates-to-encourage-useful-issues-and-pull-requests/syntax-for-issue-forms
+
+name: Bug report
+description: Report a problem with the code or documentation in this repository.
+labels:
+  - "type: imperfection"
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: Describe the problem
+    validations:
+      required: true
+  - type: textarea
+    id: reproduce
+    attributes:
+      label: To reproduce
+      description: Provide the specific set of steps we can follow to reproduce the problem.
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+      description: What would you expect to happen after following those instructions?
+    validations:
+      required: true
+  - type: textarea
+    id: additional
+    attributes:
+      label: Additional context
+      description: Add any additional information here.
+    validations:
+      required: false
+  - type: checkboxes
+    id: checklist
+    attributes:
+      label: Issue checklist
+      description: Please double-check that you have done each of the following things before submitting the issue.
+      options:
+        - label: I searched for previous reports in [the issue tracker](https://github.com/arduino/library-registry/issues?q=)
+          required: true
+        - label: My report contains all necessary details
+          required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,33 @@
+# Source:
+# https://github.com/arduino/tooling-project-assets/blob/main/issue-templates/template-choosers/general/config.yml
+# See:
+# https://docs.github.com/communities/using-templates-to-encourage-useful-issues-and-pull-requests/configuring-issue-templates-for-your-repository#configuring-the-template-chooser
+
+contact_links:
+  - name: Submit a library
+    url: https://github.com/arduino/library-registry#adding-a-library-to-library-manager
+    about: Instructions for submitting a library for inclusion in the Arduino Library Manager.
+  - name: Change the library URL
+    url: https://github.com/arduino/library-registry#changing-the-url-of-a-library-already-in-library-manager
+    about: Instructions for updating a library's registered URL.
+  - name: Library removal
+    url: https://github.com/arduino/library-registry#removing-a-library-from-library-manager
+    about: Instructions for requesting removal of your library from the Arduino Library Manager index.
+  - name: Submissions of new library releases
+    url: https://github.com/arduino/library-registry/blob/main/FAQ.md#how-can-i-publish-a-new-release-once-my-library-is-in-the-list
+    about: Instructions for publishing a new release of your library.
+  - name: Library not updated after release
+    url: https://github.com/arduino/library-registry/blob/main/FAQ.md#why-arent-releases-of-my-library-being-picked-up-by-library-manager
+    about: Information on why library releases are not picked up.
+  - name: Learn about using the Arduino Library Manager
+    url: https://docs.arduino.cc/software/ide-v1/tutorials/installing-libraries/#using-the-library-manager
+    about: Documentation is available here.
+  - name: Learn about using this project
+    url: https://github.com/arduino/library-registry#readme
+    about: Detailed usage documentation is available here.
+  - name: Support request
+    url: https://forum.arduino.cc/
+    about: We can help you out on the Arduino Forum!
+  - name: Discuss development work on the project
+    url: https://groups.google.com/a/arduino.cc/g/developers
+    about: Arduino Developers Mailing List

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -1,0 +1,42 @@
+# Source:
+# https://github.com/arduino/tooling-project-assets/blob/main/issue-templates/forms/platform-dependent/bug-report.md
+# See:
+# https://docs.github.com/communities/using-templates-to-encourage-useful-issues-and-pull-requests/syntax-for-issue-forms
+
+name: Feature request
+description: Suggest an enhancement to this project.
+labels:
+  - "type: enhancement"
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: Describe the request
+    validations:
+      required: true
+  - type: textarea
+    id: current
+    attributes:
+      label: Describe the current behavior
+      description: |
+        What is the current behavior of the Arduino Library Manager registry in relation to your request?
+        How can we reproduce that behavior?
+    validations:
+      required: true
+  - type: textarea
+    id: additional
+    attributes:
+      label: Additional context
+      description: Add any additional information here.
+    validations:
+      required: false
+  - type: checkboxes
+    id: checklist
+    attributes:
+      label: Issue checklist
+      description: Please double-check that you have done each of the following things before submitting the issue.
+      options:
+        - label: I searched for previous requests in [the issue tracker](https://github.com/arduino/library-registry/issues?q=)
+          required: true
+        - label: My request contains all necessary details
+          required: true

--- a/.github/ISSUE_TEMPLATE/release-removal.yml
+++ b/.github/ISSUE_TEMPLATE/release-removal.yml
@@ -1,0 +1,25 @@
+# See:
+# https://docs.github.com/communities/using-templates-to-encourage-useful-issues-and-pull-requests/syntax-for-issue-forms
+
+name: Library release removal
+description: Request the removal of a library release.
+title: Library release removal request
+labels:
+  - "topic: release removal"
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Please read the instructions for removing a library release: [here](https://github.com/arduino/library-registry/blob/main/FAQ.md#how-can-i-remove-a-release-of-my-library-from-library-manager).
+  - type: input
+    id: name
+    attributes:
+      label: Library name
+    validations:
+      required: true
+  - type: input
+    id: version
+    attributes:
+      label: Version to remove
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/rename.yml
+++ b/.github/ISSUE_TEMPLATE/rename.yml
@@ -1,0 +1,19 @@
+# See:
+# https://docs.github.com/communities/using-templates-to-encourage-useful-issues-and-pull-requests/syntax-for-issue-forms
+
+name: Library name change
+description: Request an update of the registered library name.
+title: Library name change request
+labels:
+  - "topic: rename"
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Please read the instructions for renaming your library: [here](https://github.com/arduino/library-registry/blob/main/FAQ.md#how-can-i-change-a-librarys-name).
+  - type: input
+    id: url
+    attributes:
+      label: Library repository URL
+    validations:
+      required: true

--- a/FAQ.md
+++ b/FAQ.md
@@ -141,7 +141,7 @@ If you discover a problem with the library release, simply fix the problem and m
 In the event a library release is later discovered to contain something that absolutely can not be published, we do allow removing releases from Library Manager on request by the following procedure:
 
 1. Delete the [tag](https://git-scm.com/book/en/v2/Git-Basics-Tagging) of the problematic release from the library's repository.
-1. Open an issue in [the issue tracker of this repository](https://github.com/arduino/library-registry/issues), specifying the URL of the library repository and requesting that the library be updated.
+1. Open an issue [here](https://github.com/arduino/library-registry/issues/new?labels=topic%3A+release+removal&template=release-removal.yml&title=Library+release+removal+request), specifying the name of the library and the version number of the release that should be removed.
 
 <a id="how-can-i-change-my-librarys-name"></a>
 
@@ -153,7 +153,7 @@ If you wish to change the name it will need to be done manually by request:
 
 1. Change the `name` value in the [library.properties file](https://arduino.github.io/arduino-cli/latest/library-specification/#libraryproperties-file-format) and update the `version`.
 1. Create a release or tag.
-1. Submit an [issue report](https://github.com/arduino/library-registry/issues) requesting the name be changed and stating the URL of the library's repository.
+1. Open an issue [here](https://github.com/arduino/library-registry/issues/new?labels=topic%3A+rename&template=rename.yml&title=Library+name+change+request) specifying the URL of the library's repository.
 
 ## Limitations
 

--- a/README.md
+++ b/README.md
@@ -96,5 +96,4 @@ because it was not compliant with all [the requirements](FAQ.md#update-requireme
 This repository is not an appropriate place to request support or report problems with a library. Check the library's
 own documentation for instructions or ask on the [Arduino Forum](https://forum.arduino.cc/).
 
-If the problem is about something else, please make an issue report here:
-https://github.com/arduino/library-registry/issues?q=is%3Aissue
+If the problem is about something else, please submit an issue report [here](https://github.com/arduino/library-registry/issues/new/choose).


### PR DESCRIPTION
High quality feedback via GitHub issues is a very valuable contribution to the project. It is important to make the issue creation and management process as efficient as possible for the contributors, maintainers, and developers.

Issue templates are helpful to the maintainers and developers because it establishes a standardized framework for the issues and encourages the library maintainers and contributors to provide the essential information.

The contributor is now presented with [a web form](https://docs.github.com/communities/using-templates-to-encourage-useful-issues-and-pull-requests/configuring-issue-templates-for-your-repository#creating-issue-forms) when creating an issue. In the case of the library registration maintenance requests, these are for the specific information the registry maintainers require. For more general bug reports or feature requests, they use multi-line input fields that have the same formatting, preview, and attachment capabilities as the standard GitHub Issue composer, in addition to other form components such as menus and checkboxes where appropriate.

The use of this form-based system should provide a better issue creation experience and result in higher quality issues by establishing a standardized framework for the issues and encouraging contributors to provide the essential information.

A [template chooser](https://docs.github.com/communities/using-templates-to-encourage-useful-issues-and-pull-requests/configuring-issue-templates-for-your-repository#configuring-the-template-chooser) allows the contributor to select the appropriate template type, redirects support requests to the appropriate communication channels via "Contact Links", and provides a prominent link to the security policy in order to guide any vulnerability disclosures.

The clear separation of the types of issues encourages the reporter to fit their report into a specific issue category, resulting in more clarity. Automatic labeling according to template choice allows the reporter to do the initial classification.

---

A preview of how the system will work can be seen in my fork here:

https://github.com/per1234/library-registry/issues/new/choose

The security policy link is absent from the chooser at the link above due to it being staged in my fork instead of the final location under the `arduino` organization.
