### PR TITLE
Add AsyncUDP_ESP32_SC_W6100 library

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -5514,3 +5514,4 @@ https://github.com/khoih-prog/AsyncWebServer_ESP32_SC_W6100
 https://github.com/khoih-prog/AsyncWebServer_ESP32_W6100
 https://github.com/Mancheron/TFT_eSPI_Widgets
 https://github.com/khoih-prog/AsyncUDP_ESP32_W6100
+https://github.com/khoih-prog/AsyncUDP_ESP32_SC_W6100


### PR DESCRIPTION
### Releases v2.1.0

1. Initial coding to port [**AsyncUDP**](https://github.com/espressif/arduino-esp32/tree/master/libraries/AsyncUDP) to **ESP32_S2/S3/C3** boards using `LwIP W6100 Ethernet`
2. Bump up to `v2.1.0` to sync with [**AsyncUDP_ESP32_SC_W5500** v2.1.0](https://github.com/khoih-prog/AsyncUDP_ESP32_SC_W5500)