### PR TITLE
Update repositories.txt

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -1983,7 +1983,7 @@ https://github.com/hideakitai/MTCParser
 https://github.com/hideakitai/Packetizer
 https://github.com/hideakitai/PCA9536
 https://github.com/hideakitai/PCA9547
-https://github.com/hideakitai/PCA95x5
+https://github.com/semcneil/PCA95x5
 https://github.com/hideakitai/PCA9624
 https://github.com/hideakitai/PCF2129
 https://github.com/hideakitai/PollingTimer


### PR DESCRIPTION
Changed URL for PCA956x5 from https://github.com/hideakitai/PCA95x5 to https://github.com/semcneil/PCA95x5 
hideakitai hasn't responded to a pull request after 5 months