### PR TITLE
Remove "pimp" from registry.txt

### DIFF
--- a/registry.txt
+++ b/registry.txt
@@ -6200,7 +6200,6 @@ https://github.com/barbarossa12/sht3x-dis-arduino-lib.git|Contributed|sht3x-dis-
 https://github.com/HoussamElbiade/Digiedge_frame_generator.git|Contributed|digiedge_frame_generator
 https://github.com/andrewhe-princeton/Iridium-GPP.git|Contributed|IridiumGPP
 https://bitbucket.org/jezhill/Keyhole.git|Contributed|Keyhole
-https://github.com/epsilonrt/pimp.git|Contributed|pimp
 https://github.com/nfc-rfid-reader-sdk/MFRC522_PN512.git|Contributed|MFRC522_PN512
 https://github.com/RobTillaart/M5ANGLE8.git|Contributed|M5ANGLE8
 https://github.com/bonezegei/Bonezegei_GSM.git|Contributed|Bonezegei_GSM


### PR DESCRIPTION
Rather than following the standard procedure for name and URL change, the library was resubmitted under the new URL+name (https://github.com/arduino/library-registry/pull/3196). This pull request removes the previous registration from the list.

Even though the conditions that triggered this operation are unusual here in the registry, it is a standard removal operation for the "backend maintainer".

Companion to https://github.com/arduino/library-registry/pull/3209
Resolves https://github.com/arduino/library-registry/issues/3195