### PR TITLE
[Library Manager] Add SAMD_PWM library

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -5304,3 +5304,4 @@ https://github.com/khoih-prog/ESP32_FastPWM
 https://github.com/vindar/ILI9341_T4
 https://github.com/RLL-Blue-Dragon/OSS-EC_TDK_CHS-MSS_00000057
 https://github.com/RLL-Blue-Dragon/OSS-EC_TDK_CHS_UPS_UPR_UGS_UGR_00000057
+https://github.com/khoih-prog/SAMD_PWM


### PR DESCRIPTION
### Releases v1.0.0

1. Initial coding for **SAMD21/SAMD51 boards** such as `NANO_33_IOT`, `ITSYBITSY_M4`, `SEEED_XIAO_M0`, `SparkFun SAMD51_Thing_Plus`, etc. using
- [**Arduino SAMD** core](https://github.com/arduino/ArduinoCore-samd)
- [**Adafruit SAMD** core](https://github.com/adafruit/ArduinoCore-samd)
- [**Seeed-Studio SAMD** core](https://github.com/Seeed-Studio/ArduinoCore-samd)
- [**Sparkfun SAMD** core](https://github.com/sparkfun/Arduino_Boards)
- [**Industruino SAMD** core](https://github.com/Industruino/IndustruinoSAMD)