### PR TITLE
Add AsyncUDP_ESP32_SC_ENC library

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -5457,3 +5457,4 @@ https://github.com/berrak/Rdebug
 https://github.com/jakeread/osap-arduino
 https://github.com/yesbotics/dualsense-controller
 https://github.com/khoih-prog/AsyncUDP_ESP32_SC_W5500
+https://github.com/khoih-prog/AsyncUDP_ESP32_SC_ENC


### PR DESCRIPTION
### Initial Releases v2.0.0

1. Initial coding to port [**AsyncUDP**](https://github.com/espressif/arduino-esp32/tree/master/libraries/AsyncUDP) to `ESP32_S3` boards using `LwIP ENC28J60` Ethernet
2. Add more examples.
3. Add debugging features.
4. Bump up to v2.0.0 to sync with [**AsyncUDP** v2.0.0](https://github.com/espressif/arduino-esp32/tree/master/libraries/AsyncUDP).