### PR TITLE
Request for removal of 8059blank/CytronPikaBot due to copyright infringement

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -1450,7 +1450,6 @@ https://github.com/cvmanjoo/RTC
 https://github.com/cygig/SDConfigCommand
 https://github.com/cygig/SerialConfigCommand
 https://github.com/cygig/TimerEvent
-https://github.com/8059blank/CytronPikaBot
 https://github.com/CytronTechnologies/Cytron_MP3Shield
 https://github.com/CytronTechnologies/Cytron_Servo_Shield_Library
 https://github.com/CytronTechnologies/Cytron_Shield3AMotor


### PR DESCRIPTION
I am writing to request the removal of **`8059blank/CytronPikaBot`** which I believe is infringing on my copyright.

After reviewing the project, I have noticed that the code functionality is similar to my library, which is **`jaredliw/PikaBot`**. On the other hand, the README.md of the library is highly identical to mine, which makes me have reasonable suspicion that `8059blank` et al. have modifed/copied my work.

The library in question:
<img width="596" alt="image" src="https://user-images.githubusercontent.com/57293776/226837129-00eb103d-e40e-47a7-bf46-03b13befe99e.png">

Mine:
<img width="586" alt="image" src="https://user-images.githubusercontent.com/57293776/226837180-4345e6b6-6645-4980-9bf9-3f48036cd149.png">

**`8059blank/CytronPikaBot`** does not follow the license of my project, which is GPL 3.0.

<img width="595" alt="image" src="https://user-images.githubusercontent.com/57293776/226841152-bc5ee124-40da-4210-9911-bb5345609e3a.png">

As the original creator of this project, I would like to request that the infringing project be removed from Arduino Library Registry. I believe this is necessary to protect my intellectual property rights and to ensure that my work is not used without my permission.

I started this project during my secondary school days. My initial initiative is to help other fellow friends to reduce the amount of code written during competition as the library we had at that time (`CytronTechnologies/CytronMotorDriver`) is less convenient to use. Although it is a relatively easy and miniature library, I hope this issue gets appropriate attention as it is meaningful to me and marks a significant milestone in my journey as a developer. 

Thanks in advance.

Regards.