### PR TITLE
Infrared receiver library

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -7128,3 +7128,4 @@ https://github.com/clavisound/SlimLoRa
 https://github.com/chan1sook/Web3E-jbc
 https://github.com/arkhipenko/PersistentQueue
 https://github.com/Meli0609/I0Servo
+https://github.com/Freenove/Freenove_IR_Lib_for_ESP32


### PR DESCRIPTION
Arduino-ESP32-V3.0.x no longer supports the ESP8266IRremote library, and I found that other IR libraries don't work either. I could only rewrite a library using ESP32's RMT feature.
