### PR TITLE
Add https://github.com/stm32duino/LPS22DF

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -5018,3 +5018,4 @@ https://github.com/lpaseen/ht16k33
 https://github.com/TheNitek/CatGFX
 https://github.com/sbouhoun/smoother/
 https://github.com/electricui/electricui-embedded
+https://github.com/stm32duino/LPS22DF


### PR DESCRIPTION
Please, add STM32duino LPS22DF library to the library manager.
Thanks in advance.
Best regards.