### PR TITLE
Remove "DC Motor Engine Control"

### DIFF
--- a/registry.txt
+++ b/registry.txt
@@ -6541,5 +6541,4 @@ https://github.com/facts-engineering/PCF8563_RTC.git|Contributed|PCF8563_RTC
 https://github.com/facts-engineering/AT24MAC_EEPROM.git|Contributed|ATMAC_EEPROM
 https://github.com/dejwk/roo_scheduler.git|Contributed|roo_scheduler
 https://github.com/GreenLeafLocal/HydroinoJobMgr.git|Contributed|HydroinoJobMgr
-https://github.com/Arduino-Library-Collection/DC-Motor-Engine-Control.git|Contributed|DC Motor Engine Control
 https://github.com/Arduino-Library-Collection/Engine-Control.git|Contributed|Engine Control


### PR DESCRIPTION
Companion to https://github.com/arduino/library-registry/pull/3664