### PR TITLE
Update repositories.txt

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -5158,3 +5158,4 @@ https://github.com/InvenSenseInc/arduino.ICM42670P
 https://github.com/matthias-bs/BresserWeatherSensorReceiver
 https://github.com/ogneyar/RussianText_u8g
 https://github.com/minhaj6/DigiPotX9Cxxx
+https://github.com/RLL-Blue-Dragon/NXP_MPXA4250A_00000057


### PR DESCRIPTION
OSS of NXP's MPXA4250A Pressure sensor.
We offer OSS for components on our OSS-EC site (https://oss-ec.com/).
