### PR TITLE
Remove "IP2366"

### DIFF
--- a/registry.txt
+++ b/registry.txt
@@ -7556,7 +7556,6 @@ https://github.com/MonHauVD/PlayNote.git|Contributed|PlayNote
 https://github.com/gi0rg0sPapamichail/QuickESPNow.git|Contributed|QuickESPNow
 https://github.com/1e1/Arduino-FastTimer.git|Contributed|FastTimer
 https://github.com/jjlondonoc/AFE4950-Arduino-Library.git|Contributed|AFE4950
-https://github.com/D-314/IP2366-Arduino-Library.git|Contributed|IP2366
 https://github.com/RobTillaart/SWSPI.git|Contributed|SWSPI
 https://github.com/cheerlights/cheerlights-arduino-library.git|Contributed|CheerLights
 https://github.com/UltiBlox/SerialLogger.git|Contributed|UltiBlox-SerialLogger


### PR DESCRIPTION
Companion to https://github.com/arduino/library-registry/pull/5430