### PR TITLE
Add IOXESP32 4-20mA Receiver shield library

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -7180,3 +7180,4 @@ https://github.com/bitbank2/zlib_turbo
 https://github.com/uutzinger/SavitzkyGolayFilter
 https://github.com/ConsentiumInc/ConsentiumThings
 https://github.com/iavorvel/MyLD2410
+https://github.com/ArtronShop/IOXESP32_4-20mA_Receiver


### PR DESCRIPTION
This library is use with 4-20mA Receiver. Tested on ESP32