### PR TITLE
Remove "pimp" from repositories.txt

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -6111,7 +6111,6 @@ https://github.com/mobizt/ESP_SSLClient
 https://github.com/IFRN-robotica-CM/CosmosNV2
 https://github.com/barbarossa12/sht3x-dis-arduino-lib
 https://bitbucket.org/jezhill/Keyhole
-https://github.com/epsilonrt/pimp
 https://github.com/ripred/Profiler
 https://github.com/epsilonrt/pImpl
 https://github.com/iory/i2c-for-esp32


### PR DESCRIPTION
Rather than following the standard procedure for name and URL change, the library was resubmitted under the new URL (https://github.com/arduino/library-registry/pull/3196). This pull request removes the previous URL from the list.