### PR TITLE
Request to add a library for IMU

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -7276,3 +7276,4 @@ https://github.com/avandalen/avdweb_CodeDebugScope
 https://github.com/LeeLeahy2/R4A_ESP32
 https://github.com/yuri-rage/arduino-i2c-slave
 https://bitbucket.org/jezhill/SyncGenie
+https://github.com/Vegetable-SYC/IMU_Fusion_SYC


### PR DESCRIPTION
This library can be used to obtain the data and data fusion of MPU6050 and QMC5883L. The manufacturers of MPU6050 and QMC5883L rarely update them, which leads to the fact that many Arduino library authors no longer maintain them. However, MPU6050 and QMC5883L are still the sensors that people often come into contact with on the way of learning. In Arduino libraries, I have seen few libraries that integrate the two well. Some libraries are well written, but it is difficult for beginners to use them. So I wrote a simple to use library, in the code file also wrote more comments, easy to use and learn.