### PR TITLE
Replace unsupported DS1624 library URL

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -1120,7 +1120,7 @@ https://github.com/BlueAndi/vscp-arduino
 https://github.com/BlueDot-Arduino/BlueDot_BMA400
 https://github.com/BlueDot-Arduino/BlueDot_BME280_TSL2591
 https://github.com/BlueDot-Arduino/BlueDot_BME280
-https://github.com/bluemurder/DS1624
+https://github.com/lucas-inacio/DS1624
 https://github.com/bluemurder/esp8266-ping
 https://github.com/bluemurder/EveryTimer
 https://github.com/bluerobotics/Arduino_I2C_ESC


### PR DESCRIPTION
Hello, eveyone!

Recently a tried to use the DS1624 library. Sadly it did not work and was lacking some features (like EEPROM read/write). I forked the original repo since it does not appear to be supported anymore. I made some changes to the library to put it in an working state.
I'm proposing a change in the library URL to my fork which was tested recently with real hardware. I'm not the original author so not sure how to proceed.

Thanks!