### PR TITLE
[Library Manager] Add WiFi101_Generic library

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -5343,3 +5343,4 @@ https://github.com/YoupiLab/YLEsp8266
 https://github.com/YoupiLab/SIM800_YL
 https://github.com/shah253kt/SimpleStack
 https://github.com/sparkfun/SparkFun_Indoor_Air_Quality_Sensor-ENS160_Arduino_Library
+https://github.com/khoih-prog/WiFi101_Generic


### PR DESCRIPTION
### Releases v1.0.0

- 2022.11.17

1. Fix severe limitation to permit sending much larger data than total 4K
2. Use `allman astyle` and add `utils`
3. Add `Packages' Patches`

### Releases v0.16.1

- 2021.05.21

* Add compatibility to [**WebSockets2_Generic**](https://github.com/khoih-prog/WebSockets2_Generic) library