### PR TITLE
Update name of "SparkFun Qwiic OLED Arduino Library"

### DIFF
--- a/registry.txt
+++ b/registry.txt
@@ -4820,7 +4820,7 @@ https://github.com/DFRobot/DFRobot_SHT.git|Contributed|DFRobot SHT
 https://github.com/hideakitai/MaxMtrParser.git|Contributed|MaxMtrParser
 https://github.com/vurdalakov/radsensboard.git|Contributed|RadSensBoard
 https://github.com/Kineis/KIM_Arduino_Library.git|Contributed|KIM Arduino Library
-https://github.com/sparkfun/SparkFun_Qwiic_OLED_Arduino_Library.git|Contributed|SparkFun Qwiic OLED Graphics Library
+https://github.com/sparkfun/SparkFun_Qwiic_OLED_Arduino_Library.git|Contributed|SparkFun Qwiic OLED Arduino Library
 https://github.com/n-wach/camino.git|Contributed|Camino
 https://github.com/PowerBroker2/navduino.git|Contributed|navduino
 https://github.com/khoih-prog/MQTTPubSubClient_Generic.git|Contributed|MQTTPubSubClient_Generic


### PR DESCRIPTION
Resolves https://github.com/arduino/library-registry/issues/3380