### PR TITLE
Add AsyncESP32_W6100_Manager library

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -5520,3 +5520,4 @@ https://github.com/khoih-prog/AsyncDNSServer_ESP32_W6100
 https://github.com/IoT-ThingsCloud/thingscloud-esp-sdk
 https://github.com/berrak/SensorWLED
 https://github.com/mimuz/mimuz-ch55x
+https://github.com/khoih-prog/AsyncESP32_W6100_Manager


### PR DESCRIPTION
#### Releases v1.0.0

1. Initial coding to port [**ESPAsync_WiFiManager**](https://github.com/khoih-prog/ESPAsync_WiFiManager) to **ESP32** boards using `LwIP W6100 Ethernet`.
2. Use `allman astyle`