### PR TITLE
Remove "ESP32CAR"

### DIFF
--- a/registry.txt
+++ b/registry.txt
@@ -7381,5 +7381,4 @@ https://github.com/PowerBroker2/Filters.git|Contributed|DSPFilters
 https://github.com/Rupakpoddar/FirebaseArduino.git|Contributed|Firebase
 https://github.com/ukkz/tiny-key-value-store.git|Contributed|Tiny Key Value Store
 https://github.com/esp-arduino-libs/esp-ui-phone_320_240_stylesheet.git|Contributed|esp-ui-phone_320_240_stylesheet
-https://github.com/MAKIST-EDU/ESP32CAR.git|Contributed|ESP32CAR
 https://github.com/MAKIST-EDU/MakistCar.git|Contributed|ESP32CAR


### PR DESCRIPTION
Companion to https://github.com/arduino/library-registry/pull/5017