### PR TITLE
Add AsyncESP32_Ethernet_Manager library

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -5413,3 +5413,4 @@ https://github.com/khoih-prog/ESP32_ENC_Manager
 https://github.com/khoih-prog/ESP8266_W5500_Manager
 https://github.com/khoih-prog/ESP8266_W5100_Manager
 https://github.com/khoih-prog/ESP8266_ENC_Manager
+https://github.com/khoih-prog/AsyncESP32_Ethernet_Manager


### PR DESCRIPTION
#### Releases v1.0.0

1. Initial coding to port [**ESPAsync_WiFiManager**](https://github.com/khoih-prog/ESPAsync_WiFiManager) to **ESP32** boards using `LwIP W5500 / ENC28J60 Ethernet`.
2. Use `allman astyle`