### PR TITLE
Rename "AVR-IoT VEML3328"

### DIFF
--- a/registry.txt
+++ b/registry.txt
@@ -5132,7 +5132,7 @@ https://github.com/m5stack/M5-ADS1115.git|Contributed|M5-ADS1115
 https://github.com/WinsonAPP/WinsonLibrary.git|Contributed|WinsonLib
 https://github.com/m5stack/M5Unit-Encoder.git|Contributed|M5Unit-Encoder
 https://github.com/m5stack/M5-ADS1100.git|Contributed|M5-ADS1100
-https://github.com/microchip-pic-avr-solutions/veml3328_arduino_driver.git|Contributed|veml3328
+https://github.com/microchip-pic-avr-solutions/veml3328_arduino_driver.git|Contributed|AVR-IoT VEML3328
 https://github.com/microchip-pic-avr-solutions/mcp9808_arduino_driver.git|Contributed|AVR-IoT MCP9808
 https://github.com/AI5GW/CCIR476.git|Contributed|CCIR476
 https://github.com/microchip-pic-avr-solutions/avr-iot-cellular-arduino-library.git|Contributed|avr-iot-cellular


### PR DESCRIPTION
Resolves https://github.com/arduino/library-registry/issues/1618