### PR TITLE
Add AsyncESP32_SC_Ethernet_Manager Library

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -5436,3 +5436,4 @@ https://github.com/khoih-prog/WebServer_ESP32_SC_W5500
 https://github.com/khoih-prog/WebServer_ESP32_SC_ENC
 https://github.com/khoih-prog/AsyncESP32_SC_W5500_Manager
 https://github.com/khoih-prog/AsyncESP32_SC_ENC_Manager
+https://github.com/khoih-prog/AsyncESP32_SC_Ethernet_Manager


### PR DESCRIPTION
#### Releases v1.0.1

1. Fix typo for PIO

#### Releases v1.0.0

1. Initial coding to port [**ESPAsync_WiFiManager**](https://github.com/khoih-prog/ESPAsync_WiFiManager) to **ESP32_S3 boards using `LwIP W5500 / ENC28J60 Ethernet`.**
2. Use `allman astyle`