### PR TITLE
Update name and URL of "ScioSense_ENS220"

### DIFF
--- a/registry.txt
+++ b/registry.txt
@@ -6266,7 +6266,7 @@ https://github.com/RobTillaart/AD9833.git|Contributed|AD9833
 https://github.com/engin100/980.git|Contributed|ENGR100-980
 https://github.com/bonezegei/Bonezegei_SSD1306.git|Contributed|Bonezegei_SSD1306
 https://github.com/yasir-shahzad/AM4096.git|Contributed|AM4096
-https://github.com/sciosense/arduino-ens220.git|Contributed|ScioSense ENS220
+https://github.com/sciosense/arduino-ens220.git|Contributed|ScioSense_ENS220
 https://gitlab.com/devgiants/embedded/arduino/libraries/jsn-sr-04t.git|Contributed|jsnsr04t
 https://github.com/RobTillaart/VolumeConverter.git|Contributed|VolumeConverter
 https://github.com/bonezegei/Bonezegei_GPS.git|Contributed|Bonezegei_GPS

--- a/registry.txt
+++ b/registry.txt
@@ -6266,7 +6266,7 @@ https://github.com/RobTillaart/AD9833.git|Contributed|AD9833
 https://github.com/engin100/980.git|Contributed|ENGR100-980
 https://github.com/bonezegei/Bonezegei_SSD1306.git|Contributed|Bonezegei_SSD1306
 https://github.com/yasir-shahzad/AM4096.git|Contributed|AM4096
-https://github.com/sciosense/arduino-ens220.git|Contributed|ScioSense_ENS220
+https://github.com/sciosense/ens220-arduino.git|Contributed|ScioSense_ENS220
 https://gitlab.com/devgiants/embedded/arduino/libraries/jsn-sr-04t.git|Contributed|jsnsr04t
 https://github.com/RobTillaart/VolumeConverter.git|Contributed|VolumeConverter
 https://github.com/bonezegei/Bonezegei_GPS.git|Contributed|Bonezegei_GPS


### PR DESCRIPTION
This PR consists of two changes:

- Change URL from `https://github.com/sciosense/arduino-ens220.git` to `https://github.com/sciosense/ens220-arduino.git` (companion to https://github.com/arduino/library-registry/pull/3311)
- Change name from `ScioSense ENS220` to `ScioSense_ENS220` (resolves https://github.com/arduino/library-registry/issues/3312)

Since the name change operation on the database is actually a removal followed by automated re-indexing on the next job run, the URL update will occur as a matter of course. For this reason, the only operation required from the backend maintainer is a standard name change procedure.
