### PR TITLE
Remove VT1100 and VT1300 Libraries

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -4336,8 +4336,6 @@ https://github.com/Velleman/K1200
 https://github.com/Velleman/Tuyav
 https://github.com/Velleman/VMA11
 https://github.com/Velleman/VMA430_GPS_Module
-https://github.com/VertorixAU/Vertorix_VT1100_Mini
-https://github.com/VertorixAU/Vertorix_VT1300_Shield
 https://github.com/viamgr/Arduino-Awesome-Click-Button
 https://github.com/victorsvi/MatrixKeypad
 https://github.com/vidor-libraries/USBBlaster


### PR DESCRIPTION
I am the creator of the libraries and wish for them to be removed.
Thank you