### PR TITLE
Update URL of "Geekble_LieDetector"

### DIFF
--- a/registry.txt
+++ b/registry.txt
@@ -4178,7 +4178,7 @@ https://github.com/FTTechBrasil/AqualaboSensor.git|Contributed|FTTech Aqualabo S
 https://github.com/guttih/DisplayMenu.git|Contributed|DisplayMenu
 https://github.com/unit-system-exports/unit-system-arduino.git|Contributed|unit-system
 https://github.com/sakabug/Bugtton.git|Contributed|Bugtton
-https://github.com/geekbleofficial/Geekble_LieDetector.git|Contributed|Geekble_LieDetector
+https://github.com/Geekble-Maker/Geekble_LieDetector.git|Contributed|Geekble_LieDetector
 https://github.com/xiongyu0523/AzureRTOS-ThreadX-For-Arduino.git|Contributed|Azure RTOS ThreadX
 https://github.com/techpaul/XMC_Servo.git|Contributed|XMC_Servo
 https://github.com/dhi-nikhil/indhi-lib-arduino-esp32.git|Contributed|indhilib


### PR DESCRIPTION
Companion to https://github.com/arduino/library-registry/pull/5512