### PR TITLE
add SCL3400 lib

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -6642,6 +6642,7 @@ https://github.com/VasilKalchev/LiquidMenu
 https://github.com/VasilKalchev/RGBLED
 https://github.com/VassilyDev/TSBridge
 https://github.com/VassilyDev/TSController
+https://github.com/vasutornjays/SCL3400
 https://github.com/vChavezB/lwip-Arduino
 https://github.com/vChavezB/NoBlockEEPROM
 https://github.com/vChavezB/qpcpp_esp32


### PR DESCRIPTION
SCL3400 lib

This is the initial release of the SCL3400 Arduino library which was modified from the SCL3300 lib (https://github.com/DavidArmstrong/SCL3300), providing support for the SCL3400 inclinometer sensor.