### PR TITLE
Update name and URL of "M5-Ethernet"

### DIFF
--- a/registry.txt
+++ b/registry.txt
@@ -6026,7 +6026,7 @@ https://github.com/ripred/CompileTime.git|Contributed|CompileTime
 https://github.com/Crazy-Max-Blog/Crazy_IoTik.git|Contributed|Crazy-IoTik
 https://github.com/eigen-value/Transform.git|Contributed|Transform
 https://github.com/DavidArmstrong/SiderealObjects.git|Contributed|SiderealObjects
-https://github.com/m5stack/PoE_CAM-Ethernet.git|Contributed|PoE_CAM-Ethernet
+https://github.com/m5stack/M5-Ethernet.git|Contributed|PoE_CAM-Ethernet
 https://github.com/vindar/ILI9342_T4.git|Contributed|ILI9342_T4
 https://github.com/m5stack/M5Unit-DigiClock.git|Contributed|M5Unit-DigiClock
 https://github.com/epsilonrt/RadioHead.git|Contributed|RadioHead

--- a/registry.txt
+++ b/registry.txt
@@ -6026,7 +6026,7 @@ https://github.com/ripred/CompileTime.git|Contributed|CompileTime
 https://github.com/Crazy-Max-Blog/Crazy_IoTik.git|Contributed|Crazy-IoTik
 https://github.com/eigen-value/Transform.git|Contributed|Transform
 https://github.com/DavidArmstrong/SiderealObjects.git|Contributed|SiderealObjects
-https://github.com/m5stack/M5-Ethernet.git|Contributed|PoE_CAM-Ethernet
+https://github.com/m5stack/M5-Ethernet.git|Contributed|M5-Ethernet
 https://github.com/vindar/ILI9342_T4.git|Contributed|ILI9342_T4
 https://github.com/m5stack/M5Unit-DigiClock.git|Contributed|M5Unit-DigiClock
 https://github.com/epsilonrt/RadioHead.git|Contributed|RadioHead


### PR DESCRIPTION
This PR consists of two changes:

- Change URL from `https://github.com/m5stack/PoE_CAM-Ethernet.git` to `https://github.com/m5stack/M5-Ethernet.git` (companion to https://github.com/arduino/library-registry/pull/3143)
- Change name from `PoE_CAM-Ethernet` to `M5-Ethernet` (resolves https://github.com/arduino/library-registry/issues/3142)

Since the name change operation on the database is actually a removal followed by automated re-indexing on the next job run, the URL update will occur as a matter of course. For this reason, the only operation required from the backend maintainer is a standard name change procedure.
