### PR TITLE
TimerOne_V2

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -3404,6 +3404,7 @@ https://github.com/kosme/flex_DST
 https://github.com/kosme/timestamp32bits
 https://github.com/kotobuki/SetPoint
 https://github.com/kotwatthana/WebServerFileUpload
+https://github.com/kotwatthana/TimerOne_V2
 https://github.com/kousheekc/Kinematics
 https://github.com/kpn-iot/thingsml-c-library
 https://github.com/KravitzLab/MicrocontrollersForNeuroscience


### PR DESCRIPTION
#TimerOne Library

Paul Stoffregen's modified TimerOne. This version provides 2 main benefits:

1: Optimized inline functions - much faster for the most common usage
2: Support for more boards (including ATTiny85 except for the PWM functionality)

http://www.pjrc.com/teensy/td_libs_TimerOne.html

https://github.com/PaulStoffregen/TimerOne

Original code

http://playground.arduino.cc/Code/Timer1

Open Source License

TimerOne is free software. You can redistribute it and/or modify it under the terms of Creative Commons Attribution 3.0 United States License. To view a copy of this license, visit

http://creativecommons.org/licenses/by/3.0/us/

Paul Stoffregen forked this version from an early copy of TimerOne/TimerThree which was licensed "Creative Commons Attribution 3.0" and has maintained the original "CC BY 3.0 US" license terms.

Other, separately developed updates to TimerOne have been released by other authors under the GNU GPLv2 license. Multiple copies of this library, bearing the same name but distributed under different license terms, is unfortunately confusing. This copy, with nearly all the code redesigned as inline functions, is provided under the "CC BY 3.0 US" license terms.