### PR TITLE
add https://github.com/bdlow/IO22_IO_Board

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -1151,6 +1151,7 @@ https://github.com/bblanchon/ArduinoJson
 https://github.com/bblanchon/ArduinoStreamUtils
 https://github.com/bblanchon/ArduinoTrace
 https://github.com/BCISOFT/OvhAPI
+https://github.com/bdlow/IO22_IO_Board
 https://github.com/BeanieBob/GY26Compass
 https://github.com/BEAT-System/SerialCom
 https://github.com/beegee-tokyo/Blues-Minimal-I2C


### PR DESCRIPTION
Drive the Eletechsup IO22 family of I/O boards: IO22D08 and IO22C04. arduino-linted for extra goodness.