### PR TITLE
Update URL of "OSP CommandInterpreter aocmd"

### DIFF
--- a/registry.txt
+++ b/registry.txt
@@ -7342,7 +7342,7 @@ https://github.com/Johboh/ConnectionHelper.git|Contributed|ConnectionHelper
 https://github.com/Johboh/MQTTRemote.git|Contributed|MQTTRemote
 https://github.com/Johboh/HomeAssistantEntities.git|Contributed|HomeAssistantEntities
 https://github.com/Johboh/nlohmann-json.git|Contributed|nlohmann-json
-https://github.com/ams-OSRAM-Group/OSP_aocmd.git|Contributed|OSP CommandInterpreter aocmd
+https://github.com/ams-OSRAM/OSP_aocmd.git|Contributed|OSP CommandInterpreter aocmd
 https://github.com/Danzo-Systems/FM25060_Library.git|Contributed|FM25060
 https://github.com/DouglasFlores-fun/SimpleLogger.git|Contributed|SimpleLogger
 https://github.com/KobaProduction/AvrFHT.git|Contributed|AVR FHT Library


### PR DESCRIPTION
Companion to https://github.com/arduino/library-registry/pull/5171