### PR TITLE
Update repositories.txt to add PID_v1_bc 

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -1575,6 +1575,7 @@ https://github.com/dreed47/WifiMQTTManager
 https://github.com/drewfish/arduino-FourRegs
 https://github.com/drewfish/arduino-TrimWright
 https://github.com/drewfish/arduino-ZeroRegs
+https://github.com/drf5n/Arduino-PID-Library
 https://github.com/DrGamerGuy/GLCD
 https://github.com/DrGFreeman/SharpDistSensor
 https://github.com/DrGFreeman/TimedPID


### PR DESCRIPTION
The PID_v1_bc library is a fork of the https://github.com/br3ttb/Arduino-PID-Library /  PID / PID_v1.h library that adds the back-calculation method of integral windup control.  See https://github.com/drf5n/Arduino-PID-Library and https://github.com/br3ttb/Arduino-PID-Library/pull/116 and https://github.com/br3ttb/Arduino-PID-Library/issues/76#issuecomment-1445273655 for more info.