### PR TITLE
Update URL of "AISwitch"

### DIFF
--- a/registry.txt
+++ b/registry.txt
@@ -6988,5 +6988,4 @@ https://github.com/FCrins1/WeatherCall.git|Contributed|weathercall
 https://github.com/Subodh-roy2/Modular.git|Contributed|Modular
 https://github.com/Chuque/arduino-CallbackButton.git|Contributed|CallbackButton
 https://github.com/ardlib/bosejis_TWI.git|Contributed|bosejis_TWI
-https://github.com/arduino279/ArduinoAI.git|Contributed|AISwitch
 https://github.com/arduino279/AI.git|Contributed|AISwitch


### PR DESCRIPTION
Companion to https://github.com/arduino/library-registry/pull/4410

---

Note to backend maintainer: the diff of this PR is different from the standard URL change (where the URL field of the entry is changed). The reason is that, due to another submission of the updated URL (https://github.com/arduino/library-registry/commit/cbbe8495f08b68eb65668ec917400cc76c84479b) having been made immediately after the first (https://github.com/arduino/library-registry/commit/8c2e83d6c174f7323dc18fc293141685135424d6), we ended up with duplicate registry entries for "AISwitch". This pull request removes the entry for the old URL `https://github.com/arduino279/ArduinoAI.git`, leaving the other "AISwitch" registry entry for the new URL:

https://github.com/arduino/library-registry/blob/cbbe8495f08b68eb65668ec917400cc76c84479b/registry.txt#L6992

As far as the backend operation is concerned, it should be possible to accomplish the URL change via the standard procedure.