### PR TITLE
Remove duplicate entry for "diwa"

### DIFF
--- a/registry.txt
+++ b/registry.txt
@@ -6257,7 +6257,6 @@ https://github.com/BestModules-Libraries/BMN31K522.git|Contributed|BMN31K522
 https://github.com/BestModules-Libraries/BM52D5021-1.git|Contributed|BM52D5021-1
 https://github.com/BestModules-Libraries/BM52D5121-1.git|Contributed|BM52D5121-1
 https://github.com/nthnn/Diwa.git|Contributed|diwa
-https://github.com/nthnn/Diwa.git|Contributed|diwa
 https://github.com/thekakester/Arduino-LoRa-Sx1262.git|Contributed|LoraSx1262
 https://github.com/holgerlembke/ESPFMfGK.git|Contributed|ESP32 File Manager for Generation Klick ESPFMfGK
 https://github.com/Xylopyrographer/BooleanButton.git|Contributed|BooleanButton


### PR DESCRIPTION
This reverts commit 8bd7ae37f35425742bb0213b07cb337a8d4fd25a, which introduced a duplicate registry entry for the "diwa" library.

The original registration was made in https://github.com/arduino/library-registry/commit/70ab36cf2499944d36c75d2951fe73f0f70a8d4f due to the submission https://github.com/arduino/library-registry/pull/3252. The duplicate registration was made due to a second submission in https://github.com/arduino/library-registry/pull/3253

The duplicate does not have any effect on the "backend" system so this is janitorial registry operation that does not require any action by the "backend maintainer".