### PR TITLE
Update name and URL of "EiMOS_U8X8"

### DIFF
--- a/registry.txt
+++ b/registry.txt
@@ -5936,7 +5936,7 @@ https://github.com/DFRobot/DFRobot_RainfallSensor.git|Contributed|DFRobot_Rainfa
 https://github.com/DFRobot/DFRobot_RP2040_SCI.git|Contributed|DFRobot_RP2040_SCI
 https://github.com/softplus/GoogleFormPost.git|Contributed|GoogleFormPost
 https://github.com/ChitoKim/mahjongAsst.git|Contributed|mahjongAsst
-https://github.com/ChitoKim/mahjongAsst_U8X8.git|Contributed|EiMOS_U8X8
+https://github.com/ChitoKim/EiMOS_U8X8.git|Contributed|EiMOS_U8X8
 https://github.com/schnoog/vl53l0x-arduino-mod.git|Contributed|VL53L0X_mod
 https://github.com/schnoog/Joystick_ESP32S2.git|Contributed|Joystick_ESP32S2
 https://github.com/SanteriLindfors/WiFiProvisioner.git|Contributed|WiFiProvisioner

--- a/registry.txt
+++ b/registry.txt
@@ -5936,7 +5936,7 @@ https://github.com/DFRobot/DFRobot_RainfallSensor.git|Contributed|DFRobot_Rainfa
 https://github.com/DFRobot/DFRobot_RP2040_SCI.git|Contributed|DFRobot_RP2040_SCI
 https://github.com/softplus/GoogleFormPost.git|Contributed|GoogleFormPost
 https://github.com/ChitoKim/mahjongAsst.git|Contributed|mahjongAsst
-https://github.com/ChitoKim/mahjongAsst_U8X8.git|Contributed|mahjongAsst_U8X8
+https://github.com/ChitoKim/mahjongAsst_U8X8.git|Contributed|EiMOS_U8X8
 https://github.com/schnoog/vl53l0x-arduino-mod.git|Contributed|VL53L0X_mod
 https://github.com/schnoog/Joystick_ESP32S2.git|Contributed|Joystick_ESP32S2
 https://github.com/SanteriLindfors/WiFiProvisioner.git|Contributed|WiFiProvisioner


### PR DESCRIPTION
This PR consists of two changes:

- Change URL from `https://github.com/ChitoKim/mahjongAsst_U8X8.git` to `https://github.com/ChitoKim/EiMOS_U8X8.git` (companion to https://github.com/arduino/library-registry/pull/4648)
- Change name from `mahjongAsst_U8X8` to `EiMOS_U8X8` (resolves https://github.com/arduino/library-registry/issues/4645)

Since the name change operation on the database is actually a removal followed by automated re-indexing on the next job run, the URL update will occur as a matter of course. For this reason, the only operation required from the backend maintainer is a standard name change procedure.