### PR TITLE
Remove duplicate "FoonteDuino" registration

### DIFF
--- a/registry.txt
+++ b/registry.txt
@@ -7762,6 +7762,5 @@ https://github.com/cakraawijaya/ESP_FC28.git|Contributed|ESP_FC28
 https://github.com/hasenradball/MCP23008-I2C.git|Contributed|MCP23008-I2C
 https://github.com/CMB27/ModbusSlaveLogic.git|Contributed|ModbusSlaveLogic
 https://github.com/hootrhino/MOTY-Mini-Temperature-Sensor.git|Contributed|MOTY-Mini Temperature Sensor
-https://github.com/kelasrobot/FoonteDuino.git|Contributed|FoonteDuino
 https://github.com/7Semi/SevenSemiSHT4x_Lib.git|Contributed|7SemiSHT4x_Lib
 https://github.com/schreibfaul1/ESP32-audioI2S.git|Contributed|ESP32-audioI2S-master


### PR DESCRIPTION
The library maintainer irresponsibly submitted the "FonteDuino" library a second time after temporarily changing the repository and library name to "FoonteDuino" in order to circumvent the registry's duplicate checks.

The presence of the duplicate library in Library Manager is harmful, and thus it must be removed.

---

Companion to https://github.com/arduino/library-registry/pull/5710