### PR TITLE
Update name and URL of "JBLogger"

### DIFF
--- a/registry.txt
+++ b/registry.txt
@@ -6469,5 +6469,5 @@ https://github.com/GyverLibs/Pairs.git|Contributed|Pairs
 https://github.com/esp-arduino-libs/ESP32_Knob.git|Contributed|ESP32_Knob
 https://github.com/bonezegei/Bonezegei_HD44780.git|Contributed|Bonezegei_HD44780
 https://github.com/GoodFilling/Motor-Driver.git|Contributed|DRV8251-Driver
-https://github.com/jonnybergdahl/Bergdahl_JBLogger.git|Contributed|JBLogger
+https://github.com/jonnybergdahl/Arduino_JBLogger_Library.git|Contributed|JBLogger
 https://github.com/pg-goose/MKRWiFiLed.git|Contributed|MKRWiFiLed

--- a/registry.txt
+++ b/registry.txt
@@ -6469,5 +6469,5 @@ https://github.com/GyverLibs/Pairs.git|Contributed|Pairs
 https://github.com/esp-arduino-libs/ESP32_Knob.git|Contributed|ESP32_Knob
 https://github.com/bonezegei/Bonezegei_HD44780.git|Contributed|Bonezegei_HD44780
 https://github.com/GoodFilling/Motor-Driver.git|Contributed|DRV8251-Driver
-https://github.com/jonnybergdahl/Bergdahl_JBLogger.git|Contributed|Bergdahl_JBLogger
+https://github.com/jonnybergdahl/Bergdahl_JBLogger.git|Contributed|JBLogger
 https://github.com/pg-goose/MKRWiFiLed.git|Contributed|MKRWiFiLed


### PR DESCRIPTION
This PR consists of two changes:

- Change URL from `https://github.com/jonnybergdahl/Bergdahl_JBLogger.git` to `https://github.com/jonnybergdahl/Arduino_JBLogger_Library.git` (companion to https://github.com/arduino/library-registry/pull/3563)
- Change name from `Bergdahl_JBLogger` to `JBLogger` (resolves https://github.com/arduino/library-registry/issues/3561)

Since the name change operation on the database is actually a removal followed by automated re-indexing on the next job run, the URL update will occur as a matter of course. For this reason, the only operation required from the backend maintainer is a standard name change procedure.