### PR TITLE
Replace 107-Arduino-UAVCAN with 107-Arduino-Cyphal.

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -344,7 +344,7 @@ https://github.com/107-systems/107-Arduino-NMEA-Parser
 https://github.com/107-systems/107-Arduino-TCS3472
 https://github.com/107-systems/107-Arduino-TMF8801
 https://github.com/107-systems/107-Arduino-TSL2550
-https://github.com/107-systems/107-Arduino-UAVCAN
+https://github.com/107-systems/107-Arduino-Cyphal
 https://github.com/1IoT/cloud-connectivity-lib
 https://github.com/loginov-rocks/UbxGps
 https://github.com/256dpi/arduino-mqtt


### PR DESCRIPTION
Since the original project underwent a name change (see [here](https://github.com/107-systems/107-Arduino-Cyphal/issues/144)) the library was also renamed. Consequently 107-Arduino-UAVCAN shall only be distributed via the library manager up until v1.4.0. First version of 107-Arduino-Cyphal is v2.0.0.