### PR TITLE
Add AsyncESP8266_Ethernet_Manager library

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -5417,3 +5417,4 @@ https://github.com/khoih-prog/AsyncESP32_Ethernet_Manager
 https://github.com/shyd/Arduino-SerialCommand
 https://github.com/dlyckelid/IOExpander-TLA2518
 https://github.com/khoih-prog/ESP32_Ethernet_Manager
+https://github.com/khoih-prog/AsyncESP8266_Ethernet_Manager


### PR DESCRIPTION
#### Releases v1.0.0

1. Initial coding to port [**ESPAsync_WiFiManager**](https://github.com/khoih-prog/ESPAsync_WiFiManager) to **ESP8266** boards using `LwIP W5500 / W5100(S) / ENC28J60 Ethernet`.
2. Use `allman astyle`