### PR TITLE
remove IP2366 library

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -7202,7 +7202,6 @@ https://github.com/ardlib/bosejis_Bin
 https://github.com/ardlib/bosejis_TWI
 https://github.com/ardlib/bosejis_PString
 https://github.com/kalmak07/SensorNorm
-https://github.com/D-314/IP2366-Arduino-Library
 https://github.com/D-314/IP2368-Arduino-Library
 https://github.com/maxpromer/AX-Mini
 https://github.com/maxpromer/Hanuman


### PR DESCRIPTION
The functionality of the IP2366 and IP2368 libraries has been merged into a IP2368 library (later will be renamed to IP236x, [!5428](https://github.com/arduino/library-registry/issues/5428))
I'm sorry, I accidentally deleted a copy of the library-registry repository, as a result of which the [previous pull request](https://github.com/arduino/library-registry/pull/5430) was automatically closed