### PR TITLE
Add Spartan Edge Accelerator ESP32 boot library

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -7263,3 +7263,4 @@ https://github.com/iamfaraz/Waveshare_ST7262_LVGL
 https://github.com/Danzo-Systems/FM25060_Library
 https://github.com/DouglasFlores-fun/SimpleLogger
 https://github.com/KobaProduction/AvrFHT
+https://github.com/cgobat/spartan-edge-esp32-boot/


### PR DESCRIPTION
Relevant [Seeed Studio Wiki page](https://wiki.seeedstudio.com/Spartan-Edge-Accelerator-Board/#spartan-edge-accelerator-board-esp32-boot)

Sourced from [Pillar1989/spartan-edge-esp32-boot](https://github.com/Pillar1989/spartan-edge-esp32-boot) and [marsfan/spartan-edge-esp32-boot](https://github.com/marsfan/spartan-edge-esp32-boot), with bookkeeping updates (version bumps and tagging).