### PR TITLE
Update name of "Cpp_Standard_Library"

### DIFF
--- a/registry.txt
+++ b/registry.txt
@@ -5560,7 +5560,7 @@ https://github.com/RobTillaart/DMM.git|Contributed|DMM
 https://github.com/Eugeniusz-Gienek/CSWButtons.git|Contributed|CSWButtons
 https://github.com/plageoj/request-builder.git|Contributed|RequestBuilder
 https://gitlab.com/softsysco/grove-as3935-lightning-sensor.git|Contributed|Grove_AS3935Lightning_sensor
-https://github.com/Silver-Fang/ArduinoSTL.git|Contributed|STL for Arduino
+https://github.com/Silver-Fang/ArduinoSTL.git|Contributed|Cpp_Standard_Library
 https://github.com/Judiviga/ROBLEX.git|Contributed|ROBLEX
 https://github.com/RobTillaart/fast_math.git|Contributed|fast_math
 https://github.com/RCmags/pulseInput.git|Contributed|pulseInput


### PR DESCRIPTION
Resolves https://github.com/arduino/library-registry/issues/3474