### PR TITLE
Configure link check to use `Accept-Encoding` header for docs.github.com links

### DIFF
--- a/.github/.markdown-link-check.json
+++ b/.github/.markdown-link-check.json
@@ -1,4 +1,12 @@
 {
+  "httpHeaders": [
+    {
+      "urls": ["https://docs.github.com/"],
+      "headers": {
+        "Accept-Encoding": "gzip, deflate, br"
+      }
+    }
+  ],
   "retryOn429": true,
   "retryCount": 3,
   "aliveStatusCodes": [200, 206]


### PR DESCRIPTION
The link check job of the "Check Markdown" workflow has had frequent intermittent spurious failures recently, caused by links under the `docs.github.com` domain returning [403 HTTP status](https://en.wikipedia.org/wiki/HTTP_403).

Others experiencing the same problem reported that they were able to work around the problem by providing a custom [`Accept-Encoding` HTTP request header](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Accept-Encoding). Although I was not able to find any explanation of why, it does appear to resolve the problem.

Since the problem seems to be permanent and the only other workarounds I have identified are unappealing (considering links returning 403 statuses alive, or ignoring all `docs.github.com` links), I think it is worth a try.