### PR TITLE
Library removal

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -1486,7 +1486,6 @@ https://github.com/dersimn/ArduinoUnifiedLog
 https://github.com/descampsa/A4963
 https://github.com/descampsa/ardyno
 https://github.com/designer2k2/EMUcan
-https://github.com/designer2k2/EMUcanT4
 https://github.com/desklab/desklab-arduino-lib
 https://github.com/devxplained/HTU21D-Sensor-Library
 https://github.com/devxplained/MAX3010x-Sensor-Library


### PR DESCRIPTION
Hello,
please remove the EMUcanT4 library https://github.com/designer2k2/EMUcanT4 (it is obsolete)
thanks!