### PR TITLE
Update name and URL of "SimpleControl"

### DIFF
--- a/registry.txt
+++ b/registry.txt
@@ -6421,4 +6421,4 @@ https://github.com/AlfredoMunguia/TinyGuixhe.git|Contributed|TinyGuixhe
 https://github.com/skathir38/ArduinoSplash.git|Contributed|Splash
 https://github.com/CIRCUITSTATE/CSE_ModbusRTU.git|Contributed|CSE_ModbusRTU
 https://github.com/ichirowo/FLINT_E220_900T22S_JP_Library.git|Contributed|FLINT_E220-900T22S-JP
-https://github.com/Tenveis/SimpleMotorControl.git|Contributed|SimpleControl
+https://github.com/Tenveis/SimpleControl.git|Contributed|SimpleControl

--- a/registry.txt
+++ b/registry.txt
@@ -6421,4 +6421,4 @@ https://github.com/AlfredoMunguia/TinyGuixhe.git|Contributed|TinyGuixhe
 https://github.com/skathir38/ArduinoSplash.git|Contributed|Splash
 https://github.com/CIRCUITSTATE/CSE_ModbusRTU.git|Contributed|CSE_ModbusRTU
 https://github.com/ichirowo/FLINT_E220_900T22S_JP_Library.git|Contributed|FLINT_E220-900T22S-JP
-https://github.com/Tenveis/SimpleMotorControl.git|Contributed|SimpleMotorControl
+https://github.com/Tenveis/SimpleMotorControl.git|Contributed|SimpleControl


### PR DESCRIPTION
This PR consists of two changes:

- Change URL from `https://github.com/Tenveis/SimpleMotorControl.git` to `https://github.com/Tenveis/SimpleControl.git`
- Change name from `SimpleMotorControl` to `SimpleControl`

Since the name change operation on the database is actually a removal followed by automated re-indexing on the next job run, the URL update will occur as a matter of course. For this reason, the only operation required from the backend maintainer is a standard name change procedure.

---

companion to https://github.com/arduino/library-registry/pull/3489