### PR TITLE
Update name and URL of "MentorBit-Library"

### DIFF
--- a/registry.txt
+++ b/registry.txt
@@ -6798,7 +6798,7 @@ https://github.com/tabahi/TabahiConsole.git|Contributed|TabahiConsole
 https://github.com/tabahi/ESP-Wifi-Config.git|Contributed|ESP-Wifi-Config
 https://github.com/mathieucarbou/MycilaPZEM004Tv3.git|Contributed|MycilaPZEM004Tv3
 https://github.com/koendv/FloatToAscii.git|Contributed|FloatToAscii
-https://github.com/DigitalCodesign/DC-Core-Library.git|Contributed|DC-Core-Library
+https://github.com/DigitalCodesign/DC-Core-Library.git|Contributed|MentorBit-Library
 https://github.com/lualtek/buttino-rak.git|Contributed|ButtinoRAK
 https://github.com/tomcombriat/FixMath.git|Contributed|FixMath
 https://github.com/teddokano/EEPROM_STM_Arduino.git|Contributed|EEPROM_STM_Arduino

--- a/registry.txt
+++ b/registry.txt
@@ -6798,7 +6798,7 @@ https://github.com/tabahi/TabahiConsole.git|Contributed|TabahiConsole
 https://github.com/tabahi/ESP-Wifi-Config.git|Contributed|ESP-Wifi-Config
 https://github.com/mathieucarbou/MycilaPZEM004Tv3.git|Contributed|MycilaPZEM004Tv3
 https://github.com/koendv/FloatToAscii.git|Contributed|FloatToAscii
-https://github.com/DigitalCodesign/DC-Core-Library.git|Contributed|MentorBit-Library
+https://github.com/DigitalCodesign/MentorBit-Library.git|Contributed|MentorBit-Library
 https://github.com/lualtek/buttino-rak.git|Contributed|ButtinoRAK
 https://github.com/tomcombriat/FixMath.git|Contributed|FixMath
 https://github.com/teddokano/EEPROM_STM_Arduino.git|Contributed|EEPROM_STM_Arduino


### PR DESCRIPTION
This PR consists of two changes:

- Change URL from `https://github.com/DigitalCodesign/DC-Core-Library.git` to `https://github.com/DigitalCodesign/MentorBit-Library.git` (companion to https://github.com/arduino/library-registry/pull/4750)
- Change name from `DC-Core-Library` to `MentorBit-Library`

Since the name change operation on the database is actually a removal followed by automated re-indexing on the next job run, the URL update will occur as a matter of course. For this reason, the only operation required from the backend maintainer is a standard name change procedure.
