### PR TITLE
Add WebServer_ESP32_SC_ENC library

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -5429,3 +5429,4 @@ https://github.com/dvarrel/ESP_Ping
 https://github.com/dvarrel/ESPAsyncWebSrv
 https://github.com/neosarchizo/am1002-uart
 https://github.com/khoih-prog/WebServer_ESP32_SC_W5500
+https://github.com/khoih-prog/WebServer_ESP32_SC_ENC


### PR DESCRIPTION
#### Releases v1.0.0

1. Initial coding to support **ESP32_S3-based boards using `LwIP ENC28J60 Ethernet`.**
2. Use `allman astyle`