### PR TITLE
Add galvo-controller

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -7519,6 +7519,7 @@ https://github.com/BestModules-Libraries/BMV31T001
 https://github.com/BestModules-Libraries/BMV51T001
 https://github.com/BestModules-Libraries/BMV56T123
 https://github.com/georgemihaila/xy2-100
+https://github.com/georgemihaila/galvo-controller
 https://github.com/pschatzmann/TalkiePCM
 https://github.com/YuenNicdao/iParol
 https://github.com/Natpol50/BME280_mini


### PR DESCRIPTION
A library based on the xy2-100 library that turns a device into a serial G code parser in order to control a laser and a galvo