### PR TITLE
Remove "ATC MiThermometer Library"

### DIFF
--- a/registry.txt
+++ b/registry.txt
@@ -5049,7 +5049,6 @@ https://github.com/deneyapkart/deneyap-role-arduino-library.git|Contributed|Dene
 https://github.com/deneyapkart/deneyap-kumanda-kolu-arduino-library.git|Contributed|Deneyap Kumanda Kolu
 https://github.com/deneyapkart/deneyap-hareket-algilama-arduino-library.git|Contributed|Deneyap Hareket Algilama
 https://github.com/Sensirion/arduino-i2c-sfm3000.git|Contributed|Sensirion I2C SFM3000
-https://github.com/matthias-bs/ESP32_ATC_MiThermometer_Library.git|Contributed|ATC MiThermometer Library
 https://github.com/deneyapkart/deneyap-6-eksen-ataletsel-olcum-birimi-arduino-library.git|Contributed|Deneyap 6 Eksen Alaletsel Olcum Birimi
 https://github.com/deneyapkart/deneyap-cift-kanalli-cizgi-algilayici-arduino-library.git|Contributed|Deneyap Cift Kanalli Cizgi Algilayici
 https://github.com/deneyapkart/deneyap-duman-dedektoru-arduino-library.git|Contributed|Deneyap Duman Dedektoru


### PR DESCRIPTION
Companion to https://github.com/arduino/library-registry/pull/2501