### PR TITLE
Add ESP8266_W5100_Manager library

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -5411,3 +5411,4 @@ https://github.com/khoih-prog/AsyncESP8266_W5100_Manager
 https://github.com/khoih-prog/ESP32_W5500_Manager
 https://github.com/khoih-prog/ESP32_ENC_Manager
 https://github.com/khoih-prog/ESP8266_W5500_Manager
+https://github.com/khoih-prog/ESP8266_W5100_Manager


### PR DESCRIPTION
#### Releases v1.0.0

1. Initial coding to port `synchronous` [**ESP_WiFiManager**](https://github.com/khoih-prog/ESP_WiFiManager) to **ESP8266** boards using `LwIP W5100 / W5100S Ethernet`.
2. Use `allman astyle`