### PR TITLE
Rename and Reversion EdgieD Library

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -177,7 +177,7 @@ https://github.com/KCN-judu/KCN-Utility-Arduino-lib
 https://github.com/addy123d/I2CDisplayController
 https://github.com/ZakKemble/LM73
 https://github.com/felias-fogg/avrCalibrate
-https://github.com/crunchysteve/EdgieD
+https://github.com/crunchysteve/EdgieD-1.0.0
 https://github.com/nthnn/PortaMob
 https://github.com/nthnn/SIM900
 https://github.com/nthnn/microlzw


### PR DESCRIPTION
Now named EdgieD-1.0.0, version is 1.0.0, replacing version 0.0.1