### PR TITLE
Remove "inIo" registration

### DIFF
--- a/registry.txt
+++ b/registry.txt
@@ -7754,7 +7754,6 @@ https://github.com/roncoa/KeySequence.git|Contributed|KeySequence
 https://github.com/kelasrobot/KelasRobotIO.git|Contributed|KelasRobotIO
 https://github.com/rescenic/rescenicio.git|Contributed|RescenicIO
 https://github.com/kelasrobot/FonnteArduino.git|Contributed|FonnteArduino
-https://github.com/JokoArdh/inIo.git|Contributed|inIo
 https://github.com/robbywm/RobbyIO.git|Contributed|RobbyIO
 https://github.com/cakraawijaya/MQ2_LPG.git|Contributed|MQ2_LPG
 https://github.com/edwiyanto/CreatorKidsIO.git|Contributed|CreatorKidsIO


### PR DESCRIPTION
Companion to https://github.com/arduino/library-registry/pull/5696