### PR TITLE
Add ThingworxESP32 library

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -6785,3 +6785,4 @@ https://github.com/paulino/ha-mqtt-entities
 https://github.com/dattasaurabh82/DFRobot_GDL
 https://github.com/iwandwip/Kinematrix
 https://github.com/floatplane/Ministache
+https://github.com/dvelaren/ThingworxESP32


### PR DESCRIPTION
I created a ESP32 library to be able to send HTTP request to Thingworx Platform 9.x.