### PR TITLE
ThingsBoard client SDK repository name updated

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -5669,7 +5669,7 @@ https://github.com/thinger-io/ClimaStick
 https://github.com/thinger-io/ClimaStick
 https://github.com/thinger-io/Core32
 https://github.com/thingface/arduino
-https://github.com/thingsboard/ThingsBoard-Arduino-SDK
+https://github.com/thingsboard/thingsboard-client-sdk
 https://github.com/thingsboard/pubsubclient
 https://github.com/thinkovation/Ambimate
 https://github.com/thomasfredericks/Bounce2


### PR DESCRIPTION
The name of the repository for ThingsBoard SDK was updated from thingsboard-arduino-sdk to thingsboard-client-sdk.