### PR TITLE
Add AsyncWebServer_ESP32_ENC Library

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -5365,3 +5365,4 @@ https://github.com/paperdink/PaperdInk-Library
 https://github.com/hafidhh/Callmebot-ESP32
 https://github.com/ESDeveloperBR/AnalogKeyboard.git
 https://github.com/ESDeveloperBR/TimeInterval
+https://github.com/khoih-prog/AsyncWebServer_ESP32_ENC


### PR DESCRIPTION
#### Releases v1.6.2

1. Initial coding to port [**ESPAsyncWebServer**](https://github.com/me-no-dev/ESPAsyncWebServer) to ESP32 boards using **ENC28J60** Ethernet.
2. Bump up to `v1.6.2` to sync with [**AsyncWebServer_WT32_ETH01** v1.6.2](https://github.com/khoih-prog/AsyncWebServer_WT32_ETH01).
3. Use `allman astyle`