### PR TITLE
Add AsyncMQTT_ESP32 library

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -5450,3 +5450,4 @@ https://github.com/BinaryBearzz/JoyStickModule
 https://github.com/leresteux/DunogeonVF
 https://github.com/leresteux/DunogeonENG
 https://github.com/khoih-prog/AsyncHTTPRequest_ESP32_Ethernet
+https://github.com/khoih-prog/AsyncMQTT_ESP32


### PR DESCRIPTION
### Releases v1.8.0

1. Initial coding to port [**AsyncMQTT_Generic**](https://github.com/khoih-prog/AsyncMQTT_Generic) to `ESP32/S2/S3/C3` boards using WiFi or `LwIP W5500 / ENC28J60 / LAN8720 Ethernet`
2. Use `allman astyle`
3. Sync with [**AsyncMQTT_Generic** v1.8.0](https://github.com/khoih-prog/AsyncMQTT_Generic)