### PR TITLE
Update repositories.txt

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -5415,8 +5415,6 @@ https://github.com/ruiseixasm/Robust-EEPROM
 https://github.com/ruiseixasm/Versatile_RotaryEncoder
 https://github.com/ruminize/FlashLightLED
 https://github.com/Rupakpoddar/FirebaseArduino
-https://github.com/Rupakpoddar/ESP32Webhook
-https://github.com/Rupakpoddar/ESP8266Webhook
 https://github.com/rv701/SPL06-007
 https://github.com/RyoKosaka/HelloDrum-arduino-Library
 https://github.com/ryraki/FXLS89xx_Arduino

--- a/repositories.txt
+++ b/repositories.txt
@@ -5412,9 +5412,7 @@ https://github.com/ruiseixasm/Robust-EEPROM
 https://github.com/ruiseixasm/Versatile_RotaryEncoder
 https://github.com/ruminize/FlashLightLED
 https://github.com/Rupakpoddar/FirebaseArduino
-https://github.com/Rupakpoddar/ESP32Firebase
 https://github.com/Rupakpoddar/ESP32Webhook
-https://github.com/Rupakpoddar/ESP8266Firebase
 https://github.com/Rupakpoddar/ESP8266Webhook
 https://github.com/rv701/SPL06-007
 https://github.com/RyoKosaka/HelloDrum-arduino-Library


### PR DESCRIPTION
The two deleted libraries have been removed intentionally. They have now been combined into this better version of the library that is more reliable and supports more devices: https://github.com/Rupakpoddar/FirebaseArduino

All three libraries created and managed by the same developer (me).