### PR TITLE
Update library urls for ESPEssentials and FastLEDHub

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -6042,8 +6042,8 @@ https://github.com/stm32duino/X-NUCLEO-NFC08A1
 https://github.com/stm32duino/X-NUCLEO-S2868A1
 https://github.com/stm32duino/X-NUCLEO-S2868A2
 https://github.com/stm32duino/X-NUCLEO-S2915A1
-https://github.com/stnkl/ESPEssentials
-https://github.com/stnkl/FastLEDHub
+https://github.com/srwi/ESPEssentials
+https://github.com/srwi/FastLEDHub
 https://github.com/STONElibrary/arduino_lib
 https://github.com/stoneroweast/HoldButton
 https://github.com/Strabox/Easyuino


### PR DESCRIPTION
After a GitHub username change the library urls for ESPEssentials and FastLEDHub have been updated.