### PR TITLE
Update name of "ESPSupabase"

### DIFF
--- a/registry.txt
+++ b/registry.txt
@@ -5798,7 +5798,7 @@ https://github.com/adafruit/Adafruit_CAN.git|Contributed|Adafruit CAN
 https://github.com/teddokano/RTC_NXP_Arduino.git|Contributed|RTC_NXP_Arduino
 https://github.com/honvl/Seeed-Xiao-NRF52840-Battery.git|Contributed|Xiao NRF52840 Battery
 https://github.com/Gfy63/NE555.git|Contributed|NE555
-https://github.com/jhagas/ESP32-Supabase.git|Contributed|ESPSupabase
+https://github.com/jhagas/ESPSupabase.git|Contributed|ESPSupabase
 https://github.com/Dhanabhon/TomIBT2.git|Contributed|TomIBT2
 https://github.com/teddokano/LCDDriver_NXP_Arduino.git|Contributed|LCDDrivers_NXP_Arduino
 https://github.com/peanut-king-solution/PeanutKing_ArduinoShield.git|Contributed|PeanutKing ArduinoShield

--- a/registry.txt
+++ b/registry.txt
@@ -5798,7 +5798,7 @@ https://github.com/adafruit/Adafruit_CAN.git|Contributed|Adafruit CAN
 https://github.com/teddokano/RTC_NXP_Arduino.git|Contributed|RTC_NXP_Arduino
 https://github.com/honvl/Seeed-Xiao-NRF52840-Battery.git|Contributed|Xiao NRF52840 Battery
 https://github.com/Gfy63/NE555.git|Contributed|NE555
-https://github.com/jhagas/ESP32-Supabase.git|Contributed|ESP32 Supabase
+https://github.com/jhagas/ESP32-Supabase.git|Contributed|ESPSupabase
 https://github.com/Dhanabhon/TomIBT2.git|Contributed|TomIBT2
 https://github.com/teddokano/LCDDriver_NXP_Arduino.git|Contributed|LCDDrivers_NXP_Arduino
 https://github.com/peanut-king-solution/PeanutKing_ArduinoShield.git|Contributed|PeanutKing ArduinoShield


### PR DESCRIPTION
This PR consists of two changes:

- Change URL from `https://github.com/jhagas/ESP32-Supabase.git` to `https://github.com/jhagas/ESPSupabase.git` (companion to https://github.com/arduino/library-registry/pull/4804)
- Change name from `ESP32 Supabase` to `ESPSupabase`

Since the name change operation on the database is actually a removal followed by automated re-indexing on the next job run, the URL update will occur as a matter of course. For this reason, the only operation required from the backend maintainer is a standard name change procedure.
