### PR TITLE
Update URL of "TimeoutCallback"

### DIFF
--- a/registry.txt
+++ b/registry.txt
@@ -2702,7 +2702,7 @@ https://github.com/Infineon/DPS310-Pressure-Sensor.git|Contributed|DigitalPressu
 https://gitlab.com/yesbotics/libs/arduino/voltmeter.git|Contributed|Voltmeter
 https://gitlab.com/yesbotics/libs/arduino/interval-callback.git|Contributed|IntervalCallback
 https://gitlab.com/yesbotics/libs/arduino/average-value.git|Contributed|AverageValue
-https://gitlab.com/yesbotics/libs/arduino/timeout-callback.git|Contributed|TimeoutCallback
+https://github.com/yesbotics/timeout-callback.git|Contributed|TimeoutCallback
 https://github.com/khoih-prog/ESP_DoubleResetDetector.git|Contributed|ESP_DoubleResetDetector
 https://github.com/Panjkrc/TCS3200_library.git|Contributed|tcs3200
 https://github.com/DBS06/CERP_DF_Robot_Wireless_GamePad_V2.git|Contributed|CERP - DF-Robot Wireless GamePad V2.0 for Arduino library


### PR DESCRIPTION
Companion to https://github.com/arduino/library-registry/pull/4512.