### PR TITLE
Update URL for "Mosiwi_Basic_Learning_Kit" in repositories list

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -1281,7 +1281,7 @@ https://github.com/Mm1KEE/SmoothTouch
 https://github.com/MohammedRashad/ArduZ80
 https://github.com/Mokolea/InputDebounce
 https://github.com/MonsieurV/ArduinoPocketGeiger
-https://github.com/Mosiwi/Mosiwi-basic-learning-kit-for-arduino
+https://github.com/Mosiwi/Mosiwi-basic-learning-kit
 https://github.com/MrYsLab/FirmataExpress
 https://github.com/MrYsLab/NanoConnectHcSr04
 https://github.com/MrYsLab/NeoPixelConnect


### PR DESCRIPTION
The repository has been renamed. The URL in the repositories list is updated accordingly to avoid a reliance on the redirect.

This was originally requested via https://github.com/arduino/library-registry/pull/3639, but that PR was closed by the library maintainer and could not be reopened due to the head branch having been deleted.