### PR TITLE
Add ESP32_SC_ENC_Manager library

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -5442,3 +5442,4 @@ https://gitlab.com/hamishcunningham/unPhoneLibrary
 https://github.com/khoih-prog/AsyncWebServer_ESP32_SC_W5500
 https://github.com/khoih-prog/AsyncWebServer_ESP32_SC_ENC
 https://github.com/khoih-prog/ESP32_SC_W5500_Manager
+https://github.com/khoih-prog/ESP32_SC_ENC_Manager


### PR DESCRIPTION
#### Releases v1.0.0

1. Initial coding to port `synchronous` [**ESP_WiFiManager**](https://github.com/khoih-prog/ESP_WiFiManager) to `ESP32_S2/S3/C3` boards using `LwIP ENC28J60 Ethernet`.
2. Use `allman astyle`