### PR TITLE
Removal of YH-Choi-001/Kojay library

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -6179,7 +6179,6 @@ https://github.com/ArtronShop/ArtronShop_SPL06-001
 https://github.com/ArtronShop/ArtronShop_PCF85363A
 https://github.com/suratin27/ESP32_FX1N
 https://github.com/SequentMicrosystems/Sequent-Building-Automation-Library
-https://github.com/YH-Choi-001/Kojay
 https://github.com/facts-engineering/P1AM_Serial
 https://github.com/ChitoKim/mahjongAsst
 https://github.com/ChitoKim/mahjongAsst_U8X8


### PR DESCRIPTION
May I kindly ask to remove this Kojay library from the Arduino libraries registry, since I would like to keep part of my code hidden from the public as secrets of my organisation.