### PR TITLE
Update name and URL of "ERa"

### DIFF
--- a/registry.txt
+++ b/registry.txt
@@ -5317,7 +5317,7 @@ https://github.com/natnqweb/EventOS.git|Contributed|EventOS
 https://github.com/jandelgado/jled-pca9685-hal.git|Contributed|JLedPCA9685-HAL
 https://github.com/joeycastillo/OSO_Arduino_LCD.git|Contributed|Oddly Specific Objects LCD FeatherWing Library
 https://github.com/drmpf/pfodGUIdesigner.git|Contributed|pfodGUIdesigner
-https://github.com/eoh-jsc/mvp-lib.git|Contributed|ERa
+https://github.com/eoh-jsc/era-lib.git|Contributed|ERa
 https://github.com/RAKWireless/RAK12039-PMSA003I.git|Contributed|RAK12039_PM_Sensor
 https://github.com/RAKWireless/RAK13006-MCP2518.git|Contributed|RAK13006-MCP2518 library
 https://github.com/RAKWireless/RAK13010-SDI12.git|Contributed|RAKwireless_SDI-12

--- a/registry.txt
+++ b/registry.txt
@@ -5317,7 +5317,7 @@ https://github.com/natnqweb/EventOS.git|Contributed|EventOS
 https://github.com/jandelgado/jled-pca9685-hal.git|Contributed|JLedPCA9685-HAL
 https://github.com/joeycastillo/OSO_Arduino_LCD.git|Contributed|Oddly Specific Objects LCD FeatherWing Library
 https://github.com/drmpf/pfodGUIdesigner.git|Contributed|pfodGUIdesigner
-https://github.com/eoh-jsc/mvp-lib.git|Contributed|EoH Platform
+https://github.com/eoh-jsc/mvp-lib.git|Contributed|ERa
 https://github.com/RAKWireless/RAK12039-PMSA003I.git|Contributed|RAK12039_PM_Sensor
 https://github.com/RAKWireless/RAK13006-MCP2518.git|Contributed|RAK13006-MCP2518 library
 https://github.com/RAKWireless/RAK13010-SDI12.git|Contributed|RAKwireless_SDI-12


### PR DESCRIPTION
This PR consists of two changes:

- Change URL from `https://github.com/eoh-jsc/mvp-lib.git` to `https://github.com/eoh-jsc/era-lib.git` (companion to https://github.com/arduino/library-registry/pull/2024)
- Change name from `EoH Platform` to `ERa` (resolves https://github.com/arduino/library-registry/issues/2025)

Since the name change operation on the database is actually a removal followed by automated re-indexing on the next job run, the URL update will occur as a matter of course. For this reason, the only operation required from the backend maintainer is a standard name change procedure.