### PR TITLE
Add ESP32_SC_W6100_Manager library

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -5522,3 +5522,4 @@ https://github.com/berrak/SensorWLED
 https://github.com/mimuz/mimuz-ch55x
 https://github.com/khoih-prog/AsyncESP32_W6100_Manager
 https://github.com/khoih-prog/AsyncESP32_SC_W6100_Manager
+https://github.com/khoih-prog/ESP32_SC_W6100_Manager


### PR DESCRIPTION
#### Releases v1.0.0

1. Initial coding to port `synchronous` [**ESP_WiFiManager**](https://github.com/khoih-prog/ESP_WiFiManager) to `ESP32_S2/S3/C3` boards using `LwIP W6100 Ethernet`.
2. Use `allman astyle`