### PR TITLE
Add AsyncESP8266_ENC_Manager library

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -5404,3 +5404,4 @@ https://github.com/khoih-prog/AsyncESP32_W5500_Manager
 https://github.com/khoih-prog/AsyncESP32_ENC_Manager
 https://github.com/khoih-prog/AsyncWT32_ETH01_Manager
 https://github.com/khoih-prog/AsyncESP8266_W5500_Manager
+https://github.com/khoih-prog/AsyncESP8266_ENC_Manager


### PR DESCRIPTION
#### Releases v1.0.0

1. Initial coding to port [**ESPAsync_WiFiManager**](https://github.com/khoih-prog/ESPAsync_WiFiManager) to **ESP8266** boards using `LwIP ENC28J60 Ethernet`.
2. Use `allman astyle`