### PR TITLE
Add ATtiny_TimerInterrupt Library

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -5139,3 +5139,4 @@ https://github.com/khoih-prog/Dx_TimerInterrupt
 https://github.com/Vulintus/ATWINC3400_Driver_Arduino
 https://github.com/khoih-prog/Dx_Slow_PWM
 https://github.com/NewhavenDisplay/NHD-Character-LCD-Library
+https://github.com/khoih-prog/ATtiny_TimerInterrupt


### PR DESCRIPTION
### Initial Release v1.0.0

1. Intial release to support Arduino **AVR ATtiny-based boards (ATtiny3217, etc.) using megaTinyCore**
2. Add notes `howto upload by drag-and-drop` to `CURIOSITY` virtual drive