### PR TITLE
Add AsyncESP32_SC_W6100_Manager library

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -5521,3 +5521,4 @@ https://github.com/IoT-ThingsCloud/thingscloud-esp-sdk
 https://github.com/berrak/SensorWLED
 https://github.com/mimuz/mimuz-ch55x
 https://github.com/khoih-prog/AsyncESP32_W6100_Manager
+https://github.com/khoih-prog/AsyncESP32_SC_W6100_Manager


### PR DESCRIPTION
1. Initial coding to port [**ESPAsync_WiFiManager**](https://github.com/khoih-prog/ESPAsync_WiFiManager) to **ESP32_S2/S3/C3** boards using `LwIP W6100 Ethernet`. Sync with [AsyncESP32_SC_W5500_Manager v1.1.0](https://github.com/khoih-prog/AsyncESP32_SC_W5500_Manager)
2. Use `allman astyle`