### PR TITLE
[Library Manager] Add AVR_PWM Library

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -5289,3 +5289,4 @@ https://github.com/liuyinze/CumulocityHttpUpstream
 https://github.com/liuyinze/CumulocityHttpDownstream
 https://github.com/dirkx/Arduino-Base32-Decode
 https://github.com/dirkx/Arduino-TOTP-RFC6238-generator
+https://github.com/khoih-prog/AVR_PWM


### PR DESCRIPTION
### Initial Releases v1.0.0

1. Initial coding to support **AVR boards, such as Mega-2560, UNO, Nano, Leonardo, etc.**, using AVR cores
2. The hardware-based PWM channels can generate **very high frequencies**.