### PR TITLE
[LIbrary Manager] Add Dx_PWM library

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -5326,3 +5326,4 @@ https://github.com/RLL-Blue-Dragon/OSS-EC_TI_LM35_LM35A_00000057
 https://github.com/smt5541/magstripelib-esp32
 https://github.com/teruyamato0731/Chassis
 https://github.com/dvarrel/DHT22
+https://github.com/khoih-prog/Dx_PWM


### PR DESCRIPTION
### Initial Release v1.0.0

1. Initial release to support Arduino **AVRDx-based boards (AVR128Dx, AVR64Dx, AVR32Dx, etc.) using DxCore**
2. Using `allman astyle`