### PR TITLE
Adding library for amx8x5 compatible RTCs

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -7090,3 +7090,4 @@ https://github.com/IPdotSetAF/EZButton
 https://github.com/shunceyb/MultiMAX6675
 https://github.com/SequentMicrosystems/Sequent-16univin-Library
 https://github.com/calliope-edu/Calliope_Arduino_library
+https://github.com/schreinerman/amx8x5


### PR DESCRIPTION
Adding RTCs library: Ambiq AM0805, AM0815, AM1805 and AM1815; Abracom AB0805, AB0815, AB1805 and AB1815; Microcrystal RV1805