### PR TITLE
Update name and URL of "EByte RF E70 library"

### DIFF
--- a/registry.txt
+++ b/registry.txt
@@ -6703,7 +6703,7 @@ https://github.com/dndg/Finder6M.git|Contributed|Finder 6M for Finder Opta
 https://github.com/kaiaai/LDS.git|Contributed|LDS
 https://github.com/mathieucarbou/MycilaLogger.git|Contributed|MycilaLogger
 https://github.com/mathieucarbou/MycilaConfig.git|Contributed|MycilaConfig
-https://github.com/xreef/EByte_LoRa_E70_Series_Library.git|Contributed|EByte RF E70 library
+https://github.com/xreef/EByte_RF_E70_Series_Library.git|Contributed|EByte RF E70 library
 https://github.com/mathieucarbou/MycilaJSY.git|Contributed|MycilaJSY
 https://github.com/mathieucarbou/ESPAsyncWebServer.git|Contributed|ESP Async WebServer
 https://github.com/mathieucarbou/MycilaESPConnect.git|Contributed|MycilaESPConnect

--- a/registry.txt
+++ b/registry.txt
@@ -6703,7 +6703,7 @@ https://github.com/dndg/Finder6M.git|Contributed|Finder 6M for Finder Opta
 https://github.com/kaiaai/LDS.git|Contributed|LDS
 https://github.com/mathieucarbou/MycilaLogger.git|Contributed|MycilaLogger
 https://github.com/mathieucarbou/MycilaConfig.git|Contributed|MycilaConfig
-https://github.com/xreef/EByte_LoRa_E70_Series_Library.git|Contributed|EByte LoRa E70 library
+https://github.com/xreef/EByte_LoRa_E70_Series_Library.git|Contributed|EByte RF E70 library
 https://github.com/mathieucarbou/MycilaJSY.git|Contributed|MycilaJSY
 https://github.com/mathieucarbou/ESPAsyncWebServer.git|Contributed|ESP Async WebServer
 https://github.com/mathieucarbou/MycilaESPConnect.git|Contributed|MycilaESPConnect


### PR DESCRIPTION
This PR consists of two changes:

- Change URL from `https://github.com/xreef/EByte_LoRa_E70_Series_Library.git` to `https://github.com/xreef/EByte_RF_E70_Series_Library.git` (companion to https://github.com/arduino/library-registry/pull/4035)
- Change name from `EByte LoRa E70 library` to `EByte RF E70 library` (resolves https://github.com/arduino/library-registry/issues/4033)

Since the name change operation on the database is actually a removal followed by automated re-indexing on the next job run, the URL update will occur as a matter of course. For this reason, the only operation required from the backend maintainer is a standard name change procedure.