### PR TITLE
Update name and URL of "artemis-cubesat"

### DIFF
--- a/registry.txt
+++ b/registry.txt
@@ -4775,7 +4775,7 @@ https://github.com/DFRobot/DFRobot_HX711.git|Contributed|DFRobot_HX711
 https://github.com/DFRobot/DFRobot_BMI160.git|Contributed|DFRobot_BMI160
 https://github.com/DFRobot/DFRobot_MAX17043.git|Contributed|DFRobot_MAX17043
 https://github.com/akkoyun/MAX17055.git|Contributed|MAX17055
-https://github.com/hsfl/artemis-teensy.git|Contributed|artemis-teensy
+https://github.com/hsfl/artemis-teensy.git|Contributed|artemis-cubesat
 https://github.com/ekkai/kocoafabLib.git|Contributed|KOCOAFAB
 https://github.com/plageoj/urlencode.git|Contributed|UrlEncode
 https://github.com/InqOnThat/InqPortal.git|Contributed|InqPortal

--- a/registry.txt
+++ b/registry.txt
@@ -4775,7 +4775,7 @@ https://github.com/DFRobot/DFRobot_HX711.git|Contributed|DFRobot_HX711
 https://github.com/DFRobot/DFRobot_BMI160.git|Contributed|DFRobot_BMI160
 https://github.com/DFRobot/DFRobot_MAX17043.git|Contributed|DFRobot_MAX17043
 https://github.com/akkoyun/MAX17055.git|Contributed|MAX17055
-https://github.com/hsfl/artemis-teensy.git|Contributed|artemis-cubesat
+https://github.com/hsfl/artemis-cubesat.git|Contributed|artemis-cubesat
 https://github.com/ekkai/kocoafabLib.git|Contributed|KOCOAFAB
 https://github.com/plageoj/urlencode.git|Contributed|UrlEncode
 https://github.com/InqOnThat/InqPortal.git|Contributed|InqPortal


### PR DESCRIPTION
This PR consists of two changes:

- Change URL from `https://github.com/hsfl/artemis-teensy.git` to `https://github.com/hsfl/artemis-cubesat.git`
- Change name from `artemis-teensy` to `artemis-cubesat` (resolves https://github.com/arduino/library-registry/issues/2633)

Since the name change operation on the database is actually a removal followed by automated re-indexing on the next job run, the URL update will occur as a matter of course. For this reason, the only operation required from the backend maintainer is a standard name change procedure.
