### PR TITLE
Update URL of "Matrix Mini Library"

### DIFF
--- a/registry.txt
+++ b/registry.txt
@@ -2348,7 +2348,7 @@ https://github.com/shielddx/oatmeal-protocol.git|Contributed|oatmeal-protocol
 https://github.com/peanut-king-solution/PeanutKing_Soccer.git|Contributed|PeanutKing Soccer
 https://github.com/hideakitai/TCS34725.git|Contributed|TCS34725
 https://github.com/matmunk/DS18B20.git|Contributed|DS18B20
-https://github.com/frason5566/MatrixMini.git|Contributed|Matrix Mini Library
+https://github.com/Matrix-Robotics/MatrixMini.git|Contributed|Matrix Mini Library
 https://github.com/allthingstalk/arduino-lorawan-sdk.git|Contributed|AllThingsTalk LoRaWAN SDK
 https://github.com/matmunk/LiquidCrystal_74HC595.git|Contributed|LiquidCrystal_74HC595
 https://github.com/zhenek-kreker/MAX6675.git|Contributed|MAX6675 with hardware SPI


### PR DESCRIPTION
Companion to https://github.com/arduino/library-registry/pull/4930