### PR TITLE
Update name and URL of "SpeedControl"

### DIFF
--- a/registry.txt
+++ b/registry.txt
@@ -5648,7 +5648,7 @@ https://github.com/Beirdo/Arduino-FRAM-Cache.git|Contributed|FRAM_Cache
 https://github.com/chochain/eForth1.git|Contributed|eForth1
 https://github.com/cubicleguy/su_arduino_uart.git|Contributed|Epson_SU_UART
 https://github.com/cubicleguy/su_arduino_spi.git|Contributed|Epson_SU_SPI
-https://github.com/mission-mangal/speed-control.git|Contributed|Speed Control
+https://github.com/mission-mangal/speed-control.git|Contributed|SpeedControl
 https://github.com/mission-mangal/PositionControl.git|Contributed|PositionControl
 https://github.com/maximemoreillon/iot-kernel.git|Contributed|IotKernel
 https://github.com/JoulePhi/Escon-Library.git|Contributed|Escon

--- a/registry.txt
+++ b/registry.txt
@@ -5648,7 +5648,7 @@ https://github.com/Beirdo/Arduino-FRAM-Cache.git|Contributed|FRAM_Cache
 https://github.com/chochain/eForth1.git|Contributed|eForth1
 https://github.com/cubicleguy/su_arduino_uart.git|Contributed|Epson_SU_UART
 https://github.com/cubicleguy/su_arduino_spi.git|Contributed|Epson_SU_SPI
-https://github.com/mission-mangal/speed-control.git|Contributed|SpeedControl
+https://github.com/mission-mangal/SpeedControl.git|Contributed|SpeedControl
 https://github.com/mission-mangal/PositionControl.git|Contributed|PositionControl
 https://github.com/maximemoreillon/iot-kernel.git|Contributed|IotKernel
 https://github.com/JoulePhi/Escon-Library.git|Contributed|Escon


### PR DESCRIPTION
This PR consists of two changes:

- Change URL from `https://github.com/mission-mangal/speed-control.git` to `https://github.com/mission-mangal/SpeedControl.git` (companion to https://github.com/arduino/library-registry/pull/2433)
- Change name from `Speed Control` to `Speed Control` (resolves https://github.com/arduino/library-registry/issues/2435)

Since the name change operation on the database is actually a removal followed by automated re-indexing on the next job run, the URL update will occur as a matter of course. For this reason, the only operation required from the backend maintainer is a standard name change procedure.
