### PR TITLE
Update repositories.txt

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -1750,6 +1750,7 @@ https://github.com/RobTillaart/SHT31_SWW
 https://github.com/RobTillaart/SHT85
 https://github.com/RobTillaart/SIMON
 https://github.com/RobTillaart/SRF05
+https://github.com/RobTillaart/SWSerialOut
 https://github.com/RobTillaart/ShiftInSlow
 https://github.com/RobTillaart/ShiftOutSlow
 https://github.com/RobTillaart/Soundex


### PR DESCRIPTION
Arduino library for SWSerialOut, supports only data out (TX).