### PR TITLE
Add AngleConvertor

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -3457,6 +3457,7 @@ https://github.com/RobTillaart/AnalogKeypad
 https://github.com/RobTillaart/AnalogPin
 https://github.com/RobTillaart/AnalogUVSensor
 https://github.com/RobTillaart/Angle
+https://github.com/RobTillaart/AngleConvertor
 https://github.com/RobTillaart/ANSI
 https://github.com/RobTillaart/AS5600
 https://github.com/RobTillaart/AsyncAnalog


### PR DESCRIPTION
Arduino library for converting angles (degrees/radians) to less known formats.