### PR TITLE
Remove "GPT_Stepper"

### DIFF
--- a/registry.txt
+++ b/registry.txt
@@ -6649,7 +6649,6 @@ https://github.com/RobTillaart/ADC081S.git|Contributed|ADC081S
 https://github.com/N4rcissist/OtaHelper.git|Contributed|OtaHelper
 https://github.com/PU2REO/PU2REO_Si570.git|Contributed|PU2REO_Si570
 https://github.com/PU2REO/PU2REO_AD9851.git|Contributed|PU2REO_AD9851
-https://github.com/delta-G/GPT_Stepper.git|Contributed|GPT_Stepper
 https://github.com/pk17r/PushButtonTaps.git|Contributed|PushButtonTaps
 https://github.com/RobTillaart/ADC08XS.git|Contributed|ADC08XS
 https://github.com/PaulNTU/Wizibot_VescMotorController.git|Contributed|VescMotorController


### PR DESCRIPTION
Companion to https://github.com/arduino/library-registry/pull/5529