### PR TITLE
Add WebServer_ESP32_ENC library

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -5366,3 +5366,4 @@ https://github.com/hafidhh/Callmebot-ESP32
 https://github.com/ESDeveloperBR/AnalogKeyboard.git
 https://github.com/ESDeveloperBR/TimeInterval
 https://github.com/khoih-prog/AsyncWebServer_ESP32_ENC
+https://github.com/khoih-prog/WebServer_ESP32_ENC


### PR DESCRIPTION
#### Releases v1.5.1

1. Initial coding to support **ESP32** boards using **ENC28J60 LwIP Ethernet**. Sync with [**WebServer_WT32_ETH01** v1.5.1](https://github.com/khoih-prog/WebServer_WT32_ETH01)