### PR TITLE
Remove EspNowNetwork

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -3051,7 +3051,6 @@ https://github.com/joeycastillo/OSO_Arduino_LCD
 https://github.com/JoeyStrandnes/Arduino-Toggl-API
 https://github.com/JoeyStrandnes/NST1001_Arduino-Driver
 https://github.com/Johboh/ConnectionHelper
-https://github.com/Johboh/EspNowNetwork
 https://github.com/Johboh/EspNowNetworkHost
 https://github.com/Johboh/EspNowNetworkHostDriver
 https://github.com/Johboh/EspNowNetworkNode


### PR DESCRIPTION
- `EspNowNetwork` used to be a "fat" library, which was built and published as individual libraries to ESP IDF Component Registry and Platform IO Registry using github actions. This, however, is not compatible with Arduino library registry, as each github repo need to be its own library. The `EspNowNetwork` repo has now been split up and replaced with four individual repositories instead:
  - https://github.com/Johboh/EspNowNetworkHost
  - https://github.com/Johboh/EspNowNetworkHostDriver
  - https://github.com/Johboh/EspNowNetworkNode
  - https://github.com/Johboh/EspNowNetworkShared

All of which are already registered in this registry.