### PR TITLE
Update name and URL of "AITINKR_SHIELDS"

### DIFF
--- a/registry.txt
+++ b/registry.txt
@@ -6393,4 +6393,4 @@ https://github.com/sparkfun/SparkFun_STHS34PF80_Arduino_Library.git|Contributed|
 https://github.com/tech-box-io/TB_TFT_eSPI.git|Contributed|TB_TFT_eSPI
 https://github.com/ConsentiumInc/ConsentiumThingsDalton.git|Contributed|ConsentiumThingsDalton
 https://github.com/NitrofMtl/DUE_ADC_Oversampler.git|Contributed|DUE_ADC_Oversampler
-https://github.com/AITINKR/AITINKR_SHEILDS.git|Contributed|AITINKR_SHEILDS
+https://github.com/AITINKR/AITINKR_SHEILDS.git|Contributed|AITINKR_SHIELDS

--- a/registry.txt
+++ b/registry.txt
@@ -6393,4 +6393,4 @@ https://github.com/sparkfun/SparkFun_STHS34PF80_Arduino_Library.git|Contributed|
 https://github.com/tech-box-io/TB_TFT_eSPI.git|Contributed|TB_TFT_eSPI
 https://github.com/ConsentiumInc/ConsentiumThingsDalton.git|Contributed|ConsentiumThingsDalton
 https://github.com/NitrofMtl/DUE_ADC_Oversampler.git|Contributed|DUE_ADC_Oversampler
-https://github.com/AITINKR/AITINKR_SHEILDS.git|Contributed|AITINKR_SHIELDS
+https://github.com/AITINKR/AITINKR_SHIELDS.git|Contributed|AITINKR_SHIELDS


### PR DESCRIPTION
This PR consists of two changes:

- Change URL from `https://github.com/AITINKR/AITINKR_SHEILDS.git` to `https://github.com/AITINKR/AITINKR_SHIELDS.git` (companion to https://github.com/arduino/library-registry/pull/3460)
- Change name from `AITINKR_SHEILDS` to `AITINKR_SHIELDS` (resolves https://github.com/arduino/library-registry/issues/3461)

Since the name change operation on the database is actually a removal followed by automated re-indexing on the next job run, the URL update will occur as a matter of course. For this reason, the only operation required from the backend maintainer is a standard name change procedure.

---

