### PR TITLE
Add rtnate/arduino-BasicTimer to repositories.txt

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -6194,3 +6194,4 @@ https://github.com/neittien0110/Soict_IoT_Labs
 https://github.com/m5stack/M5Module-GNSS
 https://github.com/BasPaap/Bas.Button
 https://github.com/ktauchathuranga/MorseEncoder
+https://github.com/rtnate/arduino-BasicTimer


### PR DESCRIPTION
Added https://github.com/rtnate/arduino-BasicTimer library to the repositories.txt file