### PR TITLE
Update name and URL of "OSS-EC NXP MPXA4250A 00000057"

### DIFF
--- a/registry.txt
+++ b/registry.txt
@@ -5260,7 +5260,7 @@ https://github.com/CalvinBultz/LightningStepper.git|Contributed|LightningStepper
 https://github.com/luni64/CallbackHelper.git|Contributed|CallbackHelper
 https://github.com/dnzayan/ESP32_Pinoo.git|Contributed|ESP32_Pinoo
 https://github.com/ndomx/MCP23017-Arduino-Library.git|Contributed|MCP23017 Port Expander
-https://github.com/RLL-Blue-Dragon/NXP_MPXA4250A_00000057.git|Contributed|NXP_MPXA4250_BSL00000057
+https://github.com/RLL-Blue-Dragon/OSS-EC_NXP_MPXA4250A_00000057.git|Contributed|NXP_MPXA4250_BSL00000057
 https://github.com/koendv/CheckDS18B20.git|Contributed|CheckDS18B20
 https://github.com/luni64/IntervalTimerEx.git|Contributed|IntervalTimerEx
 https://github.com/dev-board-tech/arduFPGA-app-common-arduino.git|Contributed|arduFPGA-app-common-arduino

--- a/registry.txt
+++ b/registry.txt
@@ -5260,7 +5260,7 @@ https://github.com/CalvinBultz/LightningStepper.git|Contributed|LightningStepper
 https://github.com/luni64/CallbackHelper.git|Contributed|CallbackHelper
 https://github.com/dnzayan/ESP32_Pinoo.git|Contributed|ESP32_Pinoo
 https://github.com/ndomx/MCP23017-Arduino-Library.git|Contributed|MCP23017 Port Expander
-https://github.com/RLL-Blue-Dragon/OSS-EC_NXP_MPXA4250A_00000057.git|Contributed|NXP_MPXA4250_BSL00000057
+https://github.com/RLL-Blue-Dragon/OSS-EC_NXP_MPXA4250A_00000057.git|Contributed|OSS-EC NXP MPXA4250A 00000057
 https://github.com/koendv/CheckDS18B20.git|Contributed|CheckDS18B20
 https://github.com/luni64/IntervalTimerEx.git|Contributed|IntervalTimerEx
 https://github.com/dev-board-tech/arduFPGA-app-common-arduino.git|Contributed|arduFPGA-app-common-arduino


### PR DESCRIPTION
This PR consists of two changes:

- Change URL from `https://github.com/RLL-Blue-Dragon/NXP_MPXA4250A_00000057.gi` to `https://github.com/RLL-Blue-Dragon/OSS-EC_NXP_MPXA4250A_00000057.git` (companion to https://github.com/arduino/library-registry/pull/1885)
- Change name from `NXP_MPXA4250_BSL00000057` to `OSS-EC NXP MPXA4250A 00000057` (resolves https://github.com/arduino/library-registry/issues/1893)

Since the name change operation on the database is actually a removal followed by automated re-indexing on the next job run, the URL update will occur as a matter of course. For this reason, the only operation required from the backend maintainer is a standard name change procedure.