### PR TITLE
Add Riscduino_MCUFRIEND_kbv library

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -6196,3 +6196,4 @@ https://github.com/m5stack/M5Module-GNSS
 https://github.com/BasPaap/Bas.Button
 https://github.com/ktauchathuranga/MorseEncoder
 https://github.com/rtnate/arduino-BasicTimer
+https://github.com/dineshannayya/Riscduino_MCUFRIEND_kbv


### PR DESCRIPTION
First clone version of MCUFRIEND_kbv to update Riscduino SOC