### PR TITLE
Add Lib for uS82 Microcontroller Board (ATmega328P-AU)

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -5567,3 +5567,4 @@ https://github.com/lualtek/ttn-device-lib
 https://github.com/r3mko/ZMPT101B
 https://github.com/Beirdo/Arduino-LIN
 https://github.com/Beirdo/Arduino-MultiWire
+https://github.com/jcubuntu/us82


### PR DESCRIPTION
Add Lib for uS82 Microcontroller Board (ATmega328P-AU) With 2 CH DC Motor Driver