### PR TITLE
Add AsyncESP32_W5500_Manager library

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -5399,3 +5399,4 @@ https://github.com/AIS-DeviceInnovation/Magellan
 https://github.com/KravitzLabDevices/FORCE2
 https://github.com/khoih-prog/HTTPS_Server_Generic
 https://github.com/joseguerra3000/AD74xx
+https://github.com/khoih-prog/AsyncESP32_W5500_Manager


### PR DESCRIPTION
#### Releases v1.0.0

1. Initial coding to port [**ESPAsync_WiFiManager**](https://github.com/khoih-prog/ESPAsync_WiFiManager) to ESP32 boards using `LwIP W5500 Ethernet`.
2. Use `allman astyle`