### PR TITLE
Update svm4x

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -1876,12 +1876,10 @@ https://github.com/Sensirion/arduino-i2c-sfm3000
 https://github.com/Sensirion/arduino-i2c-sht4x
 https://github.com/Sensirion/arduino-i2c-stc3x
 https://github.com/Sensirion/arduino-i2c-sts4x
-https://github.com/Sensirion/arduino-i2c-svm40
 https://github.com/Sensirion/arduino-sht
 https://github.com/Sensirion/arduino-sps
 https://github.com/Sensirion/arduino-uart-sen44
 https://github.com/Sensirion/arduino-uart-sfa3x
-https://github.com/Sensirion/arduino-uart-svm40
 https://github.com/Sensirion/upt-core
 https://github.com/SequentMicrosystems/Sequent-Home-Automation-Library
 https://github.com/SequentMicrosystems/Sequent-LCD-Adapter-Library
@@ -5016,8 +5014,8 @@ https://github.com/sensirion/arduino-gas-index-algorithm
 https://github.com/sensirion/arduino-i2c-sdp
 https://github.com/sensirion/arduino-i2c-sgp40
 https://github.com/sensirion/arduino-i2c-sgp41
-https://github.com/sensirion/arduino-i2c-svm41
-https://github.com/sensirion/arduino-uart-svm41
+https://github.com/sensirion/arduino-i2c-svm4x
+https://github.com/sensirion/arduino-uart-svm4x
 https://github.com/sensorium/Mozzi
 https://github.com/sensslen/LibLanc
 https://github.com/septillion-git/FadeLed


### PR DESCRIPTION
Rename SVM41 to SVM4x and remove SVM40 repositories.

SVM4x evaluation kit covers evaluation of SGP40 and SGP41 and therefore SVM40 evaluation kit is discontinued.