### PR TITLE
Added CSE_ArduinoRS485 library

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -1,3 +1,4 @@
+https://github.com/CIRCUITSTATE/CSE_ArduinoRS485
 https://github.com/codeljo/AA_MCP2515
 https://github.com/and900/Amytol_Sample
 https://github.com/iMakeOfficial/iMakeBeta


### PR DESCRIPTION
The **CSE_ArduinoRS485** Arduino library allows you to send and receive data using the RS-485 interface standard. Supported by all Arduino-compatible boards such as ESP32, STM32, RP2040, AVR, SAMD, ESP8266, etc. You can use both hardware and software serial ports for communication. This library supports the Maxim Integrated MAX485 and equivalent transceivers.