### PR TITLE
[Library Manager] Please add library ESP32WebRemoteControl

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -4485,6 +4485,7 @@ https://github.com/madhephaestus/ESP32AnalogRead
 https://github.com/madhephaestus/ESP32Encoder
 https://github.com/madhephaestus/ESP32Servo
 https://github.com/madhephaestus/Esp32SimplePacketComs
+https://github.com/madhephaestus/ESP32WebRemoteControl
 https://github.com/madhephaestus/Esp32WifiManager
 https://github.com/madhephaestus/EspWii
 https://github.com/madhephaestus/PVision


### PR DESCRIPTION
Can you please add:

https://github.com/madhephaestus/ESP32WebRemoteControl

To the library manager?

It provides a fast, low latency RC control via web sockets on the ESP32.

Thank you!