### PR TITLE
Add pax-graphics to respositories.txt

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -35,6 +35,7 @@ https://bitbucket.org/David_Such/nexgen_MSP
 https://github.com/South-River/BMI085-arduino
 https://github.com/PowerBroker2/MultivariateNormal
 https://github.com/dani007200964/Commander-API
+https://github.com/robotman2412/pax-graphics
 https://github.com/ronbentley1/eazy-Shift-Registers
 https://github.com/ronbentley1/eazy-switch-library
 https://github.com/sleepnow2/ArdRTOS/


### PR DESCRIPTION
PAX-graphics is an ESP32 computer graphics library made for MCH2022's Badge Team.