### PR TITLE
Adding bosejis_Types library

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -6848,3 +6848,4 @@ https://github.com/stm32duino/X-NUCLEO-53L4A3
 https://github.com/stm32duino/VL53L4ED
 https://github.com/arduino-libraries/Arduino_Cellular
 https://github.com/SnailDragon/MightyOhmGeigerCounter
+https://github.com/ardlib/bosejis_Types


### PR DESCRIPTION
# Boseji's Types Library

This library converts given data types into fixed values. Helps in creating the **Types Switch** for **C++ Template functions** and many other applications.

By default Arduino IDE has `-fno-rtti` flag enabled.
Hence `typeid` operator in C++ can't be used.

This library is aimed at solving this issue.