### PR TITLE
Add AsyncWebServer_ESP32_W5500 Library

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -5377,3 +5377,4 @@ https://github.com/sh123/esp32_codec2_arduino
 https://github.com/Mathieu52/GPSP
 https://github.com/ArtronShop/ArtronShop_SHT45
 https://github.com/khoih-prog/WebServer_ESP32_W5500
+https://github.com/khoih-prog/AsyncWebServer_ESP32_W5500


### PR DESCRIPTION
#### Releases v1.6.2

1. Initial coding to port [**ESPAsyncWebServer**](https://github.com/me-no-dev/ESPAsyncWebServer) to ESP32 boards using `LwIP W5500 Ethernet`.
2. Bump up to `v1.6.2` to sync with [**AsyncWebServer_WT32_ETH01** v1.6.2](https://github.com/khoih-prog/AsyncWebServer_WT32_ETH01).
3. Use `allman astyle`