### PR TITLE
Add MicroQt

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -4944,3 +4944,4 @@ https://github.com/vgroenhuis/PneumaticStepper
 https://github.com/vshymanskyy/Preferences
 https://github.com/alexbertis/Text2Matrix
 https://github.com/dong-higenis/HS_CAN_485_ESP32
+https://github.com/juliusbaechle/MicroQt


### PR DESCRIPTION
MicroQt is a library that enables event driven applications on the Arduino platform. 
This is realized by load monitoring event loops, timers and signals similar to those in the Qt framework.