### PR TITLE
Remove "fa3el_khar"

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -1,5 +1,4 @@
 https://github.com/locple/LCDI2C_Multilingual
-https://github.com/brincode/Fa3el_kher
 https://github.com/makerlabvn/BlynkGate
 https://github.com/trongthan210/iMaker-PS2
 https://github.com/makerlabvn/kxnTask


### PR DESCRIPTION
The maintainer of this library has established a pattern of [disrespectful and irresponsible behavior in the arduino/library-registry repository](https://github.com/arduino/library-registry/issues?q=author%3Abrincode+) despite repeated requests to desist. For this reason, Arduino is revoking their privileges of distributing libraries via the Library Manager system.

The library is an identical copy of "[ArduinoMDNS](https://github.com/arduino-libraries/ArduinoMDNS)", except with the addition of a trivial example sketch that doesn't even use the library or have any relation to the subject of MDNS, and the replacement of the readme text with "LOL". So it is clear this was not a good faith attempt to make a legitimate contribution to the Library Manager and the removal will only benefit the Arduino community.