### PR TITLE
Add mupplet-sensor library of project muwerk

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -5210,4 +5210,5 @@ https://github.com/tanakamasayuki/ESP32PsramLock
 https://github.com/chrmlinux/tinyDC
 https://github.com/serenewaffles/OctoPrinter
 https://github.com/serenewaffles/Dorpac-timer
+https://github.com/muwerk/mupplet-sensor
 


### PR DESCRIPTION
Please add library mupplet-sensor to the arduino library-registry.
It's part of project muwerk https://github.com/muwerk