### PR TITLE
The library version cannot be updated to the Arduino library manager

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -7500,3 +7500,4 @@ https://github.com/matthewgream/BluetoothTPMS
 https://github.com/matthewgream/DalyBMSInterface
 https://github.com/MMZBin/Arduino_MacroPad
 https://github.com/jlopezr/arduino-yl800n
+https://github.com/gooddisplayshare/ESP32epd


### PR DESCRIPTION
The Arduino library version has been updated from v1.0.1 to v1.0.2. The library has been updated and the release version has been updated. However, the library manager in Arduino software is still v1.0.1. Could you please find the reason? Thank you~   