### PR TITLE
Update URL of "Voltmeter"

### DIFF
--- a/registry.txt
+++ b/registry.txt
@@ -2687,7 +2687,7 @@ https://github.com/regimantas/Oversampling.git|Contributed|Oversampling
 https://github.com/mehyaa/esp8266-iot-helper.git|Contributed|ESP8266IoTHelper
 https://github.com/khoih-prog/ESP_WiFiManager.git|Contributed|ESP_WiFiManager
 https://github.com/adafruit/Adafruit_MCP4728.git|Contributed|Adafruit MCP4728
-https://gitlab.com/yesbotics/libs/arduino/voltmeter.git|Contributed|Voltmeter
+https://github.com/yesbotics/voltmeter.git|Contributed|Voltmeter
 https://gitlab.com/yesbotics/libs/arduino/interval-callback.git|Contributed|IntervalCallback
 https://gitlab.com/yesbotics/libs/arduino/average-value.git|Contributed|AverageValue
 https://gitlab.com/yesbotics/libs/arduino/timeout-callback.git|Contributed|TimeoutCallback


### PR DESCRIPTION
Companion to https://github.com/arduino/library-registry/pull/4512.