### PR TITLE
Added my library for the MicroWakeupper board.

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -1954,6 +1954,7 @@ https://github.com/TriadSemi/TS8000
 https://github.com/TridentTD/TridentTD_EasyFreeRTOS32
 https://github.com/TridentTD/TridentTD_LineNotify
 https://github.com/TridentTD/TridentTD_SimplePair
+https://github.com/Tstoegi/MicroWakeupper
 https://github.com/Tvde1/ConfigTool
 https://github.com/Tvde1/WiFiPicker
 https://github.com/UBTEDU/uKitExplore-library


### PR DESCRIPTION
The MicroWakeupper board is a Wemos D1 mini battery shield that also supports specially deep sleep mode by connecting an external switch (or signal source). The library isn't mandatory but makes life much easier. The board hardware design is public/open source - and basically works with any ESP8266.
You can also buy it on Tindie: https://www.tindie.com/products/moreiolabs/microwakeupper-wemos-d1-lipo-shield-deepsleep/