### PR TITLE
Retire "GSM"

### DIFF
--- a/registry.txt
+++ b/registry.txt
@@ -7,7 +7,7 @@ https://github.com/arduino-libraries/AudioZero.git|Arduino|AudioZero
 https://github.com/arduino-libraries/Bridge.git|Arduino|Bridge
 https://github.com/arduino-libraries/Esplora.git|Arduino|Esplora
 https://github.com/arduino-libraries/Ethernet.git|Arduino|Ethernet
-https://github.com/arduino-libraries/GSM.git|Arduino|GSM
+https://github.com/arduino-libraries/GSM.git|Arduino,Retired|GSM
 https://github.com/arduino-libraries/LiquidCrystal.git|Arduino|LiquidCrystal
 https://github.com/arduino-libraries/Robot_Control.git|Arduino|Robot Control
 https://github.com/arduino-libraries/RobotIRremote.git|Arduino,Retired|Robot IR Remote


### PR DESCRIPTION
[The hardware](https://docs.arduino.cc/retired/shields/arduino-gsm-shield-2-integrated-antenna/) the library supports has not been manufactured for many years and is officially retired.

The [library repository](https://github.com/arduino-libraries/GSM) was archived 2.5 years ago.

---

Resolves https://github.com/arduino/library-registry/issues/4555