### PR TITLE
Updated ThingsBoard Arduino SDK link

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -4371,7 +4371,7 @@ https://github.com/thinger-io/Core32
 https://github.com/thingface/arduino
 https://github.com/ThingPulse/esp8266-oled-ssd1306
 https://github.com/ThingPulse/XPT2046_Touchscreen
-https://github.com/thingsboard/ThingsBoard-Arduino-MQTT-SDK
+https://github.com/thingsboard/ThingsBoard-Arduino-SDK
 https://github.com/thingSoC/embedis
 https://github.com/thinkovation/Ambimate
 https://github.com/ThisSmartHouse/CoogleIOT


### PR DESCRIPTION
Hi, the link of the repository was changed from https://github.com/thingsboard/thingsboard-arduino-mqtt-sdk to https://github.com/thingsboard/thingsboard-arduino-sdk