### PR TITLE
Update URL of "micro_ros_kaia"

### DIFF
--- a/registry.txt
+++ b/registry.txt
@@ -6208,7 +6208,7 @@ https://github.com/ripred/Profiler.git|Contributed|Profiler
 https://github.com/RobTillaart/M5ROTATE8.git|Contributed|M5ROTATE8
 https://github.com/epsilonrt/pImpl.git|Contributed|pImpl
 https://github.com/MrYsLab/Telemetrix4UnoR4.git|Contributed|Telemetrix4UnoR4
-https://github.com/kaiaai/micro_ros_arduino_kaia.git|Contributed|micro_ros_kaia
+https://github.com/kaiaai/micro_ros_arduino_kaiaai.git|Contributed|micro_ros_kaia
 https://github.com/iory/i2c-for-esp32.git|Contributed|i2c-for-esp32
 https://github.com/abcdaaaaaaaaa/MQSpaceData.h.git|Contributed|MQSpaceData
 https://github.com/casiez/OneEuroFilterArduino.git|Contributed|1euroFilter


### PR DESCRIPTION
Companion to ~~https://github.com/arduino/library-registry/pull/3372~~ https://github.com/arduino/library-registry/pull/3396