### PR TITLE
Remove icm45688p support

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -11,7 +11,6 @@ https://github.com/spaziochirale/Chirale_TensorFlowLite
 https://github.com/tdk-invn-oss/motion.arduino.ICM42670S
 https://github.com/eloquentarduino/arduino-WebTerminal
 https://github.com/michaelnixonau/MaxLedControl
-https://github.com/tdk-invn-oss/motion.arduino.ICM45688P
 https://github.com/tdk-invn-oss/motion.arduino.ICM45686
 https://github.com/tdk-invn-oss/motion.arduino.ICM45605
 https://github.com/alexi-c/Primsteppermotor


### PR DESCRIPTION
Hello

this PR removes the support for TDK icm45688p sensor, for legal reason.

How is managed the internal copy done by Arduino in https://downloads.arduino.cc/libraries ? Is it deleted automatically, or do we need to create specific request?

 ```json
{
    "name": "ICM45688P",
    "version": "1.0.0",
    "author": "TDK/Invensense",
    "maintainer": "TDK/Invensense",
    "sentence": "Allows to read accelerometer, gyroscope and temperature sensors from an ICM45688P Invensence IMU device.",
    "paragraph": "This library allows to easily configure and log accelerometer, gyroscope and temperature data from an ICM45688P device, using the SPI or the I2C interface. It also provides embedded algorithms such as Tap, Tilt, Step counter, Wake on Motion...",
    "website": "https://github.com/tdk-invn-oss/motion.arduino.ICM45688P",
    "category": "Sensors",
    "architectures": [
        "*"
    ],
    "types": [
        "Contributed"
    ],
    "repository": "https://github.com/tdk-invn-oss/motion.arduino.ICM45688P.git",
    "providesIncludes": [
        "ICM456xx.h"
    ],
    "url": "https://downloads.arduino.cc/libraries/github.com/tdk-invn-oss/ICM45688P-1.0.0.zip",
    "archiveFileName": "ICM45688P-1.0.0.zip",
    "size": 2078772,
    "checksum": "SHA-256:b66f8a3f71f46822df87fa1d33cfe7d294c34968543e578b25533472c0adca35"
},
```