### PR TITLE
Remove "ESP8266 Webhook"

### DIFF
--- a/registry.txt
+++ b/registry.txt
@@ -4087,7 +4087,6 @@ https://github.com/sparkfun/SparkFun_SCD4x_Arduino_Library.git|Contributed|Spark
 https://github.com/Silver-Fang/TimersOneForAll.git|Contributed|TimersOneForAll
 https://github.com/Rupakpoddar/ESP8266Firebase.git|Contributed|ESP8266 Firebase
 https://github.com/dmadison/CtrlUtil.git|Contributed|Controller Utilities
-https://github.com/Rupakpoddar/ESP8266Webhook.git|Contributed|ESP8266 Webhook
 https://github.com/wokwi/TinyDebug.git|Contributed|TinyDebug
 https://github.com/chochain/nanoFORTH.git|Contributed|nanoFORTH
 https://github.com/kevinstadler/TCS34725AutoGain.git|Contributed|TCS34725AutoGain


### PR DESCRIPTION
Companion to https://github.com/arduino/library-registry/pull/5005