### PR TITLE
Add AsyncUDP_ESP32_SC_W5500 library

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -5455,3 +5455,4 @@ https://github.com/khoih-prog/AsyncMQTT_ESP32
 https://github.com/khoih-prog/AsyncHTTPSRequest_ESP32_Ethernet
 https://github.com/berrak/Rdebug
 https://github.com/yesbotics/dualsense-controller
+https://github.com/khoih-prog/AsyncUDP_ESP32_SC_W5500


### PR DESCRIPTION
### Initial Releases v2.0.0

1. Initial coding to port [**AsyncUDP**](https://github.com/espressif/arduino-esp32/tree/master/libraries/AsyncUDP) to **ESP32_S3** boards using `LwIP W5500 Ethernet`
2. Bump up to v2.0.0 to sync with [**AsyncUDP** v2.0.0](https://github.com/espressif/arduino-esp32/tree/master/libraries/AsyncUDP)