### PR TITLE
Add AsyncDNSServer_WT32_ETH01 library

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -5372,3 +5372,4 @@ https://github.com/khoih-prog/AsyncWebServer_ESP32_ENC
 https://github.com/khoih-prog/WebServer_ESP32_ENC
 https://github.com/khoih-prog/AsyncUdp_ESP32_ENC
 https://github.com/khoih-prog/AsyncDNSServer_ESP32_ENC
+https://github.com/khoih-prog/AsyncDNSServer_WT32_ETH01


### PR DESCRIPTION
### Initial Releases v1.0.0

1. Initial coding to support **WT32_ETH01 or ESP32-based boards using LwIP LAN8720 Ethernet**