### PR TITLE
[Library Manager] Add ATtiny_PWM library

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -5320,3 +5320,4 @@ https://github.com/RLL-Blue-Dragon/OSS-EC_TI_LM50B_00000057
 https://github.com/RLL-Blue-Dragon/OSS-EC_TI_LM45B_LM45C_00000057
 https://github.com/RLL-Blue-Dragon/OSS-EC_TI_LM35D_00000057
 https://github.com/RLL-Blue-Dragon/OSS-EC_TI_LM35C_LM35CA_00000057
+https://github.com/khoih-prog/ATtiny_PWM


### PR DESCRIPTION
### Initial Releases v1.0.0

1. Initial coding to support Arduino **AVR ATtiny-based boards (ATtiny3217, etc.)** using [**megaTinyCore**](https://github.com/SpenceKonde/megaTinyCore)