### PR TITLE
Update URL of "LightMDNS"

### DIFF
--- a/registry.txt
+++ b/registry.txt
@@ -7587,6 +7587,6 @@ https://github.com/Production3000/mvp3000esp.git|Contributed|MVP3000esp
 https://github.com/fabricioitajuba/Internal_eeprom.git|Contributed|Internal eeprom
 https://github.com/RobTillaart/HX710AB.git|Contributed|HX710AB
 https://github.com/TheSpaceEgg/SimpleAD9833.git|Contributed|SimpleAD9833
-https://github.com/matthewgream/ArduinoLightMDNS.git|Contributed|LightMDNS
+https://github.com/matthewgream/LightMDNS.git|Contributed|LightMDNS
 https://github.com/matthewgream/BluetoothTPMS.git|Contributed|BluetoothTPMS
 https://github.com/matthewgream/DalyBMSInterface.git|Contributed|DalyBMSInterface


### PR DESCRIPTION
Companion to https://github.com/arduino/library-registry/pull/5395