### PR TITLE
Update repositories.txt

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -3448,7 +3448,6 @@ https://github.com/dvarrel/ESPAsyncWebSrv
 https://github.com/dvarrel/ESPping
 https://github.com/dvarrel/TM1638.git
 https://github.com/dvernier/GDXLib
-https://github.com/dvernier/VernierLib
 https://github.com/VernierST/VernierLib
 https://github.com/dwrobel/TrivialKalmanFilter
 https://github.com/dxinteractive/AnalogMultiButton

--- a/repositories.txt
+++ b/repositories.txt
@@ -3449,6 +3449,7 @@ https://github.com/dvarrel/ESPping
 https://github.com/dvarrel/TM1638.git
 https://github.com/dvernier/GDXLib
 https://github.com/dvernier/VernierLib
+https://github.com/VernierST/VernierLib
 https://github.com/dwrobel/TrivialKalmanFilter
 https://github.com/dxinteractive/AnalogMultiButton
 https://github.com/dxinteractive/ResponsiveAnalogRead


### PR DESCRIPTION
This is a pull request to change the URL of a library that already exists in the Library Manager. The current URL points to an individual's Git account ("dvernier"). The new URL will point to the official Git account for Vernier Science Education. In addition, the new URL contains an updated version of the VernierLib library (1.0.6)