### PR TITLE
Update repositories.txt

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -3348,6 +3348,7 @@ https://github.com/LiquidCGS/FastIMU
 https://github.com/littleBitsman/Asynchrony
 https://github.com/liuyinze/CumulocityHttpDownstream
 https://github.com/liuyinze/CumulocityHttpUpstream
+https://github.com/llschall/ardwloop/tree/main/src/arduino/ardwloop
 https://github.com/llelundberg/EasyWebServer
 https://github.com/lmtreser/Robotec
 https://github.com/lnbits/arduino-nostr/

--- a/repositories.txt
+++ b/repositories.txt
@@ -3348,7 +3348,7 @@ https://github.com/LiquidCGS/FastIMU
 https://github.com/littleBitsman/Asynchrony
 https://github.com/liuyinze/CumulocityHttpDownstream
 https://github.com/liuyinze/CumulocityHttpUpstream
-https://github.com/llschall/ardwloop/tree/main/src/arduino/ardwloop
+https://github.com/llschall/ardwloop-ino
 https://github.com/llelundberg/EasyWebServer
 https://github.com/lmtreser/Robotec
 https://github.com/lnbits/arduino-nostr/


### PR DESCRIPTION
The library repository also contains Java code that operates with the library code. This is why the provided url does not point toe the root of the repository. Thanks in advance :)

EDIT: I created the **ardwloop-ino** repository dedicated to the Arduino code only to fix this.