### PR TITLE
Update name and URL of "DunogeonFR"

### DIFF
--- a/registry.txt
+++ b/registry.txt
@@ -5546,7 +5546,7 @@ https://github.com/khoih-prog/ESP32_SC_Ethernet_Manager.git|Contributed|ESP32_SC
 https://github.com/Protocentral/protocentral_tla20XX_arduino.git|Contributed|ProtoCentral TLA20xx
 https://github.com/arduino-libraries/Arduino_HS300x.git|Arduino|Arduino_HS300x
 https://github.com/BinaryBearzz/JoyStickModule.git|Contributed|joystick_module
-https://github.com/leresteux/DunogeonVF.git|Contributed|Dunogeon
+https://github.com/leresteux/DunogeonFR.git|Contributed|Dunogeon
 https://github.com/leresteux/DunogeonENG.git|Contributed|Dunogeon
 https://github.com/khoih-prog/AsyncHTTPRequest_ESP32_Ethernet.git|Contributed|AsyncHTTPRequest_ESP32_Ethernet
 https://github.com/khoih-prog/AsyncMQTT_ESP32.git|Contributed|AsyncMQTT_ESP32

--- a/registry.txt
+++ b/registry.txt
@@ -5546,7 +5546,7 @@ https://github.com/khoih-prog/ESP32_SC_Ethernet_Manager.git|Contributed|ESP32_SC
 https://github.com/Protocentral/protocentral_tla20XX_arduino.git|Contributed|ProtoCentral TLA20xx
 https://github.com/arduino-libraries/Arduino_HS300x.git|Arduino|Arduino_HS300x
 https://github.com/BinaryBearzz/JoyStickModule.git|Contributed|joystick_module
-https://github.com/leresteux/DunogeonFR.git|Contributed|Dunogeon
+https://github.com/leresteux/DunogeonFR.git|Contributed|DunogeonFR
 https://github.com/leresteux/DunogeonENG.git|Contributed|Dunogeon
 https://github.com/khoih-prog/AsyncHTTPRequest_ESP32_Ethernet.git|Contributed|AsyncHTTPRequest_ESP32_Ethernet
 https://github.com/khoih-prog/AsyncMQTT_ESP32.git|Contributed|AsyncMQTT_ESP32


### PR DESCRIPTION
This PR consists of two changes:

- Change URL from `https://github.com/leresteux/DunogeonVF.git` to `https://github.com/leresteux/DunogeonFR.git` (companion to https://github.com/arduino/library-registry/pull/2271)
- Change name from `Dunogeon` to `DunogeonFR` (resolves https://github.com/arduino/library-registry/issues/2270)

Since the name change operation on the database is actually a removal followed by automated re-indexing on the next job run, the URL update will occur as a matter of course. For this reason, the only operation required from the backend maintainer is a standard name change procedure.