### PR TITLE
Remove "libLAME"

### DIFF
--- a/registry.txt
+++ b/registry.txt
@@ -7329,7 +7329,6 @@ https://github.com/pschatzmann/arduino-audio-driver.git|Contributed|audio-driver
 https://github.com/pschatzmann/arduino-fdk-aac.git|Contributed|fdk-aac
 https://github.com/pschatzmann/arduino-libhelix.git|Contributed|libhelix
 https://github.com/pschatzmann/arduino-libflac.git|Contributed|libflac
-https://github.com/pschatzmann/arduino-liblame.git|Contributed|libLAME
 https://github.com/pschatzmann/arduino-libmad.git|Contributed|libMAD
 https://github.com/pschatzmann/arduino-libopus.git|Contributed|libopus
 https://github.com/pschatzmann/arduino-libsbc.git|Contributed|libsbc


### PR DESCRIPTION
Companion to https://github.com/arduino/library-registry/pull/4922