### PR TITLE
Add Dx_TimerInterrupt Library

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -5133,3 +5133,4 @@ https://github.com/DIYODEmag/DIYsplay
 https://github.com/thomasfredericks/MicroOsc
 https://github.com/khoih-prog/ATmega_TimerInterrupt
 https://github.com/khoih-prog/ATmega_Slow_PWM
+https://github.com/khoih-prog/Dx_TimerInterrupt


### PR DESCRIPTION
### Initial Release v1.0.0

1. Intial release to support Arduino **AVRDx-based boards (AVR128Dx, AVR64Dx, AVR32Dx, etc.)** using [**DxCore**](https://github.com/SpenceKonde/DxCore)