### PR TITLE
Removed btn99x0 library

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -2050,7 +2050,6 @@ https://github.com/Industruino/FRAM
 https://github.com/Industruino/Indio
 https://github.com/Industruino/UC1701
 https://github.com/INFICON-Spot/inficon-spot-lib
-https://github.com/Infineon/arduino-btn99x0
 https://github.com/Infineon/arduino-motix-btn99x0
 https://github.com/Infineon/arduino-high-side-switch
 https://github.com/Infineon/arduino-optiga-trust-m


### PR DESCRIPTION
The library has been  first released under the wrong repo name and thus url. The new url and library has been already added. This url no longer exist.