### PR TITLE
Update URL of "OSP Middleware aomw"

### DIFF
--- a/registry.txt
+++ b/registry.txt
@@ -7403,7 +7403,7 @@ https://github.com/Domochip/Palazzetti.git|Contributed|Palazzetti
 https://github.com/0015/LVGL_Joystick.git|Contributed|Virtual Joystick for LVGL
 https://github.com/zoho/zoho-iot-sdk-arduino.git|Contributed|ZOHO-IOT-SDK
 https://github.com/AndreiOp235/24s02ya__M24SR02-Y.git|Contributed|24s02ya__M24SR02-Y
-https://github.com/ams-OSRAM-Group/OSP_aomw.git|Contributed|OSP Middleware aomw
+https://github.com/ams-OSRAM/OSP_aomw.git|Contributed|OSP Middleware aomw
 https://github.com/ams-OSRAM-Group/OSP_aoui32.git|Contributed|OSP UIDriversOSP32 aoui32
 https://github.com/NaveItay/NonBlockingDelay.git|Contributed|NonBlockingDelay
 https://github.com/arduino-libraries/Arduino_PowerManagement.git|Arduino|Arduino_PowerManagement


### PR DESCRIPTION
Companion to https://github.com/arduino/library-registry/pull/5171