### PR TITLE
Remove "Vertorix_VT1100_Mini" and "VT1300_Shield"

### DIFF
--- a/registry.txt
+++ b/registry.txt
@@ -3856,7 +3856,6 @@ https://github.com/PlayingWithFusion/PWFusion_MAX31865.git|Contributed|PWFusion_
 https://github.com/PlayingWithFusion/PWFusion_VL53L3C.git|Contributed|PWFusion_VL53L3C
 https://github.com/PlayingWithFusion/PWFusion_TCA9548A.git|Contributed|PWFusion_TCA9548A
 https://github.com/PlayingWithFusion/PWFusion_Mcp960x.git|Contributed|PWFusion_Mcp960x
-https://github.com/VertorixAU/Vertorix_VT1100_Mini.git|Contributed|VT1100_Mini
 https://github.com/VertorixAU/Vertorix_VT1300_Shield.git|Contributed|VT1300_Shield
 https://github.com/wollewald/MPU9250_WE.git|Contributed|MPU9250_WE
 https://github.com/edumardo/DifferentialSteering.git|Contributed|Differential Steering

--- a/registry.txt
+++ b/registry.txt
@@ -3856,7 +3856,6 @@ https://github.com/PlayingWithFusion/PWFusion_MAX31865.git|Contributed|PWFusion_
 https://github.com/PlayingWithFusion/PWFusion_VL53L3C.git|Contributed|PWFusion_VL53L3C
 https://github.com/PlayingWithFusion/PWFusion_TCA9548A.git|Contributed|PWFusion_TCA9548A
 https://github.com/PlayingWithFusion/PWFusion_Mcp960x.git|Contributed|PWFusion_Mcp960x
-https://github.com/VertorixAU/Vertorix_VT1300_Shield.git|Contributed|VT1300_Shield
 https://github.com/wollewald/MPU9250_WE.git|Contributed|MPU9250_WE
 https://github.com/edumardo/DifferentialSteering.git|Contributed|Differential Steering
 https://github.com/SUPLA/supla-device.git|Contributed|SuplaDevice


### PR DESCRIPTION
Companion to https://github.com/arduino/library-registry/pull/1713