### PR TITLE
Update URL of "SimpleSerialProtocol"

### DIFF
--- a/registry.txt
+++ b/registry.txt
@@ -2720,7 +2720,7 @@ https://github.com/adafruit/Adafruit_MLX90640.git|Contributed|Adafruit MLX90640
 https://github.com/adafruit/Adafruit_SensorLab.git|Contributed|Adafruit Sensor Lab
 https://github.com/adafruit/Adafruit_LSM6DS.git|Contributed|Adafruit LSM6DS
 https://github.com/CGrassin/M62429_Arduino_Library.git|Contributed|M62429 Volume Control Library
-https://gitlab.com/yesbotics/simple-serial-protocol/simple-serial-protocol-arduino.git|Contributed|SimpleSerialProtocol
+https://github.com/yesbotics/simple-serial-protocol-arduino.git|Contributed|SimpleSerialProtocol
 https://github.com/mmuratyilmaz/KAI-Pro.git|Contributed|KAI Pro Library
 https://github.com/thebigpotatoe/Effortless-SPIFFS.git|Contributed|Effortless-SPIFFS
 https://github.com/matusm/Arduino-DataSeriesPod.git|Contributed|DataSeriesPod


### PR DESCRIPTION
Companion to https://github.com/arduino/library-registry/pull/4512.