### PR TITLE
Update URL of "OSS-EC_TDK_CHS-UPS_UPR_UGS_UGR_00000057"

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -5304,7 +5304,7 @@ https://github.com/botletics/Botletics-SIM7000
 https://github.com/khoih-prog/ESP32_FastPWM
 https://github.com/vindar/ILI9341_T4
 https://github.com/RLL-Blue-Dragon/OSS-EC_TDK_CHS-MSS_00000057
-https://github.com/RLL-Blue-Dragon/OSS-EC_TDK_CHS_UPS_UPR_UGS_UGR_00000057
+https://github.com/RLL-Blue-Dragon/OSS-EC_TDK_CHS-UPS_UPR_UGS_UGR_00000057
 https://github.com/khoih-prog/SAMD_PWM
 https://github.com/mcmchris/mcm-grove-voltage-sensor
 https://github.com/khoih-prog/SAMDUE_PWM


### PR DESCRIPTION
The name of the repository was changed, so the URL should be updated so that it doesn't rely on a redirect.

Replacement for the incorrectly closed https://github.com/arduino/library-registry/pull/2046