### PR TITLE
Update name of "base64_encode"

### DIFF
--- a/registry.txt
+++ b/registry.txt
@@ -3289,7 +3289,7 @@ https://github.com/RobTillaart/Interval.git|Contributed|Interval
 https://github.com/adafruit/Adafruit_OV7670.git|Contributed|Adafruit OV7670
 https://github.com/adafruit/Adafruit_AS7341.git|Contributed|Adafruit AS7341
 https://github.com/dojyorin/arduino_percent.git|Contributed|Percent_Codec
-https://github.com/dojyorin/arduino_base64.git|Contributed|Base64_Codec
+https://github.com/dojyorin/arduino_base64.git|Contributed|base64_encode
 https://github.com/vishnumaiea/R30X-Fingerprint-Sensor-Library.git|Contributed|R30X-Fingerprint-Sensor-Library
 https://github.com/RobTillaart/PCF8575.git|Contributed|PCF8575
 https://github.com/jandrassy/TelnetStream.git|Contributed|TelnetStream


### PR DESCRIPTION
Resolves https://github.com/arduino/library-registry/issues/2778