### PR TITLE
Update repositories.txt

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -4970,6 +4970,7 @@ https://github.com/RobTillaart/FastTrig
 https://github.com/RobTillaart/FLE
 https://github.com/RobTillaart/Fletcher
 https://github.com/RobTillaart/float16
+https://github.com/RobTillaart/float16ext
 https://github.com/RobTillaart/Fraction
 https://github.com/RobTillaart/FRAM_I2C
 https://github.com/RobTillaart/FunctionGenerator


### PR DESCRIPTION
Arduino library to implement float16ext data type.
- does not support INF/ NAN 
- uses the full range of internal values -131007..+131007