### PR TITLE
Update URL of "EthernetENC"

### DIFF
--- a/registry.txt
+++ b/registry.txt
@@ -3437,7 +3437,7 @@ https://github.com/TechnoPhysCAL/TGP_Del.git|Contributed|TGP Del
 https://github.com/TechnoPhysCAL/TGP_Ecran.git|Contributed|TGP Ecran
 https://github.com/TechnoPhysCAL/TGP_ProtoTGP.git|Contributed|TGP ProtoTGP
 https://github.com/TechnoPhysCAL/TGP_MenuOLED.git|Contributed|TGP Menu OLED
-https://github.com/jandrassy/EthernetENC.git|Contributed|EthernetENC
+https://github.com/Networking-for-Arduino/EthernetENC.git|Contributed|EthernetENC
 https://github.com/bxparks/AceUtils.git|Contributed|AceUtils
 https://github.com/Quirkbot/QuirkbotArduinoLibrary.git|Contributed|Strawbees Quirkbot
 https://github.com/1IoT/cloud-connectivity-lib.git|Contributed|OneIoT Connectivity


### PR DESCRIPTION
Companion to https://github.com/arduino/library-registry/pull/4525