### PR TITLE
The Elio board is a UART communication interface board for Arduino.

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -7330,3 +7330,4 @@ https://github.com/IlikeChooros/EEPROMReader
 https://github.com/GabyGold67/ButtonToSwitch_ESP32
 https://gitlab.com/iridium/9704_launch_pad/arduino_library
 https://github.com/Kernow-Robotics/Guppy
+https://github.com/johnsnow-nam/elio-arduino-example


### PR DESCRIPTION

"The Elio board is a UART communication interface board for Arduino. It is a library for 2 DC motors, 6 servo motors, 1 ultrasonic sensor, and 2 infrared sensors."

https://github.com/johnsnow-nam/elio-arduino-example