### PR TITLE
please delete the library added for max30100

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -5755,4 +5755,3 @@ https://github.com/fxprime/ModuleMoreSumoV2
 https://github.com/teddokano/GPIO_NXP_Arduino
 https://github.com/Nickjgniklu/ESP_TF
 https://github.com/mlesniew/PicoMQTT
-https://gitlab.com/riscv-vega/vega-sensor-libraries/sensors/vega_max30100


### PR DESCRIPTION
please delete this library since some more updates are yet to add - https://gitlab.com/riscv-vega/vega-sensor-libraries/sensors/vega_max30100