### PR TITLE
Adding 'Adafruit_SSD1306_EMULATOR'

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -5152,3 +5152,4 @@ https://github.com/asjdf/WebSerialLite
 https://github.com/khoih-prog/ATtiny_Slow_PWM
 https://github.com/Mm1KEE/SimpleFilter
 https://github.com/alexandrefelipemuller/PulseAnyPin
+https://github.com/sam-peach/Adafruit_SSD1306_EMULATOR


### PR DESCRIPTION
A required library for an open-source emulator I'm about to release :)