### PR TITLE
Update name and URL of "Mosiwi_Basic_Learning_Kit'

### DIFF
--- a/registry.txt
+++ b/registry.txt
@@ -4896,7 +4896,7 @@ https://github.com/DFRobot/DFRobot_Gesture_Touch.git|Contributed|DFRobot_Gesture
 https://github.com/South-River/BMI085-arduino.git|Contributed|High Performance IMU BMI085
 https://github.com/shraiwi/mini-qoi.git|Contributed|Mini QOI
 https://github.com/bblanchon/ArduinoContinuousStepper.git|Contributed|ContinuousStepper
-https://github.com/Mosiwi/Mosiwi-basic-learning-kit-for-arduino.git|Contributed|Mosiwi Basic Learning Kit
+https://github.com/Mosiwi/Mosiwi-basic-learning-kit-for-arduino.git|Contributed|Mosiwi_Basic_Learning_Kit
 https://github.com/nusabot-iot/dashboard-arduino.git|Contributed|Dashboard IoT
 https://github.com/UnexpectedMaker/esp32s3-arduino-helper.git|Contributed|UMS3 Helper
 https://github.com/bsch2734/SpiShiftRegisterChain.git|Contributed|SPIShiftRegister

--- a/registry.txt
+++ b/registry.txt
@@ -4896,7 +4896,7 @@ https://github.com/DFRobot/DFRobot_Gesture_Touch.git|Contributed|DFRobot_Gesture
 https://github.com/South-River/BMI085-arduino.git|Contributed|High Performance IMU BMI085
 https://github.com/shraiwi/mini-qoi.git|Contributed|Mini QOI
 https://github.com/bblanchon/ArduinoContinuousStepper.git|Contributed|ContinuousStepper
-https://github.com/Mosiwi/Mosiwi-basic-learning-kit-for-arduino.git|Contributed|Mosiwi_Basic_Learning_Kit
+https://github.com/Mosiwi/Mosiwi-basic-learning-kit.git|Contributed|Mosiwi_Basic_Learning_Kit
 https://github.com/nusabot-iot/dashboard-arduino.git|Contributed|Dashboard IoT
 https://github.com/UnexpectedMaker/esp32s3-arduino-helper.git|Contributed|UMS3 Helper
 https://github.com/bsch2734/SpiShiftRegisterChain.git|Contributed|SPIShiftRegister


### PR DESCRIPTION
This PR consists of two changes:

- Change URL from `https://github.com/Mosiwi/Mosiwi-basic-learning-kit-for-arduino.git` to `https://github.com/Mosiwi/Mosiwi-basic-learning-kit.git` (companion to https://github.com/arduino/library-registry/pull/3644)
- Change name from `Mosiwi Basic Learning Kit` to `Mosiwi_Basic_Learning_Kit` (resolves https://github.com/arduino/library-registry/issues/3640)

Since the name change operation on the database is actually a removal followed by automated re-indexing on the next job run, the URL update will occur as a matter of course. For this reason, the only operation required from the backend maintainer is a standard name change procedure.