### PR TITLE
Update URL of "tcMenu"

### DIFF
--- a/registry.txt
+++ b/registry.txt
@@ -3067,7 +3067,7 @@ https://github.com/jmparatte/jm_LCM2004A_I2C.git|Contributed|jm_LCM2004A_I2C
 https://github.com/tanakamasayuki/LinxESP32.git|Contributed|LinxESP32
 https://github.com/saghonfly/SimpleEspNowConnection.git|Contributed|SimpleEspNowConnection
 https://github.com/CelliesProjects/moonPhase-esp32.git|Contributed|MoonPhase
-https://github.com/davetcc/tcMenuLib.git|Contributed|tcMenu
+https://github.com/TcMenu/tcMenuLib.git|Contributed|tcMenu
 https://github.com/ostaquet/Arduino-MQ131-driver.git|Contributed|MQ131 gas sensor
 https://github.com/sparkfun/SparkFun_PHT_MS8607_Arduino_Library.git|Contributed|SparkFun PHT MS8607 Arduino Library
 https://github.com/LAtimes2/InternalTemperature.git|Contributed|InternalTemperature


### PR DESCRIPTION
Companion to https://github.com/arduino/library-registry/pull/4854