### PR TITLE
Add GoogleSchedular

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -7464,6 +7464,7 @@ https://github.com/goodisplayshare/esp32_epd
 https://github.com/dralicimen/dwiBus
 https://github.com/MonHauVD/PlayNote
 https://github.com/1e1/Arduino-FastTimer
+https://github.com/1e1/Arduino-GoogleSchedular
 https://github.com/UltiBlox/DisplayValueOLED
 https://github.com/UltiBlox/LCDI2C
 https://github.com/UltiBlox/SensorAnalog


### PR DESCRIPTION
Library for reading events title from a Google Calendar
use OAuth 2.0 for limited-input device applications