### PR TITLE
Add new library DS1307

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -7335,3 +7335,4 @@ https://gitlab.com/iridium/9704_launch_pad/arduino_library
 https://github.com/Kernow-Robotics/Guppy
 https://github.com/johnsnow-nam/elio-arduino-example
 https://github.com/johnosbb/MicroTFLite
+https://github.com/denicsdevices/DS1307


### PR DESCRIPTION
The Denics Devices DS1307 is an Arduino library for interfacing with the DS1307 real time clock chip. This library is an evolution of Bonezegei_DS1307 library by Bonezegei (Jofel Batutay). The library provides functions to read and write the clock time. The library is based on the datasheet of the DS1307 chip from Analog Devices (Analog Devices, 2015). The library is compatible with all Arduino architectures and can be installed from the Arduino library manager. The library also depends on the Wire library for I2C communication.

The library provides way to use different available Hardware I2C instances or pins on 32 bit ARM microcontrollers like RP2040, RP2350, ESP32 etc.