### PR TITLE
Add tcUnicodeHelper to the main repository

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -1458,6 +1458,7 @@ https://github.com/davetcc/LiquidCrystalIO
 https://github.com/davetcc/SimpleCollections
 https://github.com/davetcc/TaskManagerIO
 https://github.com/davetcc/tcMenuLib
+https://github.com/davetcc/tcUnicodeHelper
 https://github.com/david1983/eBtn
 https://github.com/DavidArmstrong/SCL3300
 https://github.com/davidchatting/Approximate


### PR DESCRIPTION
Fairly well tested library that provides UTF-8 unicode support to many display libraries including any regular Adafruit_GFX based library. Has a graphical tool built into TcMenu Designer 3.0 that can generate these unicode fonts.