### PR TITLE
Add JTAG Interface library

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -5107,3 +5107,4 @@ https://github.com/fatlab101/FixedString
 https://github.com/yuki-miyakoshi/youkey_stepper
 https://github.com/khoih-prog/AsyncUDP_RP2040W
 https://github.com/khoih-prog/AsyncDNSServer_RP2040W
+https://github.com/HerrNamenlos123/JTAG_Interface


### PR DESCRIPTION
Adding the JTAG_Interface library by me, HerrNamenlos123.
Exclusively for Arduino MKR Vidor 4000.