### PR TITLE
Add AsyncHTTPRequest_ESP32_Ethernet Library

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -5449,3 +5449,4 @@ https://github.com/Protocentral/protocentral_tla20XX_arduino
 https://github.com/BinaryBearzz/JoyStickModule
 https://github.com/leresteux/DunogeonVF
 https://github.com/leresteux/DunogeonENG
+https://github.com/khoih-prog/AsyncHTTPRequest_ESP32_Ethernet


### PR DESCRIPTION
### Releases v1.12.0

1. Initial coding to port [**AsyncHTTPRequest_Generic**](https://github.com/khoih-prog/AsyncHTTPRequest_Generic) to `ESP32/S2/S3/C3` boards using `LwIP W5500 / ENC28J60 / LAN8720 Ethernet`
2. Use `allman astyle`
3. Sync with [**AsyncHTTPRequest_Generic** v1.12.0](https://github.com/khoih-prog/AsyncHTTPRequest_Generic)