### PR TITLE
Update URL of "IntervalCallback"

### DIFF
--- a/registry.txt
+++ b/registry.txt
@@ -2700,7 +2700,7 @@ https://github.com/khoih-prog/ESP_WiFiManager.git|Contributed|ESP_WiFiManager
 https://github.com/adafruit/Adafruit_MCP4728.git|Contributed|Adafruit MCP4728
 https://github.com/Infineon/DPS310-Pressure-Sensor.git|Contributed|DigitalPressureSensor
 https://gitlab.com/yesbotics/libs/arduino/voltmeter.git|Contributed|Voltmeter
-https://gitlab.com/yesbotics/libs/arduino/interval-callback.git|Contributed|IntervalCallback
+https://github.com/yesbotics/interval-callback.git|Contributed|IntervalCallback
 https://gitlab.com/yesbotics/libs/arduino/average-value.git|Contributed|AverageValue
 https://gitlab.com/yesbotics/libs/arduino/timeout-callback.git|Contributed|TimeoutCallback
 https://github.com/khoih-prog/ESP_DoubleResetDetector.git|Contributed|ESP_DoubleResetDetector


### PR DESCRIPTION
Companion to https://github.com/arduino/library-registry/pull/4512.