### PR TITLE
add PicoEncoder to repositories.txt

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -4527,6 +4527,7 @@ https://github.com/plenprojectcompany/PLEN5Stack
 https://github.com/plerup/espsoftwareserial
 https://github.com/ploys/arduino-logger
 https://github.com/plsTrustMeImAnEngineer/StreamAverage
+https://github.com/pmarques-dev/PicoEncoder
 https://github.com/pmassio/ArduinoLMI
 https://github.com/PodgroupConnectivity/PodEnoSim
 https://github.com/poelstra/arduino-multi-button


### PR DESCRIPTION
High resolution quadrature encoder using the PIO on the RP2040
Uses both the step count and transition timings to compute a high resolution speed estimate