### PR TITLE
TouchCal

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -7347,3 +7347,4 @@ https://github.com/bgo/oled-ui-lib
 https://github.com/AITINKR/AITINKR_JSON_FIELDS
 https://github.com/AITINKR/AITINKR_AIOT_V2
 https://github.com/guerratron/minIniFS
+https://github.com/guerratron/TouchCal

--- a/repositories.txt
+++ b/repositories.txt
@@ -7346,3 +7346,4 @@ https://github.com/Alexander57rus/ADE7880Energy
 https://github.com/bgo/oled-ui-lib
 https://github.com/AITINKR/AITINKR_JSON_FIELDS
 https://github.com/AITINKR/AITINKR_AIOT_V2
+https://github.com/guerratron/minIniFS


### PR DESCRIPTION
### TouchCal
TouchCal is a (Arduino) Library to touchscreen calibration.  

Based on '**XPT2046_Touchscreen**', supports three working modes. It has utilities for the _TouchScreen_ such as touch calibration, checking valid touch based on pressure, _Lissajous_ figures to check the symmetry of the screen, and even _'Dark-Mode'_ without display..  
It is based on the examples from the '**TFT_eSPI**' library and uses '**XPT2046_Touchscreen**'.  
GNU LGPL v2.1.