### PR TITLE
Update URL of "CodeDebugScope"

### DIFF
--- a/registry.txt
+++ b/registry.txt
@@ -7369,7 +7369,7 @@ https://github.com/sierramike/HomeAssistantMQTT.git|Contributed|HomeAssistantMQT
 https://github.com/EduKits/ColourKit.git|Contributed|ColourKit
 https://github.com/microbotsio/CodeCell.git|Contributed|CodeCell
 https://github.com/DannyRavi/AD7747.git|Contributed|AD7747
-https://github.com/avandalen/avdweb_CodeDebugScope.git|Contributed|CodeDebugScope
+https://github.com/avdwebLibraries/avdweb_CodeDebugScope.git|Contributed|CodeDebugScope
 https://github.com/LeeLeahy2/R4A_ESP32.git|Contributed|R4A_ESP32
 https://github.com/zwieblum/ch32_deep_sleep.git|Contributed|CH32_Deep_Sleep
 https://github.com/semilimes/semilimes_mcu_sdk.git|Contributed|semilimes


### PR DESCRIPTION
Companion to https://github.com/arduino/library-registry/pull/5019