### PR TITLE
Remove OPTIGA-Trust-E-Security-Controller

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -2083,7 +2083,6 @@ https://github.com/Infineon/DPS310-Pressure-Sensor
 https://github.com/Infineon/hall-switch
 https://github.com/Infineon/high-side-switch
 https://github.com/Infineon/IFX007T-Motor-Control
-https://github.com/Infineon/OPTIGA-Trust-E-Security-Controller
 https://github.com/Infineon/arduino-pas-co2-sensor
 https://github.com/Infineon/RGB-LED-Lighting-Shield-XMC1202
 https://github.com/Infineon/Stepper-Motor-Shield-IFX9201-XMC1300


### PR DESCRIPTION
Remove the OPTIGA-Trust-E-Security-Controller as being deprecated, also the product is discontinued