### PR TITLE
Update repositories.txt

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -5159,3 +5159,4 @@ https://github.com/matthias-bs/BresserWeatherSensorReceiver
 https://github.com/ogneyar/RussianText_u8g
 https://github.com/minhaj6/DigiPotX9Cxxx
 https://github.com/luni64/CallbackHelper
+https://github.com/dnzayan/ESP32_Pinoo


### PR DESCRIPTION
https://github.com/dnzayan/ESP32_Pinoo

Library will be added to the Arduino Library Manager.