### PR TITLE
Update name and URL of "Arduino_USBHostMbed5"

### DIFF
--- a/registry.txt
+++ b/registry.txt
@@ -5726,7 +5726,7 @@ https://gitlab.com/yesbotics/libs/arduino/led.git|Contributed|Led
 https://github.com/Duckle29/HUSB238.git|Contributed|HUSB238
 https://github.com/MicroBeaut/MicroBeaut-RepeatButton.git|Contributed|RepeatButton
 https://github.com/deneyapkart/deneyap-arduino-projeleri.git|Contributed|Deneyap Arduino Projeleri
-https://github.com/facchinm/USBHostMbed5.git|Contributed|USBHostMbed5
+https://github.com/facchinm/USBHostMbed5.git|Contributed|Arduino_USBHostMbed5
 https://github.com/galjonsfigur/PD243x-DotMatrixDisplay.git|Contributed|DotMatrixDisplay
 https://github.com/MicroBeaut/MicroBeaut-TCone.git|Contributed|TCone
 https://github.com/Flinduino/Flinders_ENGR2781.git|Contributed|Flinders_ENGR2781

--- a/registry.txt
+++ b/registry.txt
@@ -5726,7 +5726,7 @@ https://gitlab.com/yesbotics/libs/arduino/led.git|Contributed|Led
 https://github.com/Duckle29/HUSB238.git|Contributed|HUSB238
 https://github.com/MicroBeaut/MicroBeaut-RepeatButton.git|Contributed|RepeatButton
 https://github.com/deneyapkart/deneyap-arduino-projeleri.git|Contributed|Deneyap Arduino Projeleri
-https://github.com/facchinm/USBHostMbed5.git|Contributed|Arduino_USBHostMbed5
+https://github.com/arduino-libraries/Arduino_USBHostMbed5.git|Contributed|Arduino_USBHostMbed5
 https://github.com/galjonsfigur/PD243x-DotMatrixDisplay.git|Contributed|DotMatrixDisplay
 https://github.com/MicroBeaut/MicroBeaut-TCone.git|Contributed|TCone
 https://github.com/Flinduino/Flinders_ENGR2781.git|Contributed|Flinders_ENGR2781


### PR DESCRIPTION
This PR consists of two changes:

- Change URL from `https://github.com/facchinm/USBHostMbed5.git` to `https://github.com/arduino-libraries/Arduino_USBHostMbed5.git` (companion to https://github.com/arduino/library-registry/pull/2549)
- Change name from `USBHostMbed5` to `Arduino_USBHostMbed5` (resolves https://github.com/arduino/library-registry/issues/2548)

Since the name change operation on the database is actually a removal followed by automated re-indexing on the next job run, the URL update will occur as a matter of course. For this reason, the only operation required from the backend maintainer is a standard name change procedure.
