### PR TITLE
Update name of "st7567sfGK 128x64 i2c LCD driver for Generation Klick"

### DIFF
--- a/registry.txt
+++ b/registry.txt
@@ -6721,7 +6721,7 @@ https://github.com/mathieucarbou/MycilaNTP.git|Contributed|MycilaNTP
 https://github.com/RobTillaart/DS2438.git|Contributed|DS2438
 https://github.com/bonezegei/Bonezegei_DS3231.git|Contributed|Bonezegei_DS3231
 https://github.com/mathieucarbou/MycilaHADiscovery.git|Contributed|MycilaHADiscovery
-https://github.com/holgerlembke/st7567sfGK.git|Contributed|st7567sfGK
+https://github.com/holgerlembke/st7567sfGK.git|Contributed|st7567sfGK 128x64 i2c LCD driver for Generation Klick
 https://github.com/t-oot/ESP32-PTQS1005.git|Contributed|ESP32-PTQS1005
 https://github.com/delta-G/PID_DG.git|Contributed|PID_DG
 https://github.com/mathieucarbou/MycilaMQTT.git|Contributed|MycilaMQTT


### PR DESCRIPTION
Resolves https://github.com/arduino/library-registry/issues/4026