### PR TITLE
add osap-arduino to library-repository

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -5454,3 +5454,4 @@ https://github.com/khoih-prog/AsyncHTTPRequest_ESP32_Ethernet
 https://github.com/khoih-prog/AsyncMQTT_ESP32
 https://github.com/khoih-prog/AsyncHTTPSRequest_ESP32_Ethernet
 https://github.com/berrak/Rdebug
+https://github.com/jakeread/osap-arduino


### PR DESCRIPTION
[osap!](http://osap.tools/) is a software-defined networking tool for ferrying data through heterogeneous systems using a message-passing layer; see [the OSHWA talk for more detail](https://www.youtube.com/watch?time_continue=18&v=22ldvolD51I&feature=emb_title) !  the arduino library provides a network-interface API that allows programmers to make their projects graph discoverable. it is put to use in the [modular-things](https://github.com/modular-things/modular-things) project !