### PR TITLE
Update name and URL of "EiMOS"

### DIFF
--- a/registry.txt
+++ b/registry.txt
@@ -5935,7 +5935,7 @@ https://github.com/DFRobot/DFRobot_LPUPS.git|Contributed|DFRobot_LPUPS
 https://github.com/DFRobot/DFRobot_RainfallSensor.git|Contributed|DFRobot_RainfallSensor
 https://github.com/DFRobot/DFRobot_RP2040_SCI.git|Contributed|DFRobot_RP2040_SCI
 https://github.com/softplus/GoogleFormPost.git|Contributed|GoogleFormPost
-https://github.com/ChitoKim/mahjongAsst.git|Contributed|EiMOS
+https://github.com/ChitoKim/EiMOS.git|Contributed|EiMOS
 https://github.com/ChitoKim/mahjongAsst_U8X8.git|Contributed|mahjongAsst_U8X8
 https://github.com/schnoog/vl53l0x-arduino-mod.git|Contributed|VL53L0X_mod
 https://github.com/schnoog/Joystick_ESP32S2.git|Contributed|Joystick_ESP32S2

--- a/registry.txt
+++ b/registry.txt
@@ -5935,7 +5935,7 @@ https://github.com/DFRobot/DFRobot_LPUPS.git|Contributed|DFRobot_LPUPS
 https://github.com/DFRobot/DFRobot_RainfallSensor.git|Contributed|DFRobot_RainfallSensor
 https://github.com/DFRobot/DFRobot_RP2040_SCI.git|Contributed|DFRobot_RP2040_SCI
 https://github.com/softplus/GoogleFormPost.git|Contributed|GoogleFormPost
-https://github.com/ChitoKim/mahjongAsst.git|Contributed|mahjongAsst
+https://github.com/ChitoKim/mahjongAsst.git|Contributed|EiMOS
 https://github.com/ChitoKim/mahjongAsst_U8X8.git|Contributed|mahjongAsst_U8X8
 https://github.com/schnoog/vl53l0x-arduino-mod.git|Contributed|VL53L0X_mod
 https://github.com/schnoog/Joystick_ESP32S2.git|Contributed|Joystick_ESP32S2


### PR DESCRIPTION
This PR consists of two changes:

- Change URL from `https://github.com/ChitoKim/mahjongAsst.git` to `https://github.com/ChitoKim/EiMOS.git` (companion to https://github.com/arduino/library-registry/pull/4646)
- Change name from `mahjongAsst` to `EiMOS` (resolves https://github.com/arduino/library-registry/issues/4644)

Since the name change operation on the database is actually a removal followed by automated re-indexing on the next job run, the URL update will occur as a matter of course. For this reason, the only operation required from the backend maintainer is a standard name change procedure.