### PR TITLE
Remove "libopus"

### DIFF
--- a/registry.txt
+++ b/registry.txt
@@ -7331,7 +7331,6 @@ https://github.com/pschatzmann/arduino-libhelix.git|Contributed|libhelix
 https://github.com/pschatzmann/arduino-libflac.git|Contributed|libflac
 https://github.com/pschatzmann/arduino-liblame.git|Contributed|libLAME
 https://github.com/pschatzmann/arduino-libmad.git|Contributed|libMAD
-https://github.com/pschatzmann/arduino-libopus.git|Contributed|libopus
 https://github.com/pschatzmann/arduino-libsbc.git|Contributed|libsbc
 https://github.com/pschatzmann/arduino-libvorbis-tremor.git|Contributed|libvorbisidec
 https://github.com/lhtran114/OnlyTimer.git|Contributed|OnlyTimer


### PR DESCRIPTION
Companion to https://github.com/arduino/library-registry/pull/4922