### PR TITLE
Add vdp-gl to library registry

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -5812,3 +5812,4 @@ https://github.com/takeyamayuki/RESTuino
 https://github.com/BlueDot-Arduino/BlueDot-SGP40_SHT40
 https://github.com/teddokano/MUX_SW_NXP_Arduino
 https://github.com/monowireless/mwings_arduino
+https://github.com/avalonbits/vdp-gl


### PR DESCRIPTION
vdp-gl is a fork of FabGL 1.0.8 that is being customized for the [agon-vdp](https://github.com/breakintoprogram/agon-vdp).