### PR TITLE
Update repositories.txt

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -1949,7 +1949,7 @@ https://github.com/dvarrel/ESPAsyncTCP.git
 https://github.com/dvarrel/ESPAsyncWebSrv
 https://github.com/dvarrel/ESPping
 https://github.com/dvarrel/TM1638.git
-https://github.com/dvernier/GDXLib
+https://github.com/VernierST/GDXLib
 https://github.com/dwinhmi/DWIN_DGUS_HMI
 https://github.com/dwrobel/TrivialKalmanFilter
 https://github.com/dxinteractive/AnalogMultiButton


### PR DESCRIPTION
This is a pull request that would require two manual changes:

The first is to update the URL of a library that is already in the Library Manager. The library (GDXLib) was moved from an individual's GitHub account ("dvernier") to the official GitHub account for Vernier Science Education. 

The second request that would require a manual change is for an update of the libraries name. The original library was misnamed in libraries.properties as "GDXLIb". The name has been corrected and updated as "GDXLib". 