### PR TITLE
Add ContinuousStepper_Generic library

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -5540,3 +5540,4 @@ https://github.com/stoneroweast/HoldButton
 https://github.com/jpconstantineau/BlueMicro_RP2040_Arduino_Library.git
 https://github.com/Naguissa/uUnixDate
 https://github.com/sparkfun/SparkFun_STTS22H_Arduino_Library
+https://github.com/khoih-prog/ContinuousStepper_Generic


### PR DESCRIPTION
### Initial Releases v1.0.0

1. Initial coding to use PWM to control continuous Stepper Motor. Check [**Using PWM to step a stepper driver** #16](https://github.com/khoih-prog/ContinuousStepper_Generic/issues/16)
2. Use `allman astyle` and add `utils`