### PR TITLE
Add 7SemiSHT4x_Library to Arduino Library Manager

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -7645,3 +7645,4 @@ https://github.com/bsrahmat/iotNetESP32
 https://github.com/ajangrahmat/ArduMekaWiFi
 https://github.com/eis-interbot/EIS_INTERBOT
 https://github.com/lucaschoeneberg/lw09-dali
+https://github.com/7Semi/7SemiSHT4x_Library

--- a/repositories.txt
+++ b/repositories.txt
@@ -1,3 +1,4 @@
+https://github.com/7Semi/7SemiSHT4x_Library
 https://github.com/Moarbue/incremental-rotary-encoder
 https://github.com/Moarbue/arduino-button
 https://github.com/Moarbue/FIR-Filter
@@ -7645,4 +7646,4 @@ https://github.com/bsrahmat/iotNetESP32
 https://github.com/ajangrahmat/ArduMekaWiFi
 https://github.com/eis-interbot/EIS_INTERBOT
 https://github.com/lucaschoeneberg/lw09-dali
-https://github.com/7Semi/7SemiSHT4x_Library
+


### PR DESCRIPTION
This pull request adds 7SemiSHT4x_Library to the Arduino Library Manager.

- Repository: https://github.com/7Semi/7SemiSHT4x_Library
- Version: 1.0.1
- Description: 7SemiSHT4x_Library is developed to connect SHT40 sensor, making it easier for Arduino users to interface SHT40 sensor to get accurate temperature and humidity. 
- Compliance: The library adheres to the Arduino Library Specification, including a proper folder structure, library.properties file, examples, and license.

Thank you for your consideration!