### PR TITLE
rename ArduinoLightMDNS to LightMDNS

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -7489,6 +7489,6 @@ https://github.com/SequentMicrosystems/Sequent-16relays-Library
 https://github.com/canusorn/CynoIOT
 https://github.com/GitCoyote/solarfunctions
 https://github.com/TheSpaceEgg/SimpleAD9833
-https://github.com/matthewgream/ArduinoLightMDNS
+https://github.com/matthewgream/LightMDNS
 https://github.com/matthewgream/BluetoothTPMS
 https://github.com/matthewgream/DalyBMSInterface


### PR DESCRIPTION
Taking Arduino out of the repository name as is not in the library name. Should be self explanatory.