### PR TITLE
Update name and URL of "OSS-EC_TDK_CHS-UPS_UPR_UGS_UGR_00000057"

### DIFF
--- a/registry.txt
+++ b/registry.txt
@@ -5401,7 +5401,7 @@ https://github.com/khoih-prog/ESP32_FastPWM.git|Contributed|ESP32_FastPWM
 https://github.com/vindar/ILI9341_T4.git|Contributed|ILI9341_T4
 https://github.com/joeqread/arduino-duktape.git|Contributed|JavaScript
 https://github.com/RLL-Blue-Dragon/OSS-EC_TDK_CHS-MSS_00000057.git|Contributed|OSS-EC_TDK_CHS_MSS_00000057
-https://github.com/RLL-Blue-Dragon/OSS-EC_TDK_CHS_UPS_UPR_UGS_UGR_00000057.git|Contributed|OSS-EC_TDK_CHS-UPS_UPR_UGS_UGR_00000057
+https://github.com/RLL-Blue-Dragon/OSS-EC_TDK_CHS-UPS_UPR_UGS_UGR_00000057.git|Contributed|OSS-EC_TDK_CHS-UPS_UPR_UGS_UGR_00000057
 https://github.com/PeaPodTechnologies/I2CIP.git|Contributed|I2CIP
 https://github.com/khoih-prog/SAMD_PWM.git|Contributed|SAMD_PWM
 https://github.com/mcmchris/mcm-grove-voltage-sensor.git|Contributed|MCMVoltSense

--- a/registry.txt
+++ b/registry.txt
@@ -5401,7 +5401,7 @@ https://github.com/khoih-prog/ESP32_FastPWM.git|Contributed|ESP32_FastPWM
 https://github.com/vindar/ILI9341_T4.git|Contributed|ILI9341_T4
 https://github.com/joeqread/arduino-duktape.git|Contributed|JavaScript
 https://github.com/RLL-Blue-Dragon/OSS-EC_TDK_CHS-MSS_00000057.git|Contributed|OSS-EC_TDK_CHS_MSS_00000057
-https://github.com/RLL-Blue-Dragon/OSS-EC_TDK_CHS_UPS_UPR_UGS_UGR_00000057.git|Contributed|OSS-EC_TDK_CHS_UPS_UPR_UGS_UGR_00000057
+https://github.com/RLL-Blue-Dragon/OSS-EC_TDK_CHS_UPS_UPR_UGS_UGR_00000057.git|Contributed|OSS-EC_TDK_CHS-UPS_UPR_UGS_UGR_00000057
 https://github.com/PeaPodTechnologies/I2CIP.git|Contributed|I2CIP
 https://github.com/khoih-prog/SAMD_PWM.git|Contributed|SAMD_PWM
 https://github.com/mcmchris/mcm-grove-voltage-sensor.git|Contributed|MCMVoltSense


### PR DESCRIPTION
This PR consists of two changes:

- Change URL from `https://github.com/RLL-Blue-Dragon/OSS-EC_TDK_CHS_UPS_UPR_UGS_UGR_00000057.git` to `https://github.com/RLL-Blue-Dragon/OSS-EC_TDK_CHS-UPS_UPR_UGS_UGR_00000057.git` (companion to ~~https://github.com/arduino/library-registry/pull/2046~~ https://github.com/arduino/library-registry/pull/2064)
- Change name from `OSS-EC_TDK_CHS_UPS_UPR_UGS_UGR_00000057` to `OSS-EC_TDK_CHS-UPS_UPR_UGS_UGR_00000057` (resolves https://github.com/arduino/library-registry/issues/2047)

Since the name change operation on the database is actually a removal followed by automated re-indexing on the next job run, the URL update will occur as a matter of course. For this reason, the only operation required from the backend maintainer is a standard name change procedure.