### PR TITLE
jsonencoder

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -7400,3 +7400,4 @@ https://github.com/TheSpaceEgg/InfinitePCA9685
 https://github.com/ArtronShop/ArtronShop_HDC302x
 https://github.com/Shiddieqy/MR76_Radar
 https://github.com/styropyr0/MX8650
+https://github.com/styropyr0/JSON_Encoder


### PR DESCRIPTION
A library specifically made for arduino devices to encode JSON strings to URL strings and vice versa.