### PR TITLE
Update name and URL of "24s02ya__M24SR02-Y"

### DIFF
--- a/registry.txt
+++ b/registry.txt
@@ -7412,4 +7412,4 @@ https://github.com/GyverLibs/AutoOTA.git|Contributed|AutoOTA
 https://github.com/Domochip/Palazzetti.git|Contributed|Palazzetti
 https://github.com/0015/LVGL_Joystick.git|Contributed|Virtual Joystick for LVGL
 https://github.com/zoho/zoho-iot-sdk-arduino.git|Contributed|ZOHO-IOT-SDK
-https://github.com/AndreiOp235/24s02ya__M24SR02-Y_Library.git|Contributed|24s02ya__M24SR02-Y_Library
+https://github.com/AndreiOp235/24s02ya__M24SR02-Y_Library.git|Contributed|24s02ya__M24SR02-Y

--- a/registry.txt
+++ b/registry.txt
@@ -7412,4 +7412,4 @@ https://github.com/GyverLibs/AutoOTA.git|Contributed|AutoOTA
 https://github.com/Domochip/Palazzetti.git|Contributed|Palazzetti
 https://github.com/0015/LVGL_Joystick.git|Contributed|Virtual Joystick for LVGL
 https://github.com/zoho/zoho-iot-sdk-arduino.git|Contributed|ZOHO-IOT-SDK
-https://github.com/AndreiOp235/24s02ya__M24SR02-Y_Library.git|Contributed|24s02ya__M24SR02-Y
+https://github.com/AndreiOp235/24s02ya__M24SR02-Y.git|Contributed|24s02ya__M24SR02-Y


### PR DESCRIPTION
This PR consists of two changes:

- Change URL from `https://github.com/AndreiOp235/24s02ya__M24SR02-Y_Library.git` to `https://github.com/AndreiOp235/24s02ya__M24SR02-Y` (companion to https://github.com/arduino/library-registry/pull/5067)
- Change name from `24s02ya__M24SR02-Y_Library` to `24s02ya__M24SR02-Y`

Since the name change operation on the database is actually a removal followed by automated re-indexing on the next job run, the URL update will occur as a matter of course. For this reason, the only operation required from the backend maintainer is a standard name change procedure.
