### PR TITLE
Adding PI4IOE5V9554 library

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -5829,3 +5829,4 @@ https://gitlab.com/riscv-vega/vega-sensor-libraries/communication/vega_wifinina
 https://gitlab.com/riscv-vega/vega-sensor-libraries/communication/vega_softwareserial
 https://github.com/Seeed-Studio/Seeed_Arduino_AHT20
 https://github.com/epsilonrt/EepromSecureData
+https://github.com/americodias/PI4IOE5V9554


### PR DESCRIPTION
Arduino library for [PI4IOE5V9554](https://www.diodes.com/part/view/PI4IOE5V9554) (8-bit general-purpose I/O expander that provides remote I/O expansion for most microcontroller families via the I2C-bus interface).