### PR TITLE
Update name and URL of "Firmetix"

### DIFF
--- a/registry.txt
+++ b/registry.txt
@@ -5425,7 +5425,7 @@ https://github.com/Adish0016/dht11esp8266examples.git|Contributed|dht11esp8266ex
 https://github.com/Adish0016/servodht11.git|Contributed|servodht11
 https://github.com/Adish0016/DHT118266.git|Contributed|DHT118266
 https://github.com/eloquentarduino/EloquentEsp32cam.git|Contributed|EloquentEsp32cam
-https://github.com/Nilon123456789/Firmetix4Arduino.git|Contributed|Firmetix
+https://github.com/Nilon123456789/Firmetix-Library.git|Contributed|Firmetix
 https://github.com/Adish0016/esp826611.git|Contributed|esp826611
 https://github.com/tobozo/WiFiManagerTz.git|Contributed|WiFiManagerTz
 https://github.com/npuckett/arduinoAnimation.git|Contributed|Animation Tools

--- a/registry.txt
+++ b/registry.txt
@@ -5425,7 +5425,7 @@ https://github.com/Adish0016/dht11esp8266examples.git|Contributed|dht11esp8266ex
 https://github.com/Adish0016/servodht11.git|Contributed|servodht11
 https://github.com/Adish0016/DHT118266.git|Contributed|DHT118266
 https://github.com/eloquentarduino/EloquentEsp32cam.git|Contributed|EloquentEsp32cam
-https://github.com/Nilon123456789/Firmetix4Arduino.git|Contributed|Firmetix4Arduino
+https://github.com/Nilon123456789/Firmetix4Arduino.git|Contributed|Firmetix
 https://github.com/Adish0016/esp826611.git|Contributed|esp826611
 https://github.com/tobozo/WiFiManagerTz.git|Contributed|WiFiManagerTz
 https://github.com/npuckett/arduinoAnimation.git|Contributed|Animation Tools


### PR DESCRIPTION
This PR consists of two changes:

- Change URL from `https://github.com/Nilon123456789/Firmetix4Arduino.git` to `https://github.com/Nilon123456789/Firmetix-Library.git` (companion to https://github.com/arduino/library-registry/pull/2622)
- Change name from `Firmetix4Arduino` to `Firmetix` (resolves https://github.com/arduino/library-registry/issues/2623)

Since the name change operation on the database is actually a removal followed by automated re-indexing on the next job run, the URL update will occur as a matter of course. For this reason, the only operation required from the backend maintainer is a standard name change procedure.
