### PR TITLE
Add Arduino-Base32 library

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -5287,3 +5287,4 @@ https://github.com/STONElibrary/arduino_lib
 https://github.com/Jeroen88/EasyOpenTherm
 https://github.com/liuyinze/CumulocityHttpUpstream
 https://github.com/liuyinze/CumulocityHttpDownstream
+https://github.com/dirkx/Arduino-Base32-Decode


### PR DESCRIPTION
Proposal for a tiny library to handle Base32 decoding per rfc4648 for hardware one time password calculators.