### PR TITLE
Removal of libnapc and libnapc-nightly

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -75,8 +75,6 @@ https://github.com/Tinyu-Zhao/M5-Outdepends
 https://github.com/Tinyu-Zhao/M5-Depends
 https://github.com/Tinyu-Zhao/INA3221
 https://github.com/PowerBroker2/navduino
-https://github.com/nap-software/libnapc-arduino-nightly-releases
-https://github.com/nap-software/libnapc-arduino-releases
 https://github.com/n-wach/camino
 https://gitlab.com/escalator-home-automation/escalator-switch
 https://gitlab.com/escalator-home-automation/daily-service


### PR DESCRIPTION
Hello,

I'll shortly make a new pull request because the URL/home of my project changed.

I want the library to be removed first because I don't want to host the current versions that are available on the registry today (version v1.4.1 resp. v26).