### PR TITLE
Update URL of "BasicColorLedControl"

### DIFF
--- a/registry.txt
+++ b/registry.txt
@@ -6935,7 +6935,7 @@ https://github.com/chankame/sclm-p105_shield.git|Contributed|sclm-p105_shield
 https://github.com/siroshy/SharpIR.git|Contributed|sharpIRSensor
 https://github.com/tdk-invn-oss/ultrasonic.arduino.CHx01.git|Contributed|CHx01
 https://github.com/1ux/DCF77Decode.git|Contributed|DCF77Decode
-https://github.com/1ux/BasicColorLedControl.git|Contributed|BasicColorLedControl
+https://github.com/1ux/LED_RGB_Control.git|Contributed|BasicColorLedControl
 https://github.com/kashif-baig/StringLib.git|Contributed|StringLib
 https://github.com/kashif-baig/MessagingLib.git|Contributed|MessagingLib
 https://github.com/Krookikk/my_STL.git|Contributed|my_STL


### PR DESCRIPTION
Companion to https://github.com/arduino/library-registry/pull/4319