### PR TITLE
Update URL of "ScioSense_APC1"

### DIFF
--- a/registry.txt
+++ b/registry.txt
@@ -5951,7 +5951,7 @@ https://github.com/soylentOrange/DigiSpark_PWM.git|Contributed|DigiSpark_PWM
 https://github.com/adafruit/Adafruit_MCP2515.git|Recommended|Adafruit MCP2515
 https://github.com/thelastoutpostworkshop/FastDisplayPrototyping.git|Contributed|FastDisplayPrototyping
 https://github.com/cranties/escposprinter.git|Contributed|escposprinter
-https://github.com/sciosense/APC1_driver.git|Contributed|ScioSense_APC1
+https://github.com/sciosense/apc1-arduino.git|Contributed|ScioSense_APC1
 https://github.com/ahmedosama07/mDriverL298n.git|Contributed|mDriver
 https://github.com/TMRh20/nrf_to_nrf.git|Contributed|nrf_to_nrf
 https://github.com/gemi254/ConfigAssist-ESP32-ESP8266.git|Contributed|ConfigAssist


### PR DESCRIPTION
Companion to https://github.com/arduino/library-registry/pull/3311