### PR TITLE
Remove "MOTIX BTN99x0"

### DIFF
--- a/registry.txt
+++ b/registry.txt
@@ -5515,5 +5515,4 @@ https://github.com/khoih-prog/ESP8266_ENC_Manager.git|Contributed|ESP8266_ENC_Ma
 https://github.com/khoih-prog/AsyncESP32_Ethernet_Manager.git|Contributed|AsyncESP32_Ethernet_Manager
 https://github.com/shyd/Arduino-SerialCommand.git|Contributed|SerialCommand Advanced
 https://github.com/dlyckelid/IOExpander-TLA2518.git|Contributed|TLA2518
-https://github.com/Infineon/arduino-btn99x0.git|Contributed|MOTIX BTN99x0
 https://github.com/Infineon/arduino-motix-btn99x0.git|Contributed|motix-btn99x0


### PR DESCRIPTION
Companion to https://github.com/arduino/library-registry/pull/2219