### PR TITLE
Rename "AVR-IoT MCP9808"

### DIFF
--- a/registry.txt
+++ b/registry.txt
@@ -5135,4 +5135,4 @@ https://github.com/WinsonAPP/WinsonLibrary.git|Contributed|WinsonLib
 https://github.com/m5stack/M5Unit-Encoder.git|Contributed|M5Unit-Encoder
 https://github.com/m5stack/M5-ADS1100.git|Contributed|M5-ADS1100
 https://github.com/microchip-pic-avr-solutions/veml3328_arduino_driver.git|Contributed|veml3328
-https://github.com/microchip-pic-avr-solutions/mcp9808_arduino_driver.git|Contributed|mcp9808
+https://github.com/microchip-pic-avr-solutions/mcp9808_arduino_driver.git|Contributed|AVR-IoT MCP9808


### PR DESCRIPTION
Resolves https://github.com/arduino/library-registry/issues/1605