### PR TITLE
Remove ConsentiumThingsDalton Library

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -1544,7 +1544,6 @@ https://github.com/connornishijima/Pixie
 https://github.com/connornishijima/Pixie_Chroma
 https://github.com/connornishijima/Pixie_Chroma_Lite
 https://github.com/connornishijima/TinySnore
-https://github.com/ConsentiumInc/ConsentiumThingsDalton
 https://github.com/constiko/RV-3028_C7-Arduino_Library
 https://github.com/contrem/arduino-timer
 https://github.com/CONTROLLINO-PLC/CONTROLLINO_Library


### PR DESCRIPTION
Please remove the library ConsentiumThingsDalton from the Arduino Library Index. Repository URL: https://github.com/ConsentiumInc/ConsentiumThingsDalton The `library.properties` file has been updated to mark the library as obsolete.

Thank you.