### PR TITLE
Added vovagorodok arduino libraries

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -6413,6 +6413,13 @@ https://github.com/vivitainc/VivicoreSerial
 https://github.com/VizIoT-com/viziot-mqtt-client-arduino
 https://github.com/VMinute/RootCertificates
 https://github.com/vonnieda/ScreenUi
+https://github.com/vovagorodok/ArduinoBleChess
+https://github.com/vovagorodok/ArduinoBleOTA
+https://github.com/vovagorodok/ArduinoPin
+https://github.com/vovagorodok/ArduinoStreamLogger
+https://github.com/vovagorodok/ArrayUtils
+https://github.com/vovagorodok/PicChess
+https://github.com/vovagorodok/Servo
 https://github.com/Vrekrer/Vrekrer_scpi_parser
 https://github.com/vshymanskyy/Preferences
 https://github.com/vshymanskyy/StreamDebugger


### PR DESCRIPTION
Added:
- `ArduinoBleChess` - play chess over bluetooth with couple apps (WhitePawn/chess.com/lichess) by universal chess protocol
- `ArduinoBleOTA` - upload/update your project over bluetooth (currently support esp32, atmel sam and more)
- `ArduinoPin` - analog/digital pin classes. Require c++14
- `ArduinoStreamLogger` - add stream based logging system to your project. Require c++17
- `ArrayUtils` - fast array based map and more. Require c++14
- `PicChess` - basic chess engine
- `Servo` - servo library that support position changing speed in order to decrees pic current