### PR TITLE
Add PneumaticStepper library

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -4933,3 +4933,4 @@ https://github.com/levkovigor/FastInterruptEncoder
 https://github.com/nfhktwrbq/LedMatrix8x8.git
 https://github.com/Energesis-Ingenieria/Energesis_Sensor
 https://github.com/Energesis-Ingenieria/Energesis_LM35
+https://github.com/vgroenhuis/PneumaticStepper


### PR DESCRIPTION
PneumaticStepper library is useful for controlling 3D printed or commercial 2-cylinder and 3-cylinder pneumatic stepper motors, using 3D printed or commercial pneumatic valves. Video https://www.youtube.com/watch?v=523QuGY_VwU