### PR TITLE
Remove Library

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -6733,7 +6733,6 @@ https://github.com/YoupiLab/YLSim800Lib
 https://github.com/YoupiLab/YoupiLabEsp32
 https://github.com/YoupiLab/YoupiLabESP32_IOT
 https://github.com/YoupiLab/YoupiLabEsp8266
-https://github.com/yourapiexpert/ATCommands
 https://github.com/ysard/MyOwnBricks
 https://github.com/ysard/PT6312_VFD_Arduino_Library
 https://github.com/ysard/TCS34725


### PR DESCRIPTION
Removed https://github.com/yourapiexpert/ATCommands as the repository username has changed and the library is old and defunct.