### PR TITLE
Adding the Library ReciclaBot

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -5208,3 +5208,4 @@ https://github.com/chrmlinux/easyLiDAR
 https://github.com/pikido-edutainment/CleanRTOS
 https://github.com/80Stepko08/EMFButton
 https://github.com/alessandromrc/JOAAT
+https://github.com/ifpa-pgm/reciclabot


### PR DESCRIPTION
Library necessary to use the ReciclaBot project, which aims to teach programming and robotics with plastic recycling concepts. It handles multiple elements in the same class as distance gauge, line follower and motor controller.