### PR TITLE
Add Dx_Slow_PWM Library

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -5135,3 +5135,4 @@ https://github.com/khoih-prog/ATmega_TimerInterrupt
 https://github.com/khoih-prog/ATmega_Slow_PWM
 https://github.com/khoih-prog/Dx_TimerInterrupt
 https://github.com/Vulintus/ATWINC3400_Driver_Arduino
+https://github.com/khoih-prog/Dx_Slow_PWM


### PR DESCRIPTION
### Initial Release v1.0.0

1. Initial release to support Arduino **AVRDx-based boards (AVR128Dx, AVR64Dx, AVR32Dx, etc.)** using [**DxCore**](https://github.com/SpenceKonde/DxCore)