### PR TITLE
Add spi_lcd_read

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -1,3 +1,4 @@
+https://github.com/ropg/spi_lcd_read
 https://github.com/FoltaBozZ/fvs-esp32-bib
 https://github.com/botnroll/BnrOneAPlus
 https://github.com/toaha63/BanglaDuino


### PR DESCRIPTION
Tiny simple library to read data from registers on this class of simple and cheap SPI LCD controllers (ILI9341, ST7789, etc). Can be used for identifying hardware before the actual display driver is initialized. No dependencies other than Arduino SPI.h.