### PR TITLE
Add SmallRTC library.

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -6521,3 +6521,4 @@ https://github.com/AlexandreHiroyuki/DataTome
 https://github.com/afpineda/NuS-NimBLE-Serial
 https://github.com/noranraskin/MT6701
 https://github.com/smolltalk/FileConfig
+https://github.com/GuruSR/SmallRTC


### PR DESCRIPTION
For the ESP32 Watchy, an RTC library that supports the internal ESP32 RTC as well as the 2 supported external RTCs.