### PR TITLE
Add HC4067 library 16 channel multiplexer

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -3553,6 +3553,7 @@ https://github.com/RobTillaart/FunctionGenerator
 https://github.com/RobTillaart/GAMMA
 https://github.com/RobTillaart/GST
 https://github.com/RobTillaart/GY521
+https://github.com/RobTillaart/HC4067
 https://github.com/RobTillaart/HeartBeat
 https://github.com/RobTillaart/Histogram
 https://github.com/RobTillaart/HMC6352


### PR DESCRIPTION
Library for CD74HC4067 multiplexer and compatibles.