### PR TITLE
Change repo for Beelan Library

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -1060,7 +1060,7 @@ https://github.com/beegee-tokyo/SHT1x-ESP
 https://github.com/beegee-tokyo/SX126x-Arduino
 https://github.com/beegee-tokyo/VNCL4020C-Arduino
 https://github.com/beegee-tokyo/WisBlock-API
-https://github.com/BeelanMX/arduino-LoRaWAN
+https://github.com/ElectronicCats/Beelan-LoRaWAN
 https://github.com/beetlikeyg087/MFUthings
 https://github.com/belidzs/PreciseLM35
 https://github.com/bengtmartensson/ABeacon


### PR DESCRIPTION
ElectronicCat now supports the Beelan library

the link has changed

Thnaks