### PR TITLE
TOTP generator

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -5288,3 +5288,4 @@ https://github.com/Jeroen88/EasyOpenTherm
 https://github.com/liuyinze/CumulocityHttpUpstream
 https://github.com/liuyinze/CumulocityHttpDownstream
 https://github.com/dirkx/Arduino-Base32-Decode
+https://github.com/dirkx/Arduino-TOTP-RFC6238-generator


### PR DESCRIPTION
Add time based one time password generator that accepts the SEEDs in the format typically found in Qr codes (unlike the existing options; that rely on the binary seed; which most tools do not directly expose).