### PR TITLE
Update repositories.txt

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -6085,3 +6085,4 @@ https://github.com/todd-herbert/unoHID
 https://github.com/adafruit/Adafruit_TSC2046
 https://github.com/FacundoPumilla/MQ137
 https://github.com/JSC-electronics/acdu-support-library
+https://github.com/AlexRosito67/QUAD7SHIFT


### PR DESCRIPTION
Adding:
QUAD7SHIFT
Library for driving 4 digits seven segments displays for modules that use 74HC595 shift registers. For ARDUINO UNO and NANO and ATtiny85 (or other ATtinys that use the same USI (Universal Serial Interface) module and same pins as the ATtiny85).