### PR TITLE
Add WiFiManager_RP2040W_Lite Library

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -5123,3 +5123,4 @@ https://github.com/ferrerosteve/WiFiManagerDesign
 https://github.com/XbergCode/DigitSeparator
 https://github.com/E-Lagori/ELi_MdM_4_00
 https://github.com/shurillu/Cdrv8833
+https://github.com/khoih-prog/WiFiManager_RP2040W_Lite


### PR DESCRIPTION
### Initial Release v1.6.0

1. Add support to **RP2040W boards using built-in CYW43439 WiFi** with [`arduino-pico core`](https://github.com/earlephilhower/arduino-pico)
2. Bump version to v1.6.0 to sync with [WiFiManager_Portenta_H7_Lite library](https://github.com/khoih-prog/WiFiManager_Portenta_H7_Lite)