### PR TITLE
Remove aviancompany/LCD_I2C

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -4902,7 +4902,6 @@ https://github.com/Wolodia-M/flagsapi-library
 https://github.com/Wolodia-M/timersapi-library
 https://github.com/chrmlinux/extendFor
 https://github.com/Goji2100/ESP32softPWM
-https://github.com/aviancompany/LCD_I2C
 https://github.com/ripred/TomServo
 https://github.com/ripred/ButtonGestures
 https://github.com/khoih-prog/FTPClient_Generic


### PR DESCRIPTION
We have received a trademark infringement report by the copyright holder of this library:
https://github.com/adafruit/Adafruit_LiquidCrystal

The code is the same but copyright notices were removed, thus the LCD_I2C violates the terms of the original license. 