### PR TITLE
Update repositories.txt for new URL of CodeDebugScope Library

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -7278,7 +7278,7 @@ https://github.com/KobaProduction/AvrFHT
 https://github.com/cgobat/spartan-edge-esp32-boot/
 https://github.com/sierramike/HomeAssistantMQTT
 https://github.com/DannyRavi/AD7747
-https://github.com/avandalen/avdweb_CodeDebugScope
+https://github.com/avdwebLibraries/avdweb_CodeDebugScope
 https://github.com/LeeLeahy2/R4A_ESP32
 https://github.com/yuri-rage/arduino-i2c-slave
 https://bitbucket.org/jezhill/SyncGenie


### PR DESCRIPTION
Hello,

On behalf of the Author - Albert van Dalen <http://www.avdweb.nl>

Requesting a URL Update the Library `CodeDebugScope`

New Repository Location:

<https://github.com/avdwebLibraries/avdweb_CodeDebugScope>

Kindly help us out.