### PR TITLE
Please add bb_truetype

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -7380,3 +7380,4 @@ https://github.com/gpstar81/GPStarAudio-Serial-Library
 https://github.com/moinologics/AsyncTask
 https://github.com/MoCoMakers/esp-fipsy
 https://github.com/galarb/ev3lego.git
+https://github.com/bitbank2/bb_truetype.git


### PR DESCRIPTION
Please add my bb_truetype library to Arduino Library Manager. It's a compact TrueType font rendering library made for embedded devices to be able to draw nice looking fonts directly from TTF files.