### PR TITLE
Update URL of "VernierLib"

### DIFF
--- a/registry.txt
+++ b/registry.txt
@@ -1184,7 +1184,7 @@ https://github.com/OpenBCI/OpenBCI_Radios.git|Contributed|OpenBCI_Radios
 https://github.com/cristborges/IRRemoteControl.git|Contributed|IRRemoteControl
 https://github.com/evert-arias/LedSync.git|Contributed|LedSync
 https://github.com/closedcube/ClosedCube_TSYS01_Arduino.git|Contributed|ClosedCube TSYS01
-https://github.com/dvernier/VernierLib.git|Contributed|VernierLib
+https://github.com/VernierST/VernierLib.git|Contributed|VernierLib
 https://github.com/andium/AmazonDRS.git|Contributed|AmazonDRS
 https://github.com/SodaqMoja/Microchip_RN487x.git|Contributed|Microchip_RN487x
 https://github.com/MileBuurmeijer/DS1307newAlarms.git|Contributed|DS1307newAlarms


### PR DESCRIPTION
Companion to https://github.com/arduino/library-registry/pull/3456