### PR TITLE
Add dwiBus library to Arduino Library Manager

### DIFF
--- a/libraries/dwiBus.yml
+++ b/libraries/dwiBus.yml
@@ -1,0 +1,9 @@
+name: dwiBus
+version: 1.0.0
+author: Ali Çimen <cimenwd@gmail.com>
+maintainer: Ali Çimen <cimenwd@gmail.com>
+sentence: A UART-based multi-device communication library.
+paragraph: dwiBus provides support for both SoftwareSerial and HardwareSerial. It is compatible with Arduino and ESP32 platforms.
+category: Communication
+url: https://github.com/dralicimen/dwiBus
+architectures: *


### PR DESCRIPTION
This pull request adds the dwiBus library to the Arduino Library Manager. The dwiBus library is designed to facilitate UART communication between multiple devices with support for CRC-based error handling. It is compatible with both Arduino and ESP32 platforms, and it works seamlessly with SoftwareSerial and HardwareSerial interfaces.
Key Features:

    Supports both SoftwareSerial and HardwareSerial.
    CRC-8 based error detection for reliable communication.
    Compatible with Arduino and ESP32 platforms.
    Examples included:
        SerialChat: Demonstrates a basic chat system between two devices.
        DynamicSerialChat: Allows setting device addresses dynamically at runtime.
        Client0x01 and Client0x02: Example clients that send and receive messages based on their unique addresses.

Repository: [dwiBus GitHub Repository](https://github.com/dralicimen/dwiBus)
Steps Taken:

    Forked the Arduino Library Registry repository.
    Created a new branch: add-dwiBus-library.
    Added a dwiBus.yml file with the necessary library metadata.
    Committed the changes and created this pull request.

Please Review:

I kindly request the Arduino team to review this submission. I believe this library will be a valuable addition to the Arduino Library Manager.

By adding this description to your pull request, you'll provide the Arduino team with all the relevant details, making the review process smoother and increasing the chance of approval.