### PR TITLE
[Library Manager] Add nRF52_PWM library

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -5308,3 +5308,4 @@ https://github.com/RLL-Blue-Dragon/OSS-EC_TDK_CHS_UPS_UPR_UGS_UGR_00000057
 https://github.com/khoih-prog/SAMD_PWM
 https://github.com/mcmchris/mcm-grove-voltage-sensor
 https://github.com/khoih-prog/SAMDUE_PWM
+https://github.com/khoih-prog/nRF52_PWM


### PR DESCRIPTION
### Initial Releases v1.0.0

1. Initial coding to support **nRF52-based boards, such as AdaFruit Itsy-Bitsy nRF52840, Feather nRF52840 Express, Seeed XIAO nRF52840, Seeed XIAO nRF52840 Sense**, etc. using [`Adafruit nRF52 core`](https://github.com/adafruit/Adafruit_nRF52_Arduino) or [`Seeeduino nRF52 core`](https://github.com/Seeed-Studio/Adafruit_nRF52_Arduino)