### PR TITLE
Add SimpleDCMotor library

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -1102,6 +1102,7 @@ https://github.com/arsalmaner/Arduino-Libraries
 https://github.com/AshleyF/BriefEmbedded
 https://github.com/askuric/Arduino-FOC
 https://github.com/simplefoc/Arduino-FOC-drivers
+https://github.com/simplefoc/Arduino-FOC-dcmotor
 https://github.com/aster94/GoProControl
 https://github.com/aster94/Keyword-Protocol-2000
 https://github.com/aster94/SensorFusion


### PR DESCRIPTION
Add the SimpleDCMotor library, part of the SimpleFOC ecosystem.

It allows open and closed-loop control of DC motors while making use of the infrastructure already available in SimpleFOC.