### PR TITLE
Remove "libsbc"

### DIFF
--- a/registry.txt
+++ b/registry.txt
@@ -7332,7 +7332,6 @@ https://github.com/pschatzmann/arduino-libflac.git|Contributed|libflac
 https://github.com/pschatzmann/arduino-liblame.git|Contributed|libLAME
 https://github.com/pschatzmann/arduino-libmad.git|Contributed|libMAD
 https://github.com/pschatzmann/arduino-libopus.git|Contributed|libopus
-https://github.com/pschatzmann/arduino-libsbc.git|Contributed|libsbc
 https://github.com/pschatzmann/arduino-libvorbis-tremor.git|Contributed|libvorbisidec
 https://github.com/lhtran114/OnlyTimer.git|Contributed|OnlyTimer
 https://github.com/sinricpro/arduino-renesas-sdk.git|Contributed|SinricPro_Renesas


### PR DESCRIPTION
Companion to https://github.com/arduino/library-registry/pull/4922