### PR TITLE
Added afpineda/MeanAndVarOnTheFly-Arduino

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -5622,3 +5622,4 @@ https://github.com/awootton/mqtt5nano
 https://github.com/schlarmann/esp8266channel3lib
 https://github.com/ochiengotieno304/africastalking-esp8266
 https://github.com/scottchiefbaker/ESP-WebOTA
+https://github.com/afpineda/MeanAndVarOnTheFly-Arduino


### PR DESCRIPTION
Addition of library **afpineda/MeanAndVarOnTheFly-Arduino**: Calculate mean and variance not storing individual values in memory