### PR TITLE
Update URL of "wolfssl"

### DIFF
--- a/registry.txt
+++ b/registry.txt
@@ -4010,7 +4010,7 @@ https://github.com/GyverLibs/GyverPower.git|Contributed|GyverPower
 https://github.com/GyverLibs/GyverOS.git|Contributed|GyverOS
 https://github.com/GyverLibs/buildTime.git|Contributed|buildTime
 https://github.com/abishur/ms5x.git|Contributed|MS5x
-https://github.com/onelife/Arduino_wolfssl.git|Contributed|wolfssl
+https://github.com/wolfSSL/Arduino-wolfSSL.git|Contributed|wolfssl
 https://github.com/asukiaaa/CanBusData-arduino.git|Contributed|CanBusData_asukiaaa
 https://github.com/asukiaaa/CanBusMCP2515-arduino.git|Contributed|CanBusMCP2515_asukiaaa
 https://github.com/DLE-Dev/OttoArduinoLib.git|Contributed|OttoArduinoLib


### PR DESCRIPTION
Companion to https://github.com/arduino/library-registry/pull/4056