### PR TITLE
Add Arduino_LowPowerPortentaH7 library

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -713,6 +713,7 @@ https://github.com/arduino-libraries/Arduino_HS300x
 https://github.com/arduino-libraries/Arduino_HTS221
 https://github.com/arduino-libraries/Arduino_JSON
 https://github.com/arduino-libraries/Arduino_KNN
+https://github.com/arduino-libraries/Arduino_LowPowerPortentaH7
 https://github.com/arduino-libraries/Arduino_LPS22HB
 https://github.com/arduino-libraries/Arduino_LSM6DS3
 https://github.com/arduino-libraries/Arduino_LSM6DSOX


### PR DESCRIPTION
This PR adds the Arduino_LowPowerPortentaH7 library to the index.