### PR TITLE
Add Arduino_HS300x Library

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -929,6 +929,7 @@ https://github.com/arduino-libraries/Arduino_CRC32
 https://github.com/arduino-libraries/Arduino_DebugUtils
 https://github.com/arduino-libraries/Arduino_EdgeControl
 https://github.com/arduino-libraries/Arduino_EMBRYO_2
+https://github.com/arduino-libraries/Arduino_HS300x
 https://github.com/arduino-libraries/Arduino_HTS221
 https://github.com/arduino-libraries/Arduino_JSON
 https://github.com/arduino-libraries/Arduino_KNN


### PR DESCRIPTION
Add the [Arduino_HS300x](https://github.com/arduino-libraries/Arduino_HS300x) library that was released earlier this week.