### PR TITLE
Added FixMath to repositories.txt

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -6708,3 +6708,4 @@ https://github.com/braydenanderson2014/UnorderedMap
 https://github.com/qqqlab/madflight
 https://github.com/MJBeltran13/Bucopi_library
 https://github.com/lualtek/buttino-rak
+https://github.com/tomcombriat/FixMath


### PR DESCRIPTION
Added FixMath to repositories.txt, for acceptance in the Arduino library manager.

FixMath, a fixed point arithmetic library targeted for Arduino and cie boards.

This provides an alternative to float and double types, while using integer type under the hood which provides a performance gain for microcontrollers lacking a floating point unit.

Promotion of the internal types is processed internally and at compile time. Using standard operations between FixMath types ensures that precision is kept and overflows are avoided. FixMath tries to be conservative and do not promote types when not needed.