### PR TITLE
Update repositories.txt: Fix bad URL in backend

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -3281,7 +3281,7 @@ https://github.com/dojyorin/arduino_base64
 https://github.com/dojyorin/arduino_percent
 https://github.com/dok-net/CoopTask
 https://github.com/dok-net/ad5243.git
-https://github.com/dok-net/esp_sds011
+https://github.com/dok-net/esp_sds011.git
 https://github.com/dok-net/tca9544a.git
 https://github.com/domiluci/LiquidCrystal_NKC
 https://github.com/dominicklee/TrueProx/


### PR DESCRIPTION
I have added the, by itself,redundant `.git` extension, but the real issue is that the library manager backend points at ...doknet...., which is lacking the - in dok-net, hence it never picks up new releases. Please fix the URL. Thanks.