### PR TITLE
Remove "InstagramStats"

### DIFF
--- a/registry.txt
+++ b/registry.txt
@@ -1439,7 +1439,6 @@ https://github.com/TriadSemi/TS8000.git|Contributed|TS8000 Library
 https://github.com/SodaqMoja/Sodaq_LPS22HB.git|Contributed|Sodaq_LPS22HB
 https://github.com/SodaqMoja/Sodaq_HTS221.git|Contributed|Sodaq_HTS221
 https://github.com/udoklein/MLX90393_raw.git|Contributed|MLX90393_raw
-https://github.com/witnessmenow/arduino-instagram-stats.git|Contributed|InstagramStats
 https://github.com/Floessie/frt.git|Contributed|frt
 https://github.com/bxparks/AceButton.git|Contributed|AceButton
 https://github.com/Nredor/ESPNexUpload.git|Contributed|ESPNexUpload


### PR DESCRIPTION
Companion to https://github.com/arduino/library-registry/pull/4609