### PR TITLE
Update URL of "LiquidCrystalIO"

### DIFF
--- a/registry.txt
+++ b/registry.txt
@@ -3001,7 +3001,7 @@ https://github.com/RobTillaart/DHTNew.git|Contributed|DHTNEW
 https://github.com/gicking/LIN_master_Arduino.git|Contributed|LIN master emulation with background operation
 https://github.com/RobTillaart/DistanceTable.git|Contributed|DistanceTable
 https://github.com/Nargott/birdhouse_sdk.git|Contributed|BirdhouseSDK
-https://github.com/davetcc/LiquidCrystalIO.git|Contributed|LiquidCrystalIO
+https://github.com/TcMenu/LiquidCrystalIO.git|Contributed|LiquidCrystalIO
 https://github.com/RobTillaart/FastShiftIn.git|Contributed|FastShiftIn
 https://github.com/RobTillaart/FastShiftOut.git|Contributed|FastShiftOut
 https://github.com/Asyasyarif/RFID-Spacecat.git|Contributed|Spacecat


### PR DESCRIPTION
Companion to https://github.com/arduino/library-registry/pull/4854