### PR TITLE
Update repositories.txt

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -1691,6 +1691,7 @@ https://github.com/RobTillaart/SHEX
 https://github.com/RobTillaart/SHT2x
 https://github.com/RobTillaart/SHT31
 https://github.com/RobTillaart/SHT31_SW
+https://github.com/RobTillaart/SHT31_SWW
 https://github.com/RobTillaart/SHT85
 https://github.com/RobTillaart/SIMON
 https://github.com/RobTillaart/SRF05


### PR DESCRIPTION
add https://github.com/RobTillaart/SHT31_SWW
SoftwareWire based SHT31 library for AVR only