### PR TITLE
Add my arduino Ble ota library

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -6764,3 +6764,4 @@ https://github.com/deangi/UltrasonicSensor
 https://github.com/deangi/RCWL0516
 https://github.com/deangi/IRProxSensor
 https://github.com/deangi/PIRSensor
+https://github.com/faizannazir/ArduinoIDEBle-OTA/


### PR DESCRIPTION
Arduino BLE OTA
Arduino Bluetooth LE Over The Air. Simple library for upload firmware over Bluetooth. Has built in checksum/integrity protection and software/hardware name/version indication.