### PR TITLE
Add AsyncDNSServer_ESP32_W6100 library

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -5516,3 +5516,4 @@ https://github.com/Mancheron/TFT_eSPI_Widgets
 https://github.com/khoih-prog/AsyncUDP_ESP32_W6100
 https://github.com/khoih-prog/AsyncUDP_ESP32_SC_W6100
 https://github.com/khoih-prog/AsyncUDP_ESP32_Ethernet
+https://github.com/khoih-prog/AsyncDNSServer_ESP32_W6100


### PR DESCRIPTION
### Initial Releases v1.0.0

1. Initial coding to support **ESP32 boards using LwIP W6100 Ethernet**