### PR TITLE
Remove "weatherLocation"

### DIFF
--- a/registry.txt
+++ b/registry.txt
@@ -2833,7 +2833,6 @@ https://github.com/jspark311/Arduino-SX8634.git|Contributed|SX8634
 https://github.com/marccolemont/CRMX_TimoTwo.git|Contributed|CRMX_TimoTwo
 https://github.com/NitrofMtl/ADC_Sampler.git|Contributed|ADC_SAmpler
 https://github.com/khoih-prog/EthernetWebServer.git|Contributed|EthernetWebServer
-https://github.com/JHershey69/weatherLocation-Library.git|Contributed|weatherLocation
 https://github.com/adafruit/Adafruit_nRFCrypto.git|Contributed|Adafruit nRFCrypto
 https://github.com/khoih-prog/ESP8266_AT_WebServer.git|Contributed|ESP8266_AT_WebServer
 https://github.com/ademuri/twilio-esp32-client.git|Contributed|twilio-esp32-client


### PR DESCRIPTION
Companion to https://github.com/arduino/library-registry/pull/2486