### PR TITLE
remove koendv/FloatToString

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -3208,7 +3208,6 @@ https://github.com/KOEGlike/AsyncButton
 https://github.com/koendv/Arduino-RTTStream
 https://github.com/koendv/CheckDS18B20
 https://github.com/koendv/cst816t
-https://github.com/koendv/FloatToString
 https://github.com/koendv/RTTStream
 https://github.com/koendv/SerialWireOutput
 https://github.com/koendv/STM32duino-Semihosting


### PR DESCRIPTION
Intentionally remove https://github.com/koendv/FloatToString to avoid conflict with https://github.com/tedtoal/floatToString