### PR TITLE
Add dwiBus Library to Arduino Library Manager

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -7450,3 +7450,4 @@ https://github.com/Aleksandr-ru/StepperMulti
 https://github.com/nikitagricanuk/CCS811-library-by-ASTRON
 https://github.com/joaoaugustocz/mpu6050_FastAngles
 https://github.com/goodisplayshare/esp32_epd
+https://github.com/dralicimen/dwiBus


### PR DESCRIPTION
This pull request adds the dwiBus library, a communication protocol for Arduino and ESP devices supporting packet fragmentation and CRC-based error handling. The repository URL has been added to repositories.txt. @ArduinoBot