### PR TITLE
Update URL of "micro_ros_kaia" in repositories.txt

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -30,7 +30,7 @@ https://github.com/misaproyectil/GD3300
 https://github.com/misaproyectil/Sprite_Serial_Control
 https://github.com/SndrSchnklshk/HDC302x
 https://github.com/SndrSchnklshk/TMP6x
-https://github.com/kaiaai/micro_ros_arduino_kaia
+https://github.com/kaiaai/micro_ros_arduino_kaiaai
 https://github.com/MrYsLab/Telemetrix4UnoR4
 https://github.com/Reefwing-Software/Reefwing-MPU6050
 https://github.com/Obsttube/CryptoAES_CBC


### PR DESCRIPTION
The repository name was changed from "micro_ros_arduino_kaia"  to "micro_ros_arduino_kaiaai".

Even though GitHub automatically creates a redirect from the previous URL after a repository is renamed, it is safest to avoid a reliance on these redirects so the URL in the list should be updated.

This is a resubmission of https://github.com/arduino/library-registry/pull/3372, which was closed without reason.