### PR TITLE
Update URL of "LiquidCrystal I2C"

### DIFF
--- a/registry.txt
+++ b/registry.txt
@@ -361,7 +361,7 @@ https://github.com/jonblack/arduino-menusystem.git|Contributed|arduino-menusyste
 https://github.com/jonblack/arduino-fsm.git|Contributed|arduino-fsm
 https://github.com/marcoschwartz/aREST.git|Contributed|aREST
 https://github.com/marcoschwartz/aREST_UI.git|Contributed|aREST UI
-https://github.com/marcoschwartz/LiquidCrystal_I2C.git|Contributed|LiquidCrystal I2C
+https://github.com/johnrickman/LiquidCrystal_I2C.git|Contributed|LiquidCrystal I2C
 https://github.com/mathertel/DMXSerial.git|Contributed|DMXSerial
 https://github.com/mathertel/DMXSerial2.git|Contributed|DMXSerial2
 https://github.com/mathertel/Radio.git|Contributed|Radio


### PR DESCRIPTION
Companion to https://github.com/arduino/library-registry/pull/4479