### PR TITLE
Update repositories.txt for new URL of avdweb_Switch Library

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -1068,7 +1068,7 @@ https://github.com/Avamander/arduino-tvout
 https://github.com/avandalen/avdweb_AnalogReadFast
 https://github.com/avandalen/avdweb_FreqPeriodCounter
 https://github.com/avandalen/avdweb_SAMDtimer
-https://github.com/avandalen/avdweb_Switch
+https://github.com/avdwebLibraries/avdweb_Switch
 https://github.com/avandalen/VirtualDelay
 https://github.com/avinabmalla/ESP32_BleSerial
 https://github.com/avishorp/TM1637


### PR DESCRIPTION
Hello,

On behalf of the Author - Albert van Dalen <http://www.avdweb.nl/>

Requesting a URL Update the Library `avdweb_Switch`

New Repository Location:

<https://github.com/avdwebLibraries/avdweb_Switch>

Older Repository Logs available from:

<http://downloads.arduino.cc/libraries/logs/github.com/avandalen/avdweb_Switch/>

Future Repository Logs:

<http://downloads.arduino.cc/libraries/logs/github.com/avdwebLibraries/avdweb_Switch/>

This request is in the same lines as previous #5019 request.

Kindly help us on this.
