### PR TITLE
Add WiFiManager_RTL8720 Library

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -4892,3 +4892,4 @@ https://github.com/ripred/CPUVolt
 https://github.com/Phambili-Tech/Newt_Display
 https://github.com/lewisxhe/AXP202X_Library
 https://github.com/levkovigor/ADF7023
+https://github.com/khoih-prog/WiFiManager_RTL8720


### PR DESCRIPTION
### Release v1.0.0

1. Initial coding for RTL8720DN, RTL8722DM, RTL8722CSM, etc.