### PR TITLE
[Library Manager] Add megaAVR_PWM library

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -5295,3 +5295,4 @@ https://github.com/Ninagawa123/Meridian
 https://github.com/RLL-Blue-Dragon/OSS-EC_ROHM_BD1020HFV_00000057
 https://github.com/RLL-Blue-Dragon/OSS-EC_STM_STLM20DD9F_00000057
 https://github.com/RLL-Blue-Dragon/OSS-EC_STM_STLM20W87F_00000057
+https://github.com/khoih-prog/megaAVR_PWM


### PR DESCRIPTION
### Initial Releases v1.0.0

1. Initial coding to support **megaAVR boards, such as UNO WiFi Rev2, AVR_Nano_Every, etc.**, using `Arduino megaAVR` or `MegaCoreX` core
2. The hardware-based PWM channels using TimerB can generate very high frequencies.