### PR TITLE
Remove "fdk-aac"

### DIFF
--- a/registry.txt
+++ b/registry.txt
@@ -7326,7 +7326,6 @@ https://github.com/Naguissa/uHexLib.git|Contributed|uHexLib
 https://github.com/ErlTechnologies/ERLtechRobotcontrol.git|Contributed|ERLtechRobotcontrol
 https://github.com/Muhammed-jbareen/Alarm.git|Contributed|Alarm
 https://github.com/pschatzmann/arduino-audio-driver.git|Contributed|audio-driver
-https://github.com/pschatzmann/arduino-fdk-aac.git|Contributed|fdk-aac
 https://github.com/pschatzmann/arduino-libhelix.git|Contributed|libhelix
 https://github.com/pschatzmann/arduino-libflac.git|Contributed|libflac
 https://github.com/pschatzmann/arduino-liblame.git|Contributed|libLAME


### PR DESCRIPTION
Companion to https://github.com/arduino/library-registry/pull/4922