### PR TITLE
Add Epson_PNL_CE02 library

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -6913,3 +6913,4 @@ https://github.com/Gissio/mcu-max
 https://github.com/RCMgames/BSCD
 https://github.com/ripred/SmartPin
 https://github.com/Pascal2511/TimerUtils
+https://github.com/XavierBrassoud/Arduino_Epson_PNL_CE02


### PR DESCRIPTION
Library to repurposing the control panel of EPSON XP 520/530/540 printers from an Arduino.