### PR TITLE
Add AsyncDNSServer_ESP32_ENC Library

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -5371,3 +5371,4 @@ https://github.com/ESDeveloperBR/TimeInterval
 https://github.com/khoih-prog/AsyncWebServer_ESP32_ENC
 https://github.com/khoih-prog/WebServer_ESP32_ENC
 https://github.com/khoih-prog/AsyncUdp_ESP32_ENC
+https://github.com/khoih-prog/AsyncDNSServer_ESP32_ENC


### PR DESCRIPTION
### Initial Releases v1.0.0

1. Initial coding to support **ESP32 boards using LwIP ENC28J60 Ethernet**