### PR TITLE
Change url for SuplaDevice library

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -4095,7 +4095,7 @@ https://github.com/SunitRaut/Lightweight-CD74HC4067-Arduino
 https://github.com/SunitRaut/Smart-Duty-Cycling-Arduino
 https://github.com/SunitRaut/WSN-for-RFM69-LowPowerLab
 https://github.com/SunjunKim/PMW3360
-https://github.com/SUPLA/supla-arduino
+https://github.com/SUPLA/supla-device
 https://github.com/Suraj151/esp8266-framework
 https://github.com/SV-Zanshin/INA
 https://github.com/SvenRosvall/SignalControl


### PR DESCRIPTION
We decided to move SuplaDevice library to another repository with different url. Old one will not be maintained anymore.