### PR TITLE
Remove "7SemiSHT4x_Library" from repositories list

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -4,7 +4,6 @@ https://github.com/hasenradball/MCP23008-I2C
 https://github.com/roncoa/KeySequence
 https://github.com/juanmercadin/ReceptorRF
 https://github.com/valerii-fr/menux
-https://github.com/7Semi/7SemiSHT4x_Library
 https://github.com/Moarbue/incremental-rotary-encoder
 https://github.com/Moarbue/arduino-button
 https://github.com/Moarbue/FIR-Filter


### PR DESCRIPTION
A duplicate copy of the library was later submitted under a different URL and name. So this one must be removed.