### PR TITLE
Added Arduino_CANOverSerial library

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -3592,6 +3592,7 @@ https://github.com/heisenware/arduino-vrpc
 https://github.com/heliosproj/HeliOS
 https://github.com/helium/helium-arduino
 https://github.com/helium/longfi-arduino
+https://github.com/henriksod/Arduino_CANOverSerial
 https://github.com/henriksod/Fabrik2DArduino
 https://github.com/hideakitai/ADS1x1x
 https://github.com/hideakitai/ArduinoEigen


### PR DESCRIPTION
Please add this library to the index.

I have followed these steps:
https://github.com/arduino/library-registry/blob/main/FAQ.md#submission-requirements