### PR TITLE
Update repositories to add new library sht3x-arduino-dis-lib.txt

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -6095,3 +6095,4 @@ https://github.com/JSC-electronics/acdu-support-library
 https://github.com/AlexRosito67/QUAD7SHIFT
 https://github.com/stm32duino/LIS2DUXS12
 https://github.com/mobizt/ESP_SSLClient
+https://github.com/barbarossa12/sht3x-dis-arduino-lib


### PR DESCRIPTION
Added sht3x-dis-arduino-lib. A library to use sht3x-dis by Sensirion. This library provides easy control for the measurement modes of the sensor and easy reading of the temperature and humidity data. Does not support the CRC error detection and correction.