### PR TITLE
Update repositories.txt remove EdgieD forever

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -177,7 +177,6 @@ https://github.com/KCN-judu/KCN-Utility-Arduino-lib
 https://github.com/addy123d/I2CDisplayController
 https://github.com/ZakKemble/LM73
 https://github.com/felias-fogg/avrCalibrate
-https://github.com/crunchysteve/EdgieD
 https://github.com/nthnn/PortaMob
 https://github.com/nthnn/SIM900
 https://github.com/nthnn/microlzw


### PR DESCRIPTION
The library submission process makes no sense to me at all. I quit. This is one of the reasons I moved to PlatformIO, adding libraries is on a project-by-project basis, where you simply add a link to a git repo in the project's platformio.ini file. Even version 2 of Arduino IDE is outdated rubbish.