### PR TITLE
Add AsyncWebServer_ESP32_SC_W5500 library

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -5439,3 +5439,4 @@ https://github.com/khoih-prog/AsyncESP32_SC_W5500_Manager
 https://github.com/khoih-prog/AsyncESP32_SC_ENC_Manager
 https://github.com/khoih-prog/AsyncESP32_SC_Ethernet_Manager
 https://gitlab.com/hamishcunningham/unPhoneLibrary
+https://github.com/khoih-prog/AsyncWebServer_ESP32_SC_W5500


### PR DESCRIPTION
#### Releases v1.6.3

1. Initial coding to port [**ESPAsyncWebServer**](https://github.com/me-no-dev/ESPAsyncWebServer) to **ESP32_S3 boards using `LwIP W5500 Ethernet`.**
2. Bump up to `v1.6.3` to sync with [**AsyncWebServer_ESP32_W5500** v1.6.3](https://github.com/khoih-prog/AsyncWebServer_ESP32_W5500).
3. Use `allman astyle`