### PR TITLE
Add AsyncESP32_SC_W5500_Manager Library

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -5432,3 +5432,4 @@ https://github.com/dvarrel/ESPAsyncWebSrv
 https://github.com/neosarchizo/am1002-uart
 https://github.com/khoih-prog/WebServer_ESP32_SC_W5500
 https://github.com/khoih-prog/WebServer_ESP32_SC_ENC
+https://github.com/khoih-prog/AsyncESP32_SC_W5500_Manager


### PR DESCRIPTION
#### Releases v1.0.0

1. Initial coding to port [**ESPAsync_WiFiManager**](https://github.com/khoih-prog/ESPAsync_WiFiManager) to **ESP32_S3 boards using `LwIP W5500 Ethernet`.**
2. Use `allman astyle`