### PR TITLE
Upload Freenove_RFID_Lib_for_Pico Library

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -7352,3 +7352,4 @@ https://github.com/AITINKR/AITINKR_AIOT_V2
 https://github.com/guerratron/minIniFS
 https://github.com/arielzw/DPS-Power-Supply-library-for-Arduino
 https://github.com/arastaskiran/RustyKeypad
+https://github.com/Freenove/Freenove_RFID_Lib_for_Pico


### PR DESCRIPTION
Arduino RFID Library for Raspberry Pi Pico