### PR TITLE
Remove AsyncElegantOTA and EasyUI from Registry

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -1010,9 +1010,7 @@ https://github.com/axelelettronica/sme-lsm6ds3-library
 https://github.com/axelelettronica/sme-nxp-st-library
 https://github.com/axelelettronica/sme-rn2483-library
 https://github.com/Aypac/Arduino-TR-064-SOAP-Library
-https://github.com/ayushsharma82/AsyncElegantOTA
 https://github.com/ayushsharma82/EasyDDNS
-https://github.com/ayushsharma82/EasyUI
 https://github.com/ayushsharma82/ElegantOTA
 https://github.com/ayushsharma82/ESP-DASH
 https://github.com/ayushsharma82/ESPConnect


### PR DESCRIPTION
This PR removes my `AsyncElegantOTA` and `EasyUI` libraries from this PR.

It's completely intentional and these libraries are not being maintained anymore (deprecated).