### PR TITLE
Update repositories.txt

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -5119,3 +5119,4 @@ https://github.com/E-Lagori/ELi_McM_4_00
 https://github.com/berrak/MyMacros
 https://github.com/ferrerosteve/WiFiManagerDesign
 https://github.com/XbergCode/DigitSeparator
+https://github.com/RLL-Blue-Dragon/NXP-MPXA4250A


### PR DESCRIPTION
OSS for NXP MPXA4250A(Pressure sensor).
We operate an OSS site (https://oss-ec.com/) that provides OSS for components (OSS-EC).
OSS-EC provides Arduino & Free-RTOS versions as supported OS.