### PR TITLE
Adding avandalen/avdweb_CodeDebugScope

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -7268,3 +7268,4 @@ https://github.com/KobaProduction/AvrFHT
 https://github.com/cgobat/spartan-edge-esp32-boot/
 https://github.com/sierramike/HomeAssistantMQTT
 https://github.com/DannyRavi/AD7747
+https://github.com/avandalen/avdweb_CodeDebugScope


### PR DESCRIPTION
Adding a library `avandalen/avdweb_CodeDebugScope` for helping with code debugging.