### PR TITLE
Update name and URL of "ESP_Ping"

### DIFF
--- a/registry.txt
+++ b/registry.txt
@@ -5518,7 +5518,7 @@ https://github.com/Infineon/arduino-motix-btn99x0.git|Contributed|motix-btn99x0
 https://github.com/khoih-prog/ESP32_Ethernet_Manager.git|Contributed|ESP32_Ethernet_Manager
 https://github.com/khoih-prog/AsyncESP8266_Ethernet_Manager.git|Contributed|AsyncESP8266_Ethernet_Manager
 https://github.com/khoih-prog/ESP8266_Ethernet_Manager.git|Contributed|ESP8266_Ethernet_Manager
-https://github.com/dvarrel/ESPping.git|Contributed|ESP_Ping
+https://github.com/dvarrel/ESPping.git|Contributed|ESPping
 https://github.com/Reefwing-Software/Reefwing-Timer.git|Contributed|ReefwingTimer
 https://github.com/Reefwing-Software/Reefwing-Motorshield.git|Contributed|ReefwingMotorShield
 https://github.com/neosarchizo/am1002-uart.git|Contributed|AM1002-UART

--- a/registry.txt
+++ b/registry.txt
@@ -5518,7 +5518,7 @@ https://github.com/Infineon/arduino-motix-btn99x0.git|Contributed|motix-btn99x0
 https://github.com/khoih-prog/ESP32_Ethernet_Manager.git|Contributed|ESP32_Ethernet_Manager
 https://github.com/khoih-prog/AsyncESP8266_Ethernet_Manager.git|Contributed|AsyncESP8266_Ethernet_Manager
 https://github.com/khoih-prog/ESP8266_Ethernet_Manager.git|Contributed|ESP8266_Ethernet_Manager
-https://github.com/dvarrel/ESP_Ping.git|Contributed|ESP_Ping
+https://github.com/dvarrel/ESPping.git|Contributed|ESP_Ping
 https://github.com/Reefwing-Software/Reefwing-Timer.git|Contributed|ReefwingTimer
 https://github.com/Reefwing-Software/Reefwing-Motorshield.git|Contributed|ReefwingMotorShield
 https://github.com/neosarchizo/am1002-uart.git|Contributed|AM1002-UART


### PR DESCRIPTION
This PR consists of two changes:

- Change URL from `https://github.com/dvarrel/ESP_Ping.git` to `https://github.com/dvarrel/ESPping.git` (companion to https://github.com/arduino/library-registry/pull/2255)
- Change name from `ESP_Ping` to `ESPping` (resolves https://github.com/arduino/library-registry/issues/2263)

Since the name change operation on the database is actually a removal followed by automated re-indexing on the next job run, the URL update will occur as a matter of course. For this reason, the only operation required from the backend maintainer is a standard name change procedure.