### PR TITLE
Please add my bb_epaper library

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -7413,3 +7413,4 @@ https://github.com/sinricpro/esp32-business-sdk
 https://github.com/DBSStore/EIS
 https://github.com/guerratron/TouchCal
 https://github.com/GabyGold67/ButtonToSwitch_AVR
+https://github.com/bitbank2/bb_epaper


### PR DESCRIPTION
The bb_epaper library aims to reduce frustration when working with e-paper displays. A single set of code to talk to all common 24-pin panels.