### PR TITLE
QN8066 Arduino Library

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -7164,3 +7164,5 @@ https://github.com/crane-elec/EthernetSP
 https://github.com/orcadom/DS4
 https://github.com/SeeedJP/wio_cellular
 https://github.com/bitbank2/zlib_turbo
+https://github.com/pu2clr/QN8066
+

--- a/repositories.txt
+++ b/repositories.txt
@@ -1,3 +1,4 @@
+https://github.com/pu2clr/QN8066
 https://github.com/Tympan/Tympan_Library
 https://github.com/microbotsio/CoilCell
 https://github.com/RBEGamer/HLK-LD2450
@@ -7164,5 +7165,4 @@ https://github.com/crane-elec/EthernetSP
 https://github.com/orcadom/DS4
 https://github.com/SeeedJP/wio_cellular
 https://github.com/bitbank2/zlib_turbo
-https://github.com/pu2clr/QN8066
 


### PR DESCRIPTION
The QN8066 library is designed to control the  QN8066 FM Transmitter/Receiver chip. It offers a user-friendly interface that simplifies the integration of the QN8066 chip with Arduino projects, enabling developers to efficiently manage FM transmission and reception capabilities. The library covers essential functionalities, making it a valuable addition for projects involving radio communication.