### PR TITLE
Add WMS7202DigitalPotentiometer to repositories.txt

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -6615,3 +6615,4 @@ https://github.com/mjbots/moteus-arduino
 https://github.com/Xinyuan-LilyGO/LilyGo-T-RGB
 https://gitlab.com/riscv-vega/vega-sensor-libraries/communication/vega_arduinoble
 https://github.com/mathieucarbou/MycilaTaskMonitor
+https://github.com/SALITIBI/WMS7202DigitalPotentiometer


### PR DESCRIPTION
WMS7202DigitalPotentiometer is a library for Arduino that helps controlling the WMS7202 series digital potentiometers made by Winbond. Examples: WMS7202100P and WMS7202050P.