### PR TITLE
Add AnalogSelector library

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -3346,6 +3346,7 @@ https://github.com/dleval/STLED316S
 https://github.com/dlkay0/TinyFontRenderer
 https://github.com/dlyckelid/IOExpander-TLA2518
 https://github.com/dlyckelid/KX023-1025-IMU
+https://github.com/dmadison/AnalogSelector-Arduino
 https://github.com/dmadison/ArduinoXInput
 https://github.com/dmadison/CtrlUtil
 https://github.com/dmadison/FastLED_NeoPixel


### PR DESCRIPTION
Adds the [AnalogSelector library](https://github.com/dmadison/AnalogSelector-Arduino) to the repository list.