### PR TITLE
Update repositories.txt

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -6440,5 +6440,4 @@ https://github.com/skyfroger/RLab
 https://github.com/Frai13/EasIno
 https://github.com/GreenLeafLocal/HydroinoJobMgr
 https://github.com/dev-board-tech/lvglCpp
-https://github.com/Arduino-Library-Collection/DC-Motor-Engine-Control
 https://github.com/Arduino-Library-Collection/Engine-Control


### PR DESCRIPTION
**Reason for removing this Library**

This library is a duplicate of [`Engine Control`](https://github.com/Arduino-Library-Collection/Engine-Control). I changed the name but I couldn't remove it from the list.