### PR TITLE
Add PicoDVI - Adafruit Fork

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -5640,3 +5640,4 @@ https://github.com/acksen/AcksenButton
 https://github.com/acksen/AcksenIntEEPROM
 https://github.com/acksen/AcksenUtils
 https://github.com/danny270793/ArduinoShiftRegister
+https://github.com/adafruit/PicoDVI


### PR DESCRIPTION
Arduino-compatible wrapper for Luke Wren's PicoDVI library (originally for Pico SDK), using Adafruit_GFX to provide drawing primitives.