### PR TITLE
Add AsyncDNSServer_ESP32_Ethernet library

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -5459,3 +5459,4 @@ https://github.com/yesbotics/dualsense-controller
 https://github.com/khoih-prog/AsyncUDP_ESP32_SC_W5500
 https://github.com/khoih-prog/AsyncUDP_ESP32_SC_ENC
 https://github.com/khoih-prog/AsyncUDP_ESP32_SC_Ethernet
+https://github.com/khoih-prog/AsyncDNSServer_ESP32_Ethernet


### PR DESCRIPTION
### Initial Releases v1.0.0

1. Initial coding to support **`ESP32/S3` boards using `LwIP W5500 or ENC28J60 Ethernet`**