### PR TITLE
Update URL of "IRMP"

### DIFF
--- a/registry.txt
+++ b/registry.txt
@@ -2307,7 +2307,7 @@ https://github.com/SunjunKim/PMW3360.git|Contributed|PMW3360 Module
 https://github.com/lasselukkari/aWOT.git|Contributed|aWOT
 https://github.com/mhorimoto/ELT_S300_HOLLY.git|Contributed|ELT S300 Library
 https://github.com/pstolarz/NRF_HAL.git|Contributed|NRF_HAL
-https://github.com/ukw100/IRMP.git|Contributed|IRMP
+https://github.com/IRMP-org/IRMP.git|Contributed|IRMP
 https://github.com/sparkfun/SparkFun_ICM-20948_ArduinoLibrary.git|Contributed|SparkFun 9DoF IMU Breakout - ICM 20948 - Arduino Library
 https://github.com/mehtajainam/VCNL36687.git|Contributed|VCNL36687
 https://github.com/smartmeio/arancino-library.git|Contributed|Arancino


### PR DESCRIPTION
Companion to https://github.com/arduino/library-registry/pull/5371