### PR TITLE
Remove "inIo" from repository list

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -7657,7 +7657,6 @@ https://github.com/ELOWRO/ADS1119
 https://github.com/kelasrobot/KelasRobotIO
 https://github.com/rescenic/rescenicio
 https://github.com/kelasrobot/FonnteArduino
-https://github.com/JokoArdh/inIo
 https://github.com/robbywm/RobbyIO/
 https://github.com/cakraawijaya/MQ2_LPG
 https://github.com/edwiyanto/CreatorKidsIO


### PR DESCRIPTION
This library was created only as a learning exercise and is not of any value to the Arduino community. The submission was made as a "practice test".

So it must be removed from Library Manager.