### PR TITLE
Update repositories.txt

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -1822,6 +1822,7 @@ https://github.com/RobTillaart/MCP4725
 https://github.com/RobTillaart/MCP9808_RT
 https://github.com/RobTillaart/MCP_ADC
 https://github.com/RobTillaart/MCP_DAC
+https://github.com/RobTillaart/MCP_POT
 https://github.com/RobTillaart/MHZCO2
 https://github.com/RobTillaart/MINMAX
 https://github.com/RobTillaart/ML8511


### PR DESCRIPTION
Add MCP_POT, an Arduino library for MCP41000 and MCP42000 digital potentiometers