### PR TITLE
Add filters library

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -1,3 +1,4 @@
+https://github.com/JonHub/Filters
 https://github.com/semilimes/semilimes_mcu_sdk
 https://github.com/zwieblum/ch32_deep_sleep
 https://github.com/microbotsio/CodeCell


### PR DESCRIPTION
This filtering library isn't mine, but my code is largely dependent on it. Seems the lib has a properties folder and everything needed to be hosted in the library manager, but isn't included yet for some reason. Is it ok to add this "third party" lib for convenience?