### PR TITLE
Add AsyncWebServer_ESP32_SC_W6100 library

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -5509,3 +5509,4 @@ https://github.com/dvarrel/BMP280
 https://github.com/chandrawi/U8x_Laser_Distance
 https://github.com/khoih-prog/WebServer_ESP32_W6100
 https://github.com/khoih-prog/WebServer_ESP32_SC_W6100
+https://github.com/khoih-prog/AsyncWebServer_ESP32_SC_W6100


### PR DESCRIPTION
#### Releases v1.8.1

1. Initial coding to port [**ESPAsyncWebServer**](https://github.com/me-no-dev/ESPAsyncWebServer) to **ESP32_S2/S3/C3** boards using `LwIP W6100 Ethernet`
2. Bump up to `v1.8.1` to sync with [**AsyncWebServer_ESP32_W5500** v1.8.1](https://github.com/khoih-prog/AsyncWebServer_ESP32_W5500)
3. Use `allman astyle`