### PR TITLE
Remove "YA_FSM"

### DIFF
--- a/registry.txt
+++ b/registry.txt
@@ -3179,7 +3179,6 @@ https://github.com/hideakitai/ArxStringUtils.git|Contributed|ArxStringUtils
 https://github.com/IGB-Germany/IGB-FlashSst26.git|Contributed|IGB-FlashSst26
 https://github.com/adafruit/Adafruit_ICM20X.git|Contributed|Adafruit ICM20X
 https://github.com/forntoh/LcdMenu.git|Contributed|LcdMenu
-https://github.com/cotestatnt/YA_FSM.git|Contributed|YA_FSM
 https://github.com/hideakitai/PollingTimer.git|Contributed|PollingTimer
 https://github.com/RobTillaart/nibbleArray.git|Contributed|NibbleArray
 https://github.com/RobTillaart/MS5611.git|Contributed|MS5611


### PR DESCRIPTION
Companion to https://github.com/arduino/library-registry/pull/4147