### PR TITLE
Remove TFLM from Arduino library download cache

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -1078,7 +1078,6 @@ https://github.com/bblanchon/ArduinoContinuousStepper
 https://github.com/bblanchon/ArduinoJson
 https://github.com/bblanchon/ArduinoStreamUtils
 https://github.com/bblanchon/ArduinoTrace
-https://github.com/bcmi-labs/tensorflow_lite_mirror
 https://github.com/beegee-tokyo/DHTesp
 https://github.com/beegee-tokyo/nRF52_OLED
 https://github.com/beegee-tokyo/SHT1x-ESP


### PR DESCRIPTION
Removed 'https://github.com/bcmi-labs/tensorflow_lite_mirror' from the list
Removing TFLM from Arduino library download cache.