### PR TITLE
Update repositories.txt

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -4901,7 +4901,6 @@ https://github.com/stm32duino/X-NUCLEO-53L4A2.git
 https://github.com/khoih-prog/AsyncWebServer_Teensy41
 https://github.com/khoih-prog/AsyncHTTPRequest_Teensy41
 https://github.com/khoih-prog/AsyncUDP_Teensy41
-https://github.com/ftjuh/AccelStepperI2C
 https://github.com/italia/cie-PN532
 https://github.com/patricklaf/SNMP
 https://github.com/khoih-prog/AsyncDNSServer_Teensy41


### PR DESCRIPTION
I replaced the https://github.com/ftjuh/AccelStepperI2C project with its successor, the much more powerful and flexible 
https://github.com/ftjuh/I2Cwrapper project. The latter can replace the former seamlessly. Both should not be installed concurrently to avoid inclusion conflicts. So It think it's best to pull it from the library manager.