### PR TITLE
Added SmartSW libary to the repositories

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -7538,3 +7538,4 @@ https://github.com/Lorandil/uCompression
 https://github.com/DMT-Services/GeoMagnetism
 https://github.com/ConsentiumIoT/ConsentiumStarterKit
 https://github.com/batuhantrkgl/ESP8266-D1_SMTPClient
+https://github.com/technochicken/SmartSW


### PR DESCRIPTION
SmartSW is a libary to easily interface a bunch of RGB CHERRY MX Low profile buttons with this pcb:
https://github.com/technochicken/SmartSW