### PR TITLE
Add 9704 Launch Pad library to repositories.txt

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -7330,3 +7330,4 @@ https://github.com/ConsentiumInc/EdgeNeuron
 https://github.com/cbm80amiga/DigiFont
 https://github.com/IlikeChooros/EEPROMReader
 https://github.com/GabyGold67/ButtonToSwitch_ESP32
+https://gitlab.com/iridium/9704_launch_pad/arduino_library


### PR DESCRIPTION
Adds 3rd party Arduino library to support the 9704 Launch Pad