### PR TITLE
repositories.txt: update URL for Gizmo

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -1038,7 +1038,7 @@ https://github.com/BestModules-Libraries/BMS36T001
 https://github.com/BestModules-Libraries/BMS56M605
 https://github.com/BestModules-Libraries/BMS81M001
 https://github.com/BestModules-Libraries/BMV23M001
-https://github.com/bestrobotics/ArduinoGizmo
+https://github.com/gizmo-platform/ArduinoGizmo
 https://github.com/Bexin3/GigaScope
 https://github.com/Bexin3/Snowduino
 https://github.com/Bexin3/Speeduino


### PR DESCRIPTION
Due to the repository sprawl that was starting to happen over with all the various components of the Gizmo platform we decided to split it to its own organization where the sprawl wouldn't be an issue.  Its still the same team managing everything, just under a different namespace.