### PR TITLE
Update Library Manager reference links in FAQ

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -47,7 +47,7 @@ More information:
 - https://docs.arduino.cc/software/ide-v2/tutorials/ide-v2-installing-a-library#installing-a-library
 - https://docs.arduino.cc/software/ide-v1/tutorials/installing-libraries#using-the-library-manager
 - https://arduino.github.io/arduino-cli/latest/commands/arduino-cli_lib/
-- https://create.arduino.cc/projecthub/Arduino_Genuino/getting-started-with-arduino-web-editor-on-various-platforms-4b3e4a
+- https://docs.arduino.cc/arduino-cloud/guides/editor/#library-manager
 
 ### How is the Library Manager index generated?
 

--- a/FAQ.md
+++ b/FAQ.md
@@ -44,6 +44,7 @@ When a library is [added to the library list](README.md#adding-a-library-to-libr
 
 More information:
 
+- https://docs.arduino.cc/software/ide-v2/tutorials/ide-v2-installing-a-library#installing-a-library
 - https://docs.arduino.cc/software/ide-v1/tutorials/installing-libraries#using-the-library-manager
 - https://arduino.github.io/arduino-cli/latest/commands/arduino-cli_lib/
 - https://create.arduino.cc/projecthub/Arduino_Genuino/getting-started-with-arduino-web-editor-on-various-platforms-4b3e4a


### PR DESCRIPTION
The FAQ contains an introduction to the Arduino Library Manager. This is supplemented with a list of links to references
about the Library Manager interface in each of the Arduino development tools.

The never ending churn of the Arduino IDE website structure resulted in the breakage of the link to the Arduino Cloud
reference. It is hereby updated to point to the replacement page.