### PR TITLE
SlimLoRa library

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -7121,3 +7121,4 @@ https://github.com/a3510377/MKPin
 https://github.com/a3510377/MKHC595
 https://github.com/AkessonUlrik/RLNode.git
 https://github.com/Pranjal-Prabhat/ultrasonic-arduino
+https://github.com/clavisound/SlimLoRa


### PR DESCRIPTION
Basic LoRaWAN library with respect to ADR and some MAC commands. Tested with AVR32u4 TTN and Helium and OTAA. ABP is untested.