### PR TITLE
Add WebServer_ESP32_W6100 library

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -5506,3 +5506,4 @@ https://github.com/kermite-org/keyboard_peripheral_modules
 https://github.com/kermite-org/KermiteCore_Arduino
 https://github.com/dvarrel/BMP280
 https://github.com/chandrawi/U8x_Laser_Distance
+https://github.com/khoih-prog/WebServer_ESP32_W6100


### PR DESCRIPTION
#### Releases v1.5.2

1. Initial coding to support **ESP32** boards using `W6100 LwIP Ethernet`. Sync with [**WebServer_ESP32_W6100** v1.5.2](https://github.com/khoih-prog/WebServer_ESP32_W6100)