### PR TITLE
Remove "OtaHelper"

### DIFF
--- a/registry.txt
+++ b/registry.txt
@@ -6613,7 +6613,6 @@ https://github.com/AlexandreHiroyuki/DataTome.git|Contributed|DataTome
 https://github.com/RobTillaart/MS5837.git|Contributed|MS5837
 https://github.com/afpineda/NuS-NimBLE-Serial.git|Contributed|NuS-NimBLE-Serial
 https://github.com/aelmendorf/eeprom_wear_level.git|Contributed|EEPROM_WL
-https://github.com/N4rcissist/OtaHelper.git|Contributed|OtaHelper
 https://github.com/RobTillaart/AD5248.git|Contributed|AD5248
 https://github.com/nhluan37/SerialMP3.git|Contributed|SerialMP3
 https://github.com/RobTillaart/KT0803.git|Contributed|KT0803


### PR DESCRIPTION
Companion to https://github.com/arduino/library-registry/pull/3808