### PR TITLE
Add HTTPS_Server_Generic library

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -5390,3 +5390,4 @@ https://github.com/khoih-prog/AsyncUDP_ESP32_W5500
 https://github.com/khoih-prog/AsyncDNSServer_ESP32_W5500
 https://github.com/AIS-DeviceInnovation/Magellan
 https://github.com/KravitzLabDevices/FORCE2
+https://github.com/khoih-prog/HTTPS_Server_Generic


### PR DESCRIPTION
#### Releases v1.2.0

1. Initial coding to port [**esp32_https_server**](https://github.com/fhessel/esp32_https_server) and [**ESP32_HTTPS_Server**](https://github.com/khoih-prog/ESP32_HTTPS_Server) to ESP32 boards, **WT32_ETH01**, (ESP32 + **LwIP W5500**) and (ESP32 + **LwIP ENC28J60**) Ethernet
2. Use `allman astyle` and restyle library.