### PR TITLE
Remove "SharkJ1939"

### DIFF
--- a/registry.txt
+++ b/registry.txt
@@ -5877,7 +5877,6 @@ https://gitlab.com/riscv-vega/vega-sensor-libraries/display/vega_st7735_and_st77
 https://github.com/SolderedElectronics/Soldered-SIM7020-NB-IoT-Arduino-Library.git|Contributed|Soldered SIM7020 NB-IoT Library
 https://github.com/SequentMicrosystems/Sequent-ESP32-PI-Library.git|Contributed|SM_ESP32Pi
 https://github.com/adafruit/Adafruit_CPFS.git|Recommended|Adafruit CPFS
-https://github.com/jaemannyeh/SharkJ1939.git|Contributed|SharkJ1939
 https://github.com/yashi/Servo328.git|Contributed|Servo328
 https://github.com/SolderedElectronics/Soldered-HX711-ADC-For-Weight-Scales-Arduino-Library.git|Contributed|HX711 SOLDERED
 https://github.com/SolderedElectronics/Soldered-SI114X-sensor-easyC-Arduino-Library.git|Contributed|Soldered SI114X Light Sensor


### PR DESCRIPTION
Companion to https://github.com/arduino/library-registry/pull/4074