### PR TITLE
Update URL of "byte-sized-encoder-decoder"

### DIFF
--- a/registry.txt
+++ b/registry.txt
@@ -7009,7 +7009,7 @@ https://github.com/hydra/arduino-ICM42605.git|Contributed|ICM42605
 https://github.com/cwru-greener-pastures/Heltec_LoRa_OLED_Examples.git|Contributed|Heltec_LoRa_OLED_Examples
 https://github.com/Gissio/mcu-renderer.git|Contributed|mcu-renderer
 https://github.com/Gissio/mcu-max.git|Contributed|mcu-max
-https://github.com/RCMgames/BSCD.git|Contributed|byte-sized-encoder-decoder
+https://github.com/RCMgames/BSED.git|Contributed|byte-sized-encoder-decoder
 https://github.com/ZeeDesigns7/AdvancedSerial.git|Contributed|AdvancedSerial
 https://github.com/mechasolution/Mecha_Rfinder10D.git|Contributed|Mechasolution R finder10D Arduino Library
 https://github.com/ripred/SmartPin.git|Contributed|SmartPin


### PR DESCRIPTION
Companion to https://github.com/arduino/library-registry/pull/4501