### PR TITLE
Remove "AISwitch"

### DIFF
--- a/registry.txt
+++ b/registry.txt
@@ -6735,7 +6735,6 @@ https://github.com/m5stack/M5Atomic-Motion.git|Contributed|M5Atomic-Motion
 https://github.com/m5stack/M5Unit-QRCode.git|Contributed|M5UnitQRCode
 https://github.com/m5stack/M5Unit-Synth.git|Contributed|M5UnitSynth
 https://github.com/BenCestMoiQuoi/I2C_Insarianne.git|Contributed|I2C_Insarianne
-https://github.com/arduino279/AISwitch.git|Contributed|AISwitch
 https://github.com/mkeras/EmbeddedSparkplugNode.git|Contributed|EmbeddedSparkplugNode
 https://github.com/Malih002/Klinik-Encoder.git|Contributed|KLEncoder
 https://github.com/RobTillaart/map2bits.git|Contributed|map2bits


### PR DESCRIPTION
Companion to https://github.com/arduino/library-registry/pull/4245