### PR TITLE
Adding LVGL_CYD

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -1,3 +1,4 @@
+https://github.com/ropg/LVGL_CYD
 https://github.com/DigitalCodesign/MentorBit-1Rele
 https://github.com/DigitalCodesign/MentorBit-2Rele
 https://github.com/DigitalCodesign/MentorBit-3LED


### PR DESCRIPTION
Running LVGL on CYD, the Cheap Yellow Display. All the boilerplate stuff. Detects board variants at runtime.