### PR TITLE
Update repositories.txt - one URL changed and one URL removed

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -5129,7 +5129,7 @@ https://github.com/red-scorp/SoftSPIB
 https://github.com/redkea/arduino-library
 https://github.com/redPanther/CQRobotTDS
 https://github.com/regimantas/Oversampling
-https://github.com/rei-vilo/PDLS_EXT3_Basic
+https://github.com/rei-vilo/PDLS_EXT3_Basic_Global
 https://github.com/rei-vilo/PDLS_EXT3_Basic_Fast
 https://github.com/rei-vilo/PDLS_EXT3_Basic_Touch
 https://github.com/remicaumette/esp8266-redis
@@ -6430,7 +6430,6 @@ https://github.com/boeserfrosch/GuL_TI_Humidity
 https://github.com/Zeppelin500/MBusinoLib
 https://github.com/m5stack/M5Unit-ToF4M
 https://github.com/MOMIZICH/Shift_Register_Controller
-https://github.com/rei-vilo/PDLS_EXT3_Basic_Fast_152
 https://github.com/franeum/MicroMidiDevices
 https://github.com/franeum/TI_SN76489
 https://github.com/pxsty0/deneyapkart.agent.lib


### PR DESCRIPTION
* Changed https://github.com/rei-vilo/PDLS_EXT3_Basic to https://github.com/rei-vilo/PDLS_EXT3_Basic_Global for consistency

* Removed https://github.com/rei-vilo/PDLS_EXT3_Basic_Fast_152 
The https://github.com/rei-vilo/PDLS_EXT3_Basic_Fast_152 is actually merged into https://github.com/rei-vilo/PDLS_EXT3_Basic_Fast

Thank you!