### PR TITLE
Rename "PROGMEMAssert"

### DIFF
--- a/registry.txt
+++ b/registry.txt
@@ -5280,5 +5280,5 @@ https://github.com/Scottapotamas/xsens-mti.git|Contributed|xsens_mti
 https://github.com/khoih-prog/React_Generic.git|Contributed|React_Generic
 https://github.com/abel6jose/Trial.git|Contributed|libTrial
 https://github.com/chibiegg/esp-echonet-lite.git|Contributed|esp-echonet-lite
-https://github.com/boothinator/ProgmemAssert.git|Contributed|PROGMEM Assert
+https://github.com/boothinator/ProgmemAssert.git|Contributed|PROGMEMAssert
 https://github.com/berrak/MockEEPROM.git|Contributed|MockEEPROM


### PR DESCRIPTION
Resolves https://github.com/arduino/library-registry/issues/1848