### PR TITLE
XRA1405 library

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -1,3 +1,4 @@
+https://github.com/NaveItay/PCA6408A
 https://github.com/NaveItay/NonBlockingDelay
 https://github.com/sub1inear/ArduboyI2C
 https://github.com/shorepine/amy

--- a/repositories.txt
+++ b/repositories.txt
@@ -1,3 +1,4 @@
+https://github.com/NaveItay/XRA1405
 https://github.com/NaveItay/PCA6408A
 https://github.com/NaveItay/NonBlockingDelay
 https://github.com/sub1inear/ArduboyI2C


### PR DESCRIPTION
This pull request adds the XRA1405 library for inclusion in the Arduino Library Manager.
Repository: https://github.com/NaveItay/XRA1405
