### PR TITLE
Update URL for jhagas/ESPSupabase

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -2969,7 +2969,6 @@ https://github.com/jgOhYeah/LCDGraph
 https://github.com/jgOhYeah/TunePlayer
 https://github.com/jgromes/RadioLib
 https://github.com/jgvmonteiro/SerialBus
-https://github.com/jhagas/ESP32-Supabase
 https://github.com/JHershey69/DarkSkySevenDay
 https://github.com/jhershey69/MoonStruck
 https://github.com/JHershey69/OpenWeatherOneCall
@@ -7180,3 +7179,4 @@ https://github.com/bitbank2/zlib_turbo
 https://github.com/uutzinger/SavitzkyGolayFilter
 https://github.com/ConsentiumInc/ConsentiumThings
 https://github.com/iavorvel/MyLD2410
+https://github.com/jhagas/ESPSupabase


### PR DESCRIPTION
Initially, this library is designed for ESP32. By the work of contributors, we make this library works for ESP8266, so i change the name of library and the GitHub link, so people will not confuse about this library support.