### PR TITLE
Add ESP32_SC_W5500_Manager library

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -5441,3 +5441,4 @@ https://github.com/khoih-prog/AsyncESP32_SC_Ethernet_Manager
 https://gitlab.com/hamishcunningham/unPhoneLibrary
 https://github.com/khoih-prog/AsyncWebServer_ESP32_SC_W5500
 https://github.com/khoih-prog/AsyncWebServer_ESP32_SC_ENC
+https://github.com/khoih-prog/ESP32_SC_W5500_Manager


### PR DESCRIPTION
#### Releases v1.0.0

1. Initial coding to port `synchronous` [**ESP_WiFiManager**](https://github.com/khoih-prog/ESP_WiFiManager) to **ESP32_S3 boards using `LwIP W5500 Ethernet`.**
2. Use `allman astyle`