### PR TITLE
Adding bosejis_PString Library

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -6893,6 +6893,7 @@ https://github.com/SnailDragon/MightyOhmGeigerCounter
 https://github.com/ardlib/bosejis_Types
 https://github.com/ardlib/bosejis_AMV
 https://github.com/ardlib/bosejis_TWI
+https://github.com/ardlib/bosejis_PString
 https://github.com/kalmak07/SensorNorm
 https://github.com/D-314/IP2368-Arduino-Library
 https://github.com/maxpromer/AX-Mini


### PR DESCRIPTION
**`bosejis_PString`** *("Print to String Library")* is a new lightweight Print-derivative string class that renders text into a character buffer `char[]`.