### PR TITLE
Add ESP32_Ethernet_Manager library

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -5416,3 +5416,4 @@ https://github.com/khoih-prog/ESP8266_ENC_Manager
 https://github.com/khoih-prog/AsyncESP32_Ethernet_Manager
 https://github.com/shyd/Arduino-SerialCommand
 https://github.com/dlyckelid/IOExpander-TLA2518
+https://github.com/khoih-prog/ESP32_Ethernet_Manager


### PR DESCRIPTION
#### Releases v1.0.0

1. Initial coding to port `synchronous` [**ESP_WiFiManager**](https://github.com/khoih-prog/ESP_WiFiManager) to **ESP32** boards using `LwIP W5500 / ENC28J60 Ethernet`
2. Use `allman astyle`