### PR TITLE
Changed the Repository Name And Files

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -5882,5 +5882,5 @@ https://github.com/rhrhhrhr/MPC_ruih
 https://github.com/sinricpro/teleport-arduino-esp32-library
 https://github.com/midilab/uClock
 https://github.com/sivar2311/WebMonitor
-https://github.com/fablabbh/Arduino-L298-Motor-Library
+https://github.com/fablabbh/FablabL298Driver
 https://github.com/witnessmenow/file-fetcher-arduino


### PR DESCRIPTION
The Previous
https://github.com/fablabbh/Arduino-L298-Motor-Library

The Current
https://github.com/fablabbh/FablabL298Driver

@ArduinoBot