### PR TITLE
Update name and URL of "107-Arduino-Cyphal"

### DIFF
--- a/registry.txt
+++ b/registry.txt
@@ -3323,7 +3323,7 @@ https://github.com/khoih-prog/MDNS_Generic.git|Contributed|MDNS_Generic
 https://github.com/Freenove/Freenove_WS2812_Lib_for_ESP32.git|Contributed|Freenove WS2812 Lib for ESP32
 https://github.com/jasonacox/TinyStepper.git|Contributed|TinyStepper
 https://github.com/RobTillaart/Kelvin2RGB.git|Contributed|Kelvin2RGB
-https://github.com/107-systems/107-Arduino-Cyphal.git|Contributed|107-Arduino-UAVCAN
+https://github.com/107-systems/107-Arduino-Cyphal.git|Contributed|107-Arduino-Cyphal
 https://github.com/TilenS6/SerialDraw-Library.git|Contributed|SerialDraw
 https://github.com/RobTillaart/bitHelpers.git|Contributed|bitHelpers
 https://github.com/tanakamasayuki/I2C_BM8563.git|Contributed|I2C BM8563 RTC

--- a/registry.txt
+++ b/registry.txt
@@ -3323,7 +3323,7 @@ https://github.com/khoih-prog/MDNS_Generic.git|Contributed|MDNS_Generic
 https://github.com/Freenove/Freenove_WS2812_Lib_for_ESP32.git|Contributed|Freenove WS2812 Lib for ESP32
 https://github.com/jasonacox/TinyStepper.git|Contributed|TinyStepper
 https://github.com/RobTillaart/Kelvin2RGB.git|Contributed|Kelvin2RGB
-https://github.com/107-systems/107-Arduino-UAVCAN.git|Contributed|107-Arduino-UAVCAN
+https://github.com/107-systems/107-Arduino-Cyphal.git|Contributed|107-Arduino-UAVCAN
 https://github.com/TilenS6/SerialDraw-Library.git|Contributed|SerialDraw
 https://github.com/RobTillaart/bitHelpers.git|Contributed|bitHelpers
 https://github.com/tanakamasayuki/I2C_BM8563.git|Contributed|I2C BM8563 RTC


### PR DESCRIPTION
This PR consists of two changes:

- Change URL from `https://github.com/107-systems/107-Arduino-UAVCAN.git` to `https://github.com/107-systems/107-Arduino-Cyphal` (companion to https://github.com/arduino/library-registry/pull/1489)
- Change name from `107-Arduino-UAVCAN` to `107-Arduino-Cyphal`

Since the name change operation on the database is actually a removal followed by automated re-indexing on the next job run, the URL update will occur as a matter of course and so the only thing required from the backend maintainer is the name change procedure.