### PR TITLE
Update name and URL of "nodepp"

### DIFF
--- a/registry.txt
+++ b/registry.txt
@@ -6105,7 +6105,7 @@ https://github.com/fbiego/chronos-esp32.git|Contributed|ChronosESP32
 https://github.com/namino-cc/Namino_Library.git|Contributed|Namino_Industrial_Boards
 https://github.com/Aquatwix/PD-10LX-Library.git|Contributed|PD-10LX-Library
 https://github.com/bonezegei/Bonezegei_List.git|Contributed|Bonezegei_List
-https://github.com/NodeppOficial/uNodepp.git|Contributed|nodepp
+https://github.com/NodeppOficial/nodepp-arduino.git|Contributed|nodepp
 https://github.com/fbiego/Timber.git|Contributed|Timber
 https://github.com/DeimosHall/RP2040_CPU_Temperature.git|Contributed|Raspberry Pi Pico CPU Temperature
 https://github.com/RobTillaart/PCA9553.git|Contributed|PCA9553

--- a/registry.txt
+++ b/registry.txt
@@ -6105,7 +6105,7 @@ https://github.com/fbiego/chronos-esp32.git|Contributed|ChronosESP32
 https://github.com/namino-cc/Namino_Library.git|Contributed|Namino_Industrial_Boards
 https://github.com/Aquatwix/PD-10LX-Library.git|Contributed|PD-10LX-Library
 https://github.com/bonezegei/Bonezegei_List.git|Contributed|Bonezegei_List
-https://github.com/NodeppOficial/uNodepp.git|Contributed|uNodepp
+https://github.com/NodeppOficial/uNodepp.git|Contributed|nodepp
 https://github.com/fbiego/Timber.git|Contributed|Timber
 https://github.com/DeimosHall/RP2040_CPU_Temperature.git|Contributed|Raspberry Pi Pico CPU Temperature
 https://github.com/RobTillaart/PCA9553.git|Contributed|PCA9553


### PR DESCRIPTION
This PR consists of two changes:

- Change URL from `https://github.com/NodeppOficial/uNodepp.git` to `https://github.com/NodeppOficial/nodepp-arduino.git` (companion to https://github.com/arduino/library-registry/pull/3756)
- Change name from `uNodepp` to `nodepp` (resolves https://github.com/arduino/library-registry/issues/3780)

Since the name change operation on the database is actually a removal followed by automated re-indexing on the next job run, the URL update will occur as a matter of course. For this reason, the only operation required from the backend maintainer is a standard name change procedure.