### PR TITLE
[Library Manager] Add Teensy_PWM library

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -5311,3 +5311,4 @@ https://github.com/khoih-prog/SAMDUE_PWM
 https://github.com/khoih-prog/nRF52_PWM
 https://github.com/dvarrel/TM1638.git
 https://gitlab.com/UJUR007/mpu6050_ind
+https://github.com/khoih-prog/Teensy_PWM


### PR DESCRIPTION
### Initial Releases v1.0.0

1. Initial coding to support **Teensy 4.x boards, such as Teensy 4.0, Teensy 4.1, Teensy MicroMod, etc.**, using [**Teensyduno** core](https://www.pjrc.com/teensy/td_download.html). The support to **Teensy 2.x, Teensy LC and Teensy 3.x** will be added gradually.