### PR TITLE
Remove duplicate "FoonteDuino" from repositories list

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -7667,5 +7667,4 @@ https://github.com/edwiyanto/CreatorKidsIO
 https://github.com/cakraawijaya/ESP_FC28
 https://github.com/CMB27/ModbusSlaveLogic
 https://github.com/wwhai/MOTY-Mini-Temperature-Sensor.git
-https://github.com/kelasrobot/FoonteDuino
 https://github.com/stacknix/stackmq-esp32


### PR DESCRIPTION
The library maintainer irresponsibly submitted the "FonteDuino" library a second time after temporarily changing the repository and library name to "FoonteDuino" in order to circumvent the registry's duplicate checks.

The presence of the duplicate library in Library Manager is harmful, and thus it must be removed.