### PR TITLE
Update name and URL of "ESPLogger"

### DIFF
--- a/registry.txt
+++ b/registry.txt
@@ -1961,7 +1961,7 @@ https://github.com/witnessmenow/arduino_twitch_api.git|Contributed|TwitchApi
 https://github.com/adafruit/TinyLoRa.git|Contributed|TinyLoRa
 https://github.com/FaBoPlatform/FaBoUV-Si1132-Library.git|Contributed|FaBo 206 UV Si1132
 https://github.com/FaBoPlatform/FaBoEnvironment-BME680-Library.git|Contributed|FaBo 222 Environment BME680
-https://github.com/fabianoriccardi/esp-logger.git|Contributed|ESP Logger
+https://github.com/fabianoriccardi/esp-logger.git|Contributed|ESPLogger
 https://github.com/madhephaestus/PVision.git|Contributed|PVision
 https://github.com/FaBoPlatform/FaBoGas-CCS811-Library.git|Contributed|FaBo 223 Gas CCS811
 https://github.com/LUXROBO/MODI-Arduino.git|Contributed|MODI

--- a/registry.txt
+++ b/registry.txt
@@ -1961,7 +1961,7 @@ https://github.com/witnessmenow/arduino_twitch_api.git|Contributed|TwitchApi
 https://github.com/adafruit/TinyLoRa.git|Contributed|TinyLoRa
 https://github.com/FaBoPlatform/FaBoUV-Si1132-Library.git|Contributed|FaBo 206 UV Si1132
 https://github.com/FaBoPlatform/FaBoEnvironment-BME680-Library.git|Contributed|FaBo 222 Environment BME680
-https://github.com/fabianoriccardi/esp-logger.git|Contributed|ESPLogger
+https://github.com/fabianoriccardi/ESPLogger.git|Contributed|ESPLogger
 https://github.com/madhephaestus/PVision.git|Contributed|PVision
 https://github.com/FaBoPlatform/FaBoGas-CCS811-Library.git|Contributed|FaBo 223 Gas CCS811
 https://github.com/LUXROBO/MODI-Arduino.git|Contributed|MODI


### PR DESCRIPTION
This PR consists of two changes:

- Change URL from `https://github.com/fabianoriccardi/esp-logger.git` to `https://github.com/fabianoriccardi/ESPLogger.git` (companion to https://github.com/arduino/library-registry/pull/1559)
- Change name from `ESP Logger` to `ESPLogger` (resolves https://github.com/arduino/library-registry/issues/1557)

Since the name change operation on the database is actually a removal followed by automated re-indexing on the next job run, the URL update will occur as a matter of course. For this reason, the only operation required from the backend maintainer is a standard name change procedure.

---

Companion to https://github.com/arduino/library-registry/pull/1559
Resolves https://github.com/arduino/library-registry/issues/1557