### PR TITLE
Add ATmega_TimerInterrupt Library

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -5131,3 +5131,4 @@ https://github.com/khoih-prog/WiFiManager_RP2040W
 https://github.com/natnqweb/EventSystem
 https://github.com/DIYODEmag/DIYsplay
 https://github.com/thomasfredericks/MicroOsc
+https://github.com/khoih-prog/ATmega_TimerInterrupt


### PR DESCRIPTION
### Releases v1.0.0

1. Initial coding for AVR **ATmega164(A/P), ATmega324(A/P/PA/PB), ATmega644(A/P), ATmega1284(P)** using [**MightyCore**](https://github.com/MCUdude/MightyCore)