### PR TITLE
Update URL of "TimersOneForAll"

### DIFF
--- a/registry.txt
+++ b/registry.txt
@@ -4084,7 +4084,7 @@ https://github.com/cvmanjoo/AT24Cxx.git|Contributed|AT24Cxx
 https://github.com/ekkai/WizFi360.git|Contributed|WizFi360
 https://github.com/mathertel/RFCodes.git|Contributed|RFCodes
 https://github.com/sparkfun/SparkFun_SCD4x_Arduino_Library.git|Contributed|SparkFun SCD4x Arduino Library
-https://github.com/Silver-Fang/TimersOneForAll.git|Contributed|TimersOneForAll
+https://github.com/Ebola-Chan-bot/Timers_one_for_all.git|Contributed|TimersOneForAll
 https://github.com/dmadison/CtrlUtil.git|Contributed|Controller Utilities
 https://github.com/wokwi/TinyDebug.git|Contributed|TinyDebug
 https://github.com/chochain/nanoFORTH.git|Contributed|nanoFORTH


### PR DESCRIPTION
Companion to https://github.com/arduino/library-registry/pull/5348