### PR TITLE
Update repositories.txt

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -1,5 +1,4 @@
 https://github.com/DuinoDNS/ddns-arduino-nightly-releases
-https://github.com/arbotics-llc/databot_ESP32
 https://github.com/HakkanR/DMD2TUR
 https://github.com/bolderflight/ms4525do
 https://github.com/MSZ98/pcf8574


### PR DESCRIPTION
https://github.com/arbotics-llc/databot_ESP32

We want to remove the above library as we messed up a little in version numbering actually we forgot to add the examples in V2.8 and now we do not want to add examples and increment the version number as we need to match it with our web flashing tool also.

So the most straightforward way we come around is to remove the library now and then add all examples needed and then add it again with the same V2.8

We are aware of the versioning system on git that is why we want the library to start from V2.8 we have this particular reason as we want to match the firmware release version with our web flashing tool here check here.
https://databot.us.com/firmware/
So that our users won't confuse. As the current situation is like this: the latest firmware on the web flashing is V2.8, So now if the library version is not the same, the user will confuse that it has some changes.
That's the only reason we want to remove the library from the Arduino library manager and start it fresh from V2.8.

So kindly understand the situation and remove the databot2 library from the manager so that we can correct our error.

Thank you.