### PR TITLE
Add ATmega_Slow_PWM Library

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -5132,3 +5132,4 @@ https://github.com/natnqweb/EventSystem
 https://github.com/DIYODEmag/DIYsplay
 https://github.com/thomasfredericks/MicroOsc
 https://github.com/khoih-prog/ATmega_TimerInterrupt
+https://github.com/khoih-prog/ATmega_Slow_PWM


### PR DESCRIPTION
### Initial Releases v1.0.0

1. Initial coding for AVR **ATmega164(A/P), ATmega324(A/P/PA/PB), ATmega644(A/P), ATmega1284(P)** using [**MightyCore**](https://github.com/MCUdude/MightyCore)
2. The hybrid **ISR-based PWM channels** can generate from very low (much less than 1Hz) to highest PWM frequencies up to 500Hz with acceptable accuracy.