### PR TITLE
Update URL of "ESPEssentials"

### DIFF
--- a/registry.txt
+++ b/registry.txt
@@ -3801,7 +3801,7 @@ https://github.com/RobTillaart/Currency.git|Contributed|currency
 https://github.com/Seeed-Studio/Seeed_Arduino_rpcWiFi.git|Contributed|Seeed Arduino rpcWiFi
 https://github.com/mrfaptastic/Easy-IoT-Arduino-CC1101-LORA.git|Contributed|Easy IoT with CC1101 - Sub-1GHz LORA-like
 https://github.com/igorantolic/ai-esp32-rotary-encoder.git|Contributed|Ai Esp32 Rotary Encoder
-https://github.com/stnkl/ESPEssentials.git|Contributed|ESPEssentials
+https://github.com/srwi/ESPEssentials.git|Contributed|ESPEssentials
 https://github.com/heisenware/arduino-vrpc.git|Contributed|VRPC
 https://github.com/gpb01/NVSRAM.git|Contributed|NVSRAM
 https://github.com/viamgr/Arduino-Awesome-Click-Button.git|Contributed|AwesomeClickButton


### PR DESCRIPTION
Companion to https://github.com/arduino/library-registry/pull/4359