### PR TITLE
Add AsyncWebServer_ESP32_W6100 library

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -5511,3 +5511,4 @@ https://github.com/chandrawi/U8x_Laser_Distance
 https://github.com/khoih-prog/WebServer_ESP32_W6100
 https://github.com/khoih-prog/WebServer_ESP32_SC_W6100
 https://github.com/khoih-prog/AsyncWebServer_ESP32_SC_W6100
+https://github.com/khoih-prog/AsyncWebServer_ESP32_W6100


### PR DESCRIPTION
#### Releases v1.6.4

1. Initial coding to port [**ESPAsyncWebServer**](https://github.com/me-no-dev/ESPAsyncWebServer) to **ESP32** boards using `LwIP W6100 Ethernet`.
2. Bump up to `v1.6.4` to sync with [**AsyncWebServer_ESP32_W5500** v1.6.4](https://github.com/khoih-prog/AsyncWebServer_ESP32_W5500)
3. Use `allman astyle`