### PR TITLE
Add AsyncWT32_ETH01_Manager library

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -5401,3 +5401,4 @@ https://github.com/khoih-prog/HTTPS_Server_Generic
 https://github.com/joseguerra3000/AD74xx
 https://github.com/khoih-prog/AsyncESP32_W5500_Manager
 https://github.com/khoih-prog/AsyncESP32_ENC_Manager
+https://github.com/khoih-prog/AsyncWT32_ETH01_Manager


### PR DESCRIPTION
#### Releases v1.0.0

1. Initial coding to port [**ESPAsync_WiFiManager**](https://github.com/khoih-prog/ESPAsync_WiFiManager) to ESP32 boards using `LwIP LAN8720 Ethernet`, such as **WT32_ETH01**
2. Use `allman astyle`