### PR TITLE
Update name and URL of "DirectCurrent_Motor_Module"

### DIFF
--- a/registry.txt
+++ b/registry.txt
@@ -6540,7 +6540,7 @@ https://github.com/facts-engineering/PCF8563_RTC.git|Contributed|PCF8563_RTC
 https://github.com/facts-engineering/AT24MAC_EEPROM.git|Contributed|ATMAC_EEPROM
 https://github.com/dejwk/roo_scheduler.git|Contributed|roo_scheduler
 https://github.com/GreenLeafLocal/HydroinoJobMgr.git|Contributed|HydroinoJobMgr
-https://github.com/Arduino-Library-Collection/Engine-Control.git|Contributed|Engine Control
+https://github.com/Arduino-Library-Collection/Engine-Control.git|Contributed|DirectCurrent_Motor_Module
 https://github.com/hoeken/PsychicHttp.git|Contributed|PsychicHttp
 https://github.com/rm5248/m95-eeprom-arduino.git|Contributed|M95_EEPROM
 https://github.com/DefHam140/IOTClient.git|Contributed|IOTClient

--- a/registry.txt
+++ b/registry.txt
@@ -6540,7 +6540,7 @@ https://github.com/facts-engineering/PCF8563_RTC.git|Contributed|PCF8563_RTC
 https://github.com/facts-engineering/AT24MAC_EEPROM.git|Contributed|ATMAC_EEPROM
 https://github.com/dejwk/roo_scheduler.git|Contributed|roo_scheduler
 https://github.com/GreenLeafLocal/HydroinoJobMgr.git|Contributed|HydroinoJobMgr
-https://github.com/Arduino-Library-Collection/Engine-Control.git|Contributed|DirectCurrent_Motor_Module
+https://github.com/arduino279/DirectCurrent-Motor-Module.git|Contributed|DirectCurrent_Motor_Module
 https://github.com/hoeken/PsychicHttp.git|Contributed|PsychicHttp
 https://github.com/rm5248/m95-eeprom-arduino.git|Contributed|M95_EEPROM
 https://github.com/DefHam140/IOTClient.git|Contributed|IOTClient


### PR DESCRIPTION
This PR consists of two changes:

- Change URL from `https://github.com/Arduino-Library-Collection/Engine-Control.git` to `https://github.com/arduino279/DirectCurrent-Motor-Module.git` (companion to https://github.com/arduino/library-registry/pull/3706)
- Change name from `Engine Control` to `DirectCurrent_Motor_Module` (resolves https://github.com/arduino/library-registry/issues/3704)

Since the name change operation on the database is actually a removal followed by automated re-indexing on the next job run, the URL update will occur as a matter of course. For this reason, the only operation required from the backend maintainer is a standard name change procedure.