### PR TITLE
Remove "NEO-6M_GPS"

### DIFF
--- a/registry.txt
+++ b/registry.txt
@@ -2635,7 +2635,6 @@ https://github.com/adafruit/Adafruit_9DOF.git|Contributed|Adafruit 9DOF
 https://github.com/ArminJo/ATtinySerialOut.git|Contributed|ATtinySerialOut
 https://github.com/u-fire/uFire_PAR.git|Contributed|uFire PAR Sensor
 https://github.com/MHotchin/YAAWS.git|Contributed|YAAWS
-https://github.com/PowerBroker2/NEO-6M_GPS.git|Contributed|NEO-6M_GPS
 https://github.com/PowerBroker2/DFPlayerMini_Fast.git|Contributed|DFPlayerMini_Fast
 https://github.com/mickey9801/MultiButtons.git|Contributed|MultiButtons
 https://github.com/mickey9801/BlinkControl.git|Contributed|BlinkControl


### PR DESCRIPTION
Companion to https://github.com/arduino/library-registry/pull/4878