### PR TITLE
remove url for Library Index

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -2626,7 +2626,6 @@ https://github.com/adnan-elabdullah/KmeStepper
 https://github.com/adrian200223/Simple5641AS
 https://github.com/adrien-legrand/as5x47
 https://github.com/aelse/ArduinoStatsd
-https://github.com/affanhanifathtarech/DS3231_RTC
 https://github.com/afpineda/MeanAndVarOnTheFly-Arduino
 https://github.com/agdl/Base64
 https://github.com/agdl/GoPRO


### PR DESCRIPTION
# Remove url for Library Index https://github.com/affanhanifathtarech/DS3231_RTC

Removing this entry has the following reasons:

1. The library was copied without adapting the metadata correctly in the `library.properties` file
* url points to wrong location
* maintainer is wrong
* include name differs from Library name which causes issues during build process if both libraries are installed.
* => this causes confusion by the users, see PR of maintainer of original Lib [PR](https://github.com/affanhanifathtarech/DS3231_RTC/pull/1)

2. The library was not maintained about Aug 2022, over one year

3. owner of this Library did not respond since Mar 2022 to this PR mentioned above, regarding to correct the entries in the `library.properties` file.

This is a friendly request to remove this library from the index to give the owner a hint to adapt the `library.properties` file accordingly.
If there is no response from him following, I would see this as hint this library is not used anymore in Arduino Index.
You can also see the issue if you search for the `DS3231` library in Arduino IDE which results in two entries pointing to the identical github location (when clicked on `More Info`) but meaning should be two different libraries.

Library `DS3231` and  `DS3231_RTC` points to the same URL when use the `More Info`-button.

Best regards
Frank