### PR TITLE
PID-Autotune library

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -473,6 +473,7 @@ https://github.com/aharshac/StringSplitter
 https://github.com/ahmedarif193/Hlw8032
 https://github.com/ahmedosama07/LineFollowerPID
 https://github.com/ahmedosama07/mDriverL298n
+https://github.com/ahmedosama07/PID-autotune
 https://github.com/AhmedYousryM/NonBlockingSequence
 https://github.com/ahmsec/fork-webbino-ahmsec
 https://github.com/ai-techsystems/arduino


### PR DESCRIPTION
PID-Autotune library is a library for tuning PID using Ziegler-Nichols tuning methods.