### PR TITLE
Update name and URL of  "M5PoECAM"

### DIFF
--- a/registry.txt
+++ b/registry.txt
@@ -4461,7 +4461,7 @@ https://github.com/Picovoice/picovoice-arduino-fr.git|Contributed|Picovoice_FR
 https://github.com/Picovoice/porcupine-arduino-de.git|Contributed|Porcupine_DE
 https://github.com/Picovoice/porcupine-arduino-fr.git|Contributed|Porcupine_FR
 https://github.com/Picovoice/porcupine-arduino-es.git|Contributed|Porcupine_ES
-https://github.com/m5stack/PoE_CAM.git|Contributed|M5PoECAM
+https://github.com/m5stack/M5PoECAM.git|Contributed|M5PoECAM
 https://github.com/sensirion/arduino-gas-index-algorithm.git|Contributed|Sensirion Gas Index Algorithm
 https://github.com/sensirion/arduino-i2c-sdp.git|Contributed|Sensirion I2C SDP
 https://github.com/sensirion/arduino-i2c-sgp40.git|Contributed|Sensirion I2C SGP40

--- a/registry.txt
+++ b/registry.txt
@@ -4461,7 +4461,7 @@ https://github.com/Picovoice/picovoice-arduino-fr.git|Contributed|Picovoice_FR
 https://github.com/Picovoice/porcupine-arduino-de.git|Contributed|Porcupine_DE
 https://github.com/Picovoice/porcupine-arduino-fr.git|Contributed|Porcupine_FR
 https://github.com/Picovoice/porcupine-arduino-es.git|Contributed|Porcupine_ES
-https://github.com/m5stack/PoE_CAM.git|Contributed|PoE_CAM
+https://github.com/m5stack/PoE_CAM.git|Contributed|M5PoECAM
 https://github.com/sensirion/arduino-gas-index-algorithm.git|Contributed|Sensirion Gas Index Algorithm
 https://github.com/sensirion/arduino-i2c-sdp.git|Contributed|Sensirion I2C SDP
 https://github.com/sensirion/arduino-i2c-sgp40.git|Contributed|Sensirion I2C SGP40


### PR DESCRIPTION
This PR consists of two changes:

- Change URL from `https://github.com/m5stack/PoE_CAM.git` to `https://github.com/m5stack/M5PoECAM.git` (companion to https://github.com/arduino/library-registry/pull/4325)
- Change name from `PoE_CAM` to `M5PoECAM` (resolves https://github.com/arduino/library-registry/issues/4326)

Since the name change operation on the database is actually a removal followed by automated re-indexing on the next job run, the URL update will occur as a matter of course. For this reason, the only operation required from the backend maintainer is a standard name change procedure.