### PR TITLE
removed_pfodGUIdesigner_library

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -30,7 +30,6 @@ https://github.com/Nilon123456789/Receiver
 https://github.com/cwi-dis/iotsa
 https://github.com/chuanstudyup/EasyGNSS.git
 https://github.com/Call-for-Code/ClusterDuck-Protocol
-https://github.com/drmpf/pfodGUIdesigner
 https://github.com/plsTrustMeImAnEngineer/StreamAverage
 https://github.com/trevorwslee/Arduino-DumbDisplay
 https://github.com/dirkhillbrecht/UiUiUi


### PR DESCRIPTION
This library has been superceded by the free Android app [pfodGUIdesigner](https://play.google.com/store/apps/details?id=au.com.forward.pfodGUIdesigner).  Download that app from Google play and use it instead of this code. The pfodGUIdesigner app supports generating code for more boards and has the latest bug fixes. The code in this library has a few bugs which will not be fixed. The code is left here for reference only. To compile this code you need the SafeString library (V4.1.24) and the the pfodParser library V3.58.0.  The later versions of pfodParser library will not compile with this code.