### PR TITLE
Add WebServer_ESP32_W5500 Library

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -5376,3 +5376,4 @@ https://github.com/khoih-prog/AsyncDNSServer_WT32_ETH01
 https://github.com/sh123/esp32_codec2_arduino
 https://github.com/Mathieu52/GPSP
 https://github.com/ArtronShop/ArtronShop_SHT45
+https://github.com/khoih-prog/WebServer_ESP32_W5500


### PR DESCRIPTION
#### Releases v1.5.1

1. Initial coding to support ESP32 boards using `W5500 LwIP Ethernet`. Sync with [**WebServer_WT32_ETH01** v1.5.1](https://github.com/khoih-prog/WebServer_WT32_ETH01)