### PR TITLE
Removing a new library I added earlier today.

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -5896,7 +5896,6 @@ https://github.com/deneyapkart/deneyap-servo-arduino-library
 https://github.com/hmz06967/SPI-FlashMem
 https://github.com/hmz06967/OZGPS_NMEA
 https://github.com/pazi88/STM32_CAN
-https://github.com/zapta/serial_packets_arduino
 https://github.com/dang-gun/Arduino_ButtonClickCheck
 https://github.com/flash62au/WiThrottleProtocol
 https://github.com/ArtronShop/ArtronShop_PCF85363


### PR DESCRIPTION
After using the package in the Arduino IDE I realized that it has portability issues, e.g. because it uses vprintf. Removing it for now.