### PR TITLE
Add ATtiny_Slow_PWM Library

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -5145,3 +5145,4 @@ https://github.com/NewhavenDisplay/NHD-Character-LCD-Library
 https://github.com/khoih-prog/ATtiny_TimerInterrupt
 https://github.com/berrak/LedTask
 https://github.com/asjdf/WebSerialLite
+https://github.com/khoih-prog/ATtiny_Slow_PWM


### PR DESCRIPTION
### Initial Release v1.0.0

1. Intial release to support Arduino **AVR ATtiny-based boards (ATtiny3217, etc.) using megaTinyCore**