### PR TITLE
Remove "ArdUAV"

### DIFF
--- a/registry.txt
+++ b/registry.txt
@@ -2454,7 +2454,6 @@ https://github.com/beegee-tokyo/SX126x-Arduino.git|Contributed|SX126x-Arduino
 https://github.com/jonnieZG/LinkedPointerList.git|Contributed|LinkedPointerList
 https://github.com/skx/Z80RetroShield.git|Contributed|Z80RetroShield
 https://github.com/kigster/back-seat-driver.git|Contributed|BackSeatDriver
-https://github.com/PowerBroker2/ArdUAV.git|Contributed|ArdUAV
 https://github.com/adafruit/Adafruit_DotStarMatrix.git|Contributed|Adafruit DotStarMatrix
 https://github.com/Isaranu/Senses_NBIoT.git|Contributed|Senses_NBIoT
 https://github.com/a7md0/WakeOnLan.git|Contributed|WakeOnLan


### PR DESCRIPTION
Companion to https://github.com/arduino/library-registry/pull/4878