### PR TITLE
Update name and URL of "esp-brookesia"

### DIFF
--- a/registry.txt
+++ b/registry.txt
@@ -7354,7 +7354,7 @@ https://github.com/Johboh/EspNowNetworkHostDriver.git|Contributed|EspNowNetworkH
 https://github.com/Johboh/EspNowNetworkNode.git|Contributed|EspNowNetworkNode
 https://github.com/nthnn/goblin3d.git|Contributed|goblin3d
 https://github.com/JFlores88/SteerBot_TB6612.git|Contributed|SteerBot_TB6612
-https://github.com/espressif/esp-ui.git|Contributed|esp-ui
+https://github.com/espressif/esp-ui.git|Contributed|esp-brookesia
 https://github.com/esp-arduino-libs/esp-ui-phone_480_480_stylesheet.git|Contributed|esp-ui-phone_480_480_stylesheet
 https://github.com/esp-arduino-libs/esp-ui-phone_800_480_stylesheet.git|Contributed|esp-ui-phone_800_480_stylesheet
 https://github.com/esp-arduino-libs/esp-ui-phone_1024_600_stylesheet.git|Contributed|esp-ui-phone_1024_600_stylesheet

--- a/registry.txt
+++ b/registry.txt
@@ -7354,7 +7354,7 @@ https://github.com/Johboh/EspNowNetworkHostDriver.git|Contributed|EspNowNetworkH
 https://github.com/Johboh/EspNowNetworkNode.git|Contributed|EspNowNetworkNode
 https://github.com/nthnn/goblin3d.git|Contributed|goblin3d
 https://github.com/JFlores88/SteerBot_TB6612.git|Contributed|SteerBot_TB6612
-https://github.com/espressif/esp-ui.git|Contributed|esp-brookesia
+https://github.com/espressif/esp-brookesia.git|Contributed|esp-brookesia
 https://github.com/esp-arduino-libs/esp-ui-phone_480_480_stylesheet.git|Contributed|esp-ui-phone_480_480_stylesheet
 https://github.com/esp-arduino-libs/esp-ui-phone_800_480_stylesheet.git|Contributed|esp-ui-phone_800_480_stylesheet
 https://github.com/esp-arduino-libs/esp-ui-phone_1024_600_stylesheet.git|Contributed|esp-ui-phone_1024_600_stylesheet


### PR DESCRIPTION
This PR consists of two changes:

- Change URL from `https://github.com/espressif/esp-ui.git` to `https://github.com/espressif/esp-brookesia.git` (companion to https://github.com/arduino/library-registry/pull/5155)
- Change name from `esp-ui` to `esp-brookesia`

Since the name change operation on the database is actually a removal followed by automated re-indexing on the next job run, the URL update will occur as a matter of course. For this reason, the only operation required from the backend maintainer is a standard name change procedure.

