### PR TITLE
Remove "RaiseDev"

### DIFF
--- a/registry.txt
+++ b/registry.txt
@@ -5895,7 +5895,6 @@ https://github.com/kmilo17pet/QuarkTS-cpp.git|Contributed|QuarkTS
 https://github.com/2bndy5/CirquePinnacle.git|Contributed|CirquePinnacle
 https://github.com/imiconsystem/MicromationDevboardV3.git|Contributed|MicromationDevboardV3
 https://github.com/SolderedElectronics/Soldered-8x8-MAX7219-LED-Matrix-Arduino-Library.git|Contributed|8x8 Led Matrix Soldered
-https://github.com/raisedevs/raise-dev-library.git|Contributed|RaiseDev
 https://github.com/dacarson/WeatherFlowApi.git|Contributed|WeatherFlowAPI
 https://github.com/marclura/PT2258-Arduino-Library.git|Contributed|PT2258
 https://github.com/Segilmez06/DistanceSensor.git|Contributed|DistanceSensor


### PR DESCRIPTION
Companion to https://github.com/arduino/library-registry/pull/3033