### PR TITLE
Remove "DSpotterSDK_Maker_*" libraries

### DIFF
--- a/registry.txt
+++ b/registry.txt
@@ -5652,7 +5652,6 @@ https://github.com/mission-mangal/SpeedControl.git|Contributed|SpeedControl
 https://github.com/mission-mangal/PositionControl.git|Contributed|PositionControl
 https://github.com/maximemoreillon/iot-kernel.git|Contributed|IotKernel
 https://github.com/JoulePhi/Escon-Library.git|Contributed|Escon
-https://github.com/CyberonEBU/Cyberon_DSpotterSDK_Maker_RP2040.git|Contributed|DSpotterSDK_Maker_RP2040
 https://github.com/CyberonEBU/Cyberon_DSpotterSDK_Maker_PortentaH7.git|Contributed|DSpotterSDK_Maker_PortentaH7
 https://github.com/firechip/Firechip_RV-8263_Arduino_Library.git|Contributed|FC0005748911
 https://github.com/kimble4/CrossMgrLapCounter.git|Contributed|CrossMgrLapCounter

--- a/registry.txt
+++ b/registry.txt
@@ -5652,7 +5652,6 @@ https://github.com/mission-mangal/SpeedControl.git|Contributed|SpeedControl
 https://github.com/mission-mangal/PositionControl.git|Contributed|PositionControl
 https://github.com/maximemoreillon/iot-kernel.git|Contributed|IotKernel
 https://github.com/JoulePhi/Escon-Library.git|Contributed|Escon
-https://github.com/CyberonEBU/Cyberon_DSpotterSDK_Maker_PortentaH7.git|Contributed|DSpotterSDK_Maker_PortentaH7
 https://github.com/firechip/Firechip_RV-8263_Arduino_Library.git|Contributed|FC0005748911
 https://github.com/kimble4/CrossMgrLapCounter.git|Contributed|CrossMgrLapCounter
 https://github.com/plasmapper/adxl355-arduino.git|Contributed|PL ADXL355

--- a/registry.txt
+++ b/registry.txt
@@ -5652,7 +5652,6 @@ https://github.com/mission-mangal/SpeedControl.git|Contributed|SpeedControl
 https://github.com/mission-mangal/PositionControl.git|Contributed|PositionControl
 https://github.com/maximemoreillon/iot-kernel.git|Contributed|IotKernel
 https://github.com/JoulePhi/Escon-Library.git|Contributed|Escon
-https://github.com/CyberonEBU/Cyberon_DSpotterSDK_Maker_33BLE.git|Contributed|DSpotterSDK_Maker_33BLE
 https://github.com/CyberonEBU/Cyberon_DSpotterSDK_Maker_RP2040.git|Contributed|DSpotterSDK_Maker_RP2040
 https://github.com/CyberonEBU/Cyberon_DSpotterSDK_Maker_PortentaH7.git|Contributed|DSpotterSDK_Maker_PortentaH7
 https://github.com/firechip/Firechip_RV-8263_Arduino_Library.git|Contributed|FC0005748911


### PR DESCRIPTION
Note to "backend" maintainer: the removal request was received via an alternative communication channel so there is no request issue associated with this PR.