### PR TITLE
Update name and URL of "GDXLib"

### DIFF
--- a/registry.txt
+++ b/registry.txt
@@ -3701,7 +3701,7 @@ https://github.com/Seeed-Studio/Seeed_Arduino_SFUD.git|Contributed|Seeed Arduino
 https://github.com/Seeed-Studio/Seeed_Arduino_IR.git|Contributed|Seeed Arduino IR
 https://github.com/jhershey69/MoonStruck.git|Contributed|MoonStruck
 https://github.com/imax9000/Arduino-PID-Library.git|Contributed|PID_v2
-https://github.com/dvernier/GDXLib.git|Contributed|GDXLib
+https://github.com/VernierST/GDXLib.git|Contributed|GDXLib
 https://github.com/GerLech/Talking_Display.git|Contributed|Talking_Display
 https://github.com/telleropnul/BigFont01.git|Contributed|BigFont01
 https://github.com/telleropnul/BigFont01_I2C.git|Contributed|BigFont01_I2C

--- a/registry.txt
+++ b/registry.txt
@@ -3701,7 +3701,7 @@ https://github.com/Seeed-Studio/Seeed_Arduino_SFUD.git|Contributed|Seeed Arduino
 https://github.com/Seeed-Studio/Seeed_Arduino_IR.git|Contributed|Seeed Arduino IR
 https://github.com/jhershey69/MoonStruck.git|Contributed|MoonStruck
 https://github.com/imax9000/Arduino-PID-Library.git|Contributed|PID_v2
-https://github.com/dvernier/GDXLib.git|Contributed|GDXLIb
+https://github.com/dvernier/GDXLib.git|Contributed|GDXLib
 https://github.com/GerLech/Talking_Display.git|Contributed|Talking_Display
 https://github.com/telleropnul/BigFont01.git|Contributed|BigFont01
 https://github.com/telleropnul/BigFont01_I2C.git|Contributed|BigFont01_I2C


### PR DESCRIPTION
This PR consists of two changes:

- Change URL from `https://github.com/dvernier/GDXLib.git` to `https://github.com/VernierST/GDXLib.git` 
- Change name from `GDXLIb` to `GDXLib`

Since the name change operation on the database is actually a removal followed by automated re-indexing on the next job run, the URL update will occur as a matter of course. For this reason, the only operation required from the backend maintainer is a standard name change procedure.

---

Companion to https://github.com/arduino/library-registry/pull/4601