### PR TITLE
changing URL of EthernetENC and NetApiHelpers library

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -2813,8 +2813,8 @@ https://github.com/jandelgado/jled
 https://github.com/jandelgado/jled-pca9685-hal
 https://github.com/jandelgado/log4arduino
 https://github.com/jandrassy/ArduinoOTA
-https://github.com/jandrassy/EthernetENC
-https://github.com/jandrassy/NetApiHelpers
+https://github.com/Networking-for-Arduino/EthernetENC
+https://github.com/Networking-for-Arduino/NetApiHelpers
 https://github.com/jandrassy/StreamLib
 https://github.com/jandrassy/TelnetStream
 https://github.com/jandrassy/UnoWiFiDevEdSerial1


### PR DESCRIPTION
I created a github org and I move some libraries there