### PR TITLE
Change library name

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -93,7 +93,7 @@ https://github.com/2taras/espwifiarduino_ide_lib
 https://github.com/x0x0200/VARSTEP_ultrasonic
 https://github.com/StefanHerald/Timing
 https://github.com/tdk-invn-oss/pressure.arduino.ICP201XX
-https://github.com/DigitalCodesign/DC-Core-Library
+https://github.com/DigitalCodesign/MentorBit-Library
 https://github.com/tabahi/ESP-Wifi-Config
 https://github.com/tabahi/TabahiConsole
 https://github.com/karolis1115/FTPduino


### PR DESCRIPTION
We need to change the library name because a rebranding of the product associated to the library.