### PR TITLE
Add ESP32_ENC_Manager library

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -5408,3 +5408,4 @@ https://github.com/khoih-prog/AsyncESP8266_ENC_Manager
 https://github.com/gicking/LIN_master_portable_Arduino
 https://github.com/khoih-prog/AsyncESP8266_W5100_Manager
 https://github.com/khoih-prog/ESP32_W5500_Manager
+https://github.com/khoih-prog/ESP32_ENC_Manager


### PR DESCRIPTION
#### Releases v1.0.0

1. Initial coding to port `synchronous` [**ESP_WiFiManager**](https://github.com/khoih-prog/ESP_WiFiManager) to **ESP32** boards using `LwIP ENC28J60 Ethernet`.
2. Use `allman astyle`