### PR TITLE
Add Blues-Minimal-I2C

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -2977,6 +2977,7 @@ https://github.com/beegee-tokyo/VNCL4020C-Arduino
 https://github.com/beegee-tokyo/WisBlock-API
 https://github.com/beegee-tokyo/WisBlock-API-V2
 https://github.com/beegee-tokyo/nRF52_OLED
+https://github.com/beegee-tokyo/Blues-Minimal-I2C
 https://github.com/beetlikeyg087/MFUthings
 https://github.com/belidzs/PreciseLM35
 https://github.com/bengtmartensson/ABeacon


### PR DESCRIPTION
Adding a low memory footprint alternative for Blues Notecard access through I2C