### PR TITLE
Remove "Simple_Robot_Motor_Control"

### DIFF
--- a/registry.txt
+++ b/registry.txt
@@ -5074,7 +5074,6 @@ https://github.com/ConnorKirkpatrick/E220Lib.git|Contributed|E220Lib
 https://github.com/ElectroMagus/ESP32MX1508.git|Contributed|ESP32MX1508
 https://github.com/chrmlinux/tinyCore.git|Contributed|tinyCore
 https://github.com/goldfish4tech/Goldfish4Tech.git|Contributed|Goldfish4Tech
-https://github.com/Mirco04/Simple_Robot_Motor_Control.git|Contributed|Simple_Robot_Motor_Control
 https://github.com/dai-eoh/ledrgb565.git|Contributed|LedRGB565
 https://github.com/deneyapkart/deneyap-5x7-led-matris-arduino-library.git|Contributed|Deneyap 5x7 LED Matris
 https://github.com/deneyapkart/deneyap-oled-ekran-arduino-library.git|Contributed|Deneyap OLED Ekran


### PR DESCRIPTION
Companion to https://github.com/arduino/library-registry/pull/1525