### PR TITLE
Update url of "Supabase-ESP32"

### DIFF
--- a/registry.txt
+++ b/registry.txt
@@ -6845,7 +6845,7 @@ https://github.com/WitsanuP/WitsanuDotH.git|Contributed|Witsanu
 https://github.com/blackhack/LittleVector.git|Contributed|LittleVector
 https://github.com/ALICHOUCHENE/Qmi8658c.git|Contributed|Qmi8658c
 https://github.com/x-radio/EEBoom.git|Contributed|EEBoom
-https://github.com/zumatt/Supabase-ESP32.git|Contributed|Supabase-ESP32
+https://github.com/zumatt/Supabase-Arduino.git|Contributed|Supabase-ESP32
 https://github.com/ojw5014/OpenJigWare_A.git|Contributed|OpenJigWare_A
 https://github.com/RobTillaart/float16ext.git|Contributed|float16ext
 https://github.com/RobTillaart/MAX520.git|Contributed|MAX520


### PR DESCRIPTION
Companion to https://github.com/arduino/library-registry/pull/4180