### PR TITLE
Add MAVLink library

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -6535,3 +6535,4 @@ https://github.com/karol-brejna-i/RemoteDebug
 https://github.com/thelastoutpostworkshop/gpio_viewer
 https://github.com/firefly-cpp/TCXWriter
 https://github.com/smartpanle/PanelLan_esp32_arduino
+https://github.com/okalachev/mavlink-arduino


### PR DESCRIPTION
MAVLink (https://mavlink.io/en) as an Arduino library.