### PR TITLE
rename Arduino-SignatureRow to Arduino-Signature

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -2923,7 +2923,7 @@ https://github.com/NitrofMtl/weeklyAlarm
 https://github.com/njh/EtherCard
 https://github.com/njh/EtherSia
 https://github.com/nkaaf/Arduino-List
-https://github.com/nkaaf/Arduino-SignatureRow
+https://github.com/nkaaf/Arduino-Signature
 https://github.com/Nkawu/TFT_22_ILI9225
 https://github.com/nkolban/ESP32_BLE_Arduino
 https://github.com/noah1510/LedController


### PR DESCRIPTION
I have renamed my repository because the term "SignatureRow" for AVR microcontrollers is not used by all documentations. In the documentation of the ATmega328 this section of the memory is called "Signature Row", however in the documentation of the ATtiny848 it is called "Signature Imprint Table".

Therefore is generalize the name of my repository.