### PR TITLE
Update URL of "AverageValue"

### DIFF
--- a/registry.txt
+++ b/registry.txt
@@ -2689,7 +2689,7 @@ https://github.com/khoih-prog/ESP_WiFiManager.git|Contributed|ESP_WiFiManager
 https://github.com/adafruit/Adafruit_MCP4728.git|Contributed|Adafruit MCP4728
 https://gitlab.com/yesbotics/libs/arduino/voltmeter.git|Contributed|Voltmeter
 https://gitlab.com/yesbotics/libs/arduino/interval-callback.git|Contributed|IntervalCallback
-https://gitlab.com/yesbotics/libs/arduino/average-value.git|Contributed|AverageValue
+https://github.com/yesbotics/average-value.git|Contributed|AverageValue
 https://gitlab.com/yesbotics/libs/arduino/timeout-callback.git|Contributed|TimeoutCallback
 https://github.com/khoih-prog/ESP_DoubleResetDetector.git|Contributed|ESP_DoubleResetDetector
 https://github.com/Panjkrc/TCS3200_library.git|Contributed|tcs3200


### PR DESCRIPTION
Companion to https://github.com/arduino/library-registry/pull/4512.