### PR TITLE
Update URL of "OSP 2wireSPI aospi"

### DIFF
--- a/registry.txt
+++ b/registry.txt
@@ -7238,7 +7238,7 @@ https://github.com/JoJos1220/adafruit_fram_i2C_mock.git|Contributed|adafruit_fra
 https://github.com/nthnn/mdif.git|Contributed|mdif
 https://github.com/MaxMax-embedded/TLE9012_Arduino_Lib.git|Contributed|TLE9012_BMS_IC
 https://github.com/crane-elec/EthernetSP.git|Contributed|EthernetSP
-https://github.com/ams-OSRAM-Group/OSP_aospi.git|Contributed|OSP 2wireSPI aospi
+https://github.com/ams-OSRAM/OSP_aospi.git|Contributed|OSP 2wireSPI aospi
 https://github.com/ams-OSRAM-Group/OSP_aoresult.git|Contributed|OSP ResultCodes aoresult
 https://github.com/RoboCore/RoboCore_Rocky.git|Contributed|RoboCore - Rocky
 https://github.com/RobTillaart/MCP4261.git|Contributed|MCP4261


### PR DESCRIPTION
Companion to https://github.com/arduino/library-registry/pull/5171