### PR TITLE
Add AsyncHTTPSRequest_ESP32_Ethernet library

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -5451,3 +5451,4 @@ https://github.com/leresteux/DunogeonVF
 https://github.com/leresteux/DunogeonENG
 https://github.com/khoih-prog/AsyncHTTPRequest_ESP32_Ethernet
 https://github.com/khoih-prog/AsyncMQTT_ESP32
+https://github.com/khoih-prog/AsyncHTTPSRequest_ESP32_Ethernet


### PR DESCRIPTION
### Releases v2.4.0

1. Initial coding to port [**AsyncHTTPSRequest_Generic**](https://github.com/khoih-prog/AsyncHTTPSRequest_Generic) to `ESP32/S2/S3/C3` boards using `LwIP W5500 / ENC28J60 / LAN8720 Ethernet`
2. Use `allman astyle`
3. Sync with [**AsyncHTTPSRequest_Generic** v2.4.0](https://github.com/khoih-prog/AsyncHTTPSRequest_Generic)