### PR TITLE
Update URL of "IoT_Modules-Buttons" in repository list

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -3746,7 +3746,7 @@ https://github.com/gpb01/NVSRAM
 https://github.com/gpb01/SerialCmd
 https://github.com/gpb01/wdt_samd21
 https://github.com/gpoolb/ads1148
-https://github.com/gq97a6/IoT_Modules-Buttons
+https://github.com/gq97a6/arduino_buttons
 https://github.com/grafana/arduino-prom-loki-transport
 https://github.com/grafana/arduino-snappy-proto
 https://github.com/grafana/loki-arduino


### PR DESCRIPTION
Resubmission of https://github.com/arduino/library-registry/pull/3672, which was closed without reason by the library maintainer and could not be reopened due to deletion of the head.