### PR TITLE
Add ESP8266_ENC_Manager library

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -5412,3 +5412,4 @@ https://github.com/khoih-prog/ESP32_W5500_Manager
 https://github.com/khoih-prog/ESP32_ENC_Manager
 https://github.com/khoih-prog/ESP8266_W5500_Manager
 https://github.com/khoih-prog/ESP8266_W5100_Manager
+https://github.com/khoih-prog/ESP8266_ENC_Manager


### PR DESCRIPTION
#### Releases v1.0.0

1. Initial coding to port `synchronous` [**ESP_WiFiManager**](https://github.com/khoih-prog/ESP_WiFiManager) to **ESP8266** boards using `LwIP ENC28J60 Ethernet`.
2. Use `allman astyle`