### PR TITLE
Remove "MINDS-i-Trailer"

### DIFF
--- a/registry.txt
+++ b/registry.txt
@@ -7580,7 +7580,6 @@ https://github.com/biomurph/GrayCode.git|Contributed|GrayCode
 https://github.com/UltiBlox/DisplayValueNull.git|Contributed|UltiBlox DisplayValueNull
 https://github.com/VanSilver/LCD595.git|Contributed|LCD595
 https://github.com/gi0rg0sPapamichail/YDLiDaR_GS2.git|Contributed|YDLidar
-https://github.com/MINDS-i/MINDS-i-Trailer.git|Contributed|MINDS-i-Trailer
 https://github.com/RobTillaart/AD8495.git|Contributed|AD8495
 https://github.com/GitCoyote/solarfunctions.git|Contributed|solarfunctions
 https://github.com/Production3000/mvp3000esp.git|Contributed|MVP3000esp


### PR DESCRIPTION
Companion to https://github.com/arduino/library-registry/pull/5400