### PR TITLE
[Library Manager] Add SAMDUE_PWM library

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -5306,3 +5306,4 @@ https://github.com/RLL-Blue-Dragon/OSS-EC_TDK_CHS-MSS_00000057
 https://github.com/RLL-Blue-Dragon/OSS-EC_TDK_CHS_UPS_UPR_UGS_UGR_00000057
 https://github.com/khoih-prog/SAMD_PWM
 https://github.com/mcmchris/mcm-grove-voltage-sensor
+https://github.com/khoih-prog/SAMDUE_PWM


### PR DESCRIPTION
### Initial Releases v1.0.0

1. Initial coding to support **SAM_DUE** using [`Arduino SAM core`](https://github.com/arduino/ArduinoCore-sam)