### PR TITLE
[skip-changelog] Configure actions/upload-artifact action to upload required hidden files

### DIFF
--- a/.github/workflows/manage-prs.yml
+++ b/.github/workflows/manage-prs.yml
@@ -383,6 +383,7 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           if-no-files-found: error
+          include-hidden-files: true
           path: ${{ env.FAIL_FLAG_PATH }}
           name: ${{ env.CHECK_SUBMISSIONS_FAIL_FLAG_ARTIFACT }}
 


### PR DESCRIPTION
A breaking change was made in the 3.2.1 release of the "actions/upload-artifact" action, without doing a major version bump as would be done in a responsibly maintained project. The action now defaults to not uploading "hidden" files.

The when the workflows fail, it stores information in a file called `.check-submissions-failed`.

The `.` at the start of the `.check-submissions-failed` folder name causes it to now not be uploaded to the workflow artifact. In order to catch such problems, the workflow configures the "actions/upload-artifact" action to fail if no files were uploaded. So in addition to not uploading the artifact, the change in the "actions/upload-artifact" action's behavior also resulted in the workflow runs failing:

Error: No files were found with the provided path: /home/runner/work/_temp/.check-submissions-failed. No artifacts will be uploaded.

The problem is fixed by disabling the "actions/upload-artifact" action's new behavior via the `include-hidden-files` input. After this change, the workflow can once more upload the check-submission-failed file to a workflow artifact as needed.

Related to https://github.com/arduino/tooling-project-assets/pull/513