### PR TITLE
Add FlixPeriph library

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -4229,6 +4229,7 @@ https://github.com/ohad32/FireBase32
 https://github.com/ojx/GigaAudio
 https://github.com/ojx/HTTPed
 https://github.com/okalachev/mavlink-arduino
+https://github.com/okalachev/flixperiph
 https://github.com/OkbaO/KS0108_LCD
 https://github.com/OkbaO/ST7565_LCD
 https://github.com/OladapoAjala/Drive


### PR DESCRIPTION
Library that combines all the needed Arduino drivers for the [Flix educational drone project](https://github.com/okalachev/flix).