### PR TITLE
Adding libraries esp32_idf5_https_server and esp32_idf5_https_server_compat

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -1,3 +1,5 @@
+https://github.com/jackjansen/esp32_idf5_https_server
+https://github.com/jackjansen/esp32_idf5_https_server_compat
 https://github.com/jamesy0ung/MPXHZ6116A
 https://github.com/ClemensAtElektor/Elektor_AudioDSP
 https://github.com/PowerBroker2/DataLogger


### PR DESCRIPTION
These are forked and renamed and version-upped from the originals, for which the maintainer seems to have become inactive for more than two years. and the fixes in these forks are needed to be able to use the libraries with ESP-IDF v5, which is now the common version.