### PR TITLE
Add AsyncWebServer_ESP32_SC_ENC library

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -5440,3 +5440,4 @@ https://github.com/khoih-prog/AsyncESP32_SC_ENC_Manager
 https://github.com/khoih-prog/AsyncESP32_SC_Ethernet_Manager
 https://gitlab.com/hamishcunningham/unPhoneLibrary
 https://github.com/khoih-prog/AsyncWebServer_ESP32_SC_W5500
+https://github.com/khoih-prog/AsyncWebServer_ESP32_SC_ENC


### PR DESCRIPTION
#### Releases v1.6.3

1. Initial coding to port [**ESPAsyncWebServer**](https://github.com/me-no-dev/ESPAsyncWebServer) to **`ESP32_S3` boards using `LwIP ENC28J60 Ethernet`.**
2. Bump up to `v1.6.3` to sync with [**AsyncWebServer_ESP32_ENC** v1.6.3](https://github.com/khoih-prog/AsyncWebServer_ESP32_ENC)
3. Use `allman astyle`