### PR TITLE
add FastTimer

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -7458,3 +7458,4 @@ https://github.com/joaoaugustocz/mpu6050_FastAngles
 https://github.com/goodisplayshare/esp32_epd
 https://github.com/dralicimen/dwiBus
 https://github.com/MonHauVD/PlayNote
+https://github.com/1e1/Arduino-FastTimer


### PR DESCRIPTION
Notify at regular intervals to distribute actions over time. Can be extended with an NTP client to obtain a Unix or RFC3339 timestamp.