### PR TITLE
Update repositories.txt

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -1,4 +1,3 @@
-https://github.com/arbotics-llc/databot_ESP32
 https://github.com/HakkanR/DMD2TUR
 https://github.com/bolderflight/ms4525do
 https://github.com/MSZ98/pcf8574


### PR DESCRIPTION
https://github.com/arbotics-llc/databot_ESP32

We want to remove the above library as we messed up a little in version numbering actually we forgot to add the examples in V2.8 and now we do not want to add examples and increment the version number as we need to match it with our web flashing tool also. 

So the simplest way we come around is to remove the library now and then add all examples needed and then add it again with same V2.8

Thank You,
Dharmik