### PR TITLE
Add WebServer_ESP32_SC_W5500 library

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -5423,3 +5423,4 @@ https://github.com/khoih-prog/AsyncESP8266_Ethernet_Manager
 https://github.com/khoih-prog/ESP8266_Ethernet_Manager
 https://github.com/dvarrel/ESP_Ping
 https://github.com/neosarchizo/am1002-uart
+https://github.com/khoih-prog/WebServer_ESP32_SC_W5500


### PR DESCRIPTION
#### Releases v1.0.0

1. Initial coding to support **ESP32_S3-based boards using `LwIP W5500 Ethernet`.**
2. Use `allman astyle`