### PR TITLE
[Library Manager] Add ESP32_FastPWM library

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -5298,3 +5298,4 @@ https://github.com/RLL-Blue-Dragon/OSS-EC_STM_STLM20DD9F_00000057
 https://github.com/RLL-Blue-Dragon/OSS-EC_STM_STLM20W87F_00000057
 https://github.com/khoih-prog/megaAVR_PWM
 https://github.com/botletics/Botletics-SIM7000
+https://github.com/khoih-prog/ESP32_FastPWM


### PR DESCRIPTION
### Releases v1.0.0

1. Initial coding for **ESP32, ESP32_S2, ESP32_S3 and ESP32_C3** boards using [**ESP32 core**](https://github.com/espressif/arduino-esp32)