### PR TITLE
Add WebServer_ESP32_SC_W6100 library

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -5507,3 +5507,4 @@ https://github.com/kermite-org/KermiteCore_Arduino
 https://github.com/dvarrel/BMP280
 https://github.com/chandrawi/U8x_Laser_Distance
 https://github.com/khoih-prog/WebServer_ESP32_W6100
+https://github.com/khoih-prog/WebServer_ESP32_SC_W6100


### PR DESCRIPTION
#### Releases v1.2.1

1. Initial coding to support `ESP32_S2/S3/C3`-based boards using `LwIP W6100 Ethernet`. Sync with [**WebServer_ESP32_SC_W5500** v1.2.1](https://github.com/khoih-prog/WebServer_ESP32_SC_W5500)
2. Use `allman astyle`