### PR TITLE
Add AsyncDNSServer_RP2040W Library

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -5106,3 +5106,4 @@ https://github.com/khoih-prog/AsyncHTTPRequest_RP2040W
 https://github.com/fatlab101/FixedString
 https://github.com/yuki-miyakoshi/youkey_stepper
 https://github.com/khoih-prog/AsyncUDP_RP2040W
+https://github.com/khoih-prog/AsyncDNSServer_RP2040W


### PR DESCRIPTION
### Initial Releases v1.0.0

1. Initial coding to support **RASPBERRY_PI_PICO_W with CYW43439 WiFi**, using [**arduino-pico core v2.4.0+**](https://github.com/earlephilhower/arduino-pico)