### PR TITLE
Added Heltec_LoRa_OLED_Examples

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -6905,3 +6905,4 @@ https://github.com/Embeddronics-ltd/BLEOTALIBRARY/
 https://github.com/SMotlaq/PI3EQX12908-arduino
 https://github.com/mmarkin/GeoIP
 https://github.com/HighASG936/Mc74hc595a
+https://github.com/cwru-greener-pastures/Heltec_LoRa_OLED_Examples


### PR DESCRIPTION
This provides examples to use Heltec boards with mainstream libraries.