### PR TITLE
Update repositories.txt

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -1,3 +1,4 @@
+https://github.com/arielzw/DPS-Power-Supply
 https://github.com/cheerlights/cheerlights-arduino-library
 https://github.com/gi0rg0sPapamichail/QuickESPNow
 https://github.com/jjlondonoc/AFE4950-Arduino-Library


### PR DESCRIPTION
Primera versión.

Please rename: 

https://github.com/arielzw/DPS-Power-Supply-library-for-Arduino

to this new URL.