### PR TITLE
add CirquePinnacle lib

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -1,3 +1,4 @@
+https://github.com/2bndy5/CirquePinnacle
 https://github.com/SolderedElectronics/Soldered-MQ-Gas-Sensor-Arduino-Library
 https://github.com/SolderedElectronics/Soldered-OLED-Display-Arduino-Library
 https://github.com/SolderedElectronics/Soldered-AS3935-Lightning-detect-Arduino-Library


### PR DESCRIPTION
Adds a driver library for circular trackpads empowered with Cirque's 1CA027 ASIC (surnamed "Pinnacle") as seen in the Steam controller and HTC Vive VR controllers.