### PR TITLE
Remove "7SemiSHT4x_Library"

### DIFF
--- a/registry.txt
+++ b/registry.txt
@@ -7743,7 +7743,6 @@ https://github.com/eis-interbot/EIS_INTERBOT.git|Contributed|EIS_INTERBOT
 https://github.com/m5stack/M5Atomic-EchoBase.git|Contributed|M5Atomic-EchoBase
 https://github.com/Moarbue/incremental-rotary-encoder.git|Contributed|IncRotaryEncoder
 https://github.com/lucaschoeneberg/lw09-dali.git|Contributed|LW09-Dali
-https://github.com/7Semi/7SemiSHT4x_Library.git|Contributed|7SemiSHT4x_Library
 https://github.com/HarrysLabDotNet/nes-controller-interface.git|Contributed|NESControllerInterface
 https://github.com/moononournation/Dev_Device_Pins.git|Contributed|Dev Device Pins
 https://github.com/dndubins/tinyServo85.git|Contributed|tinyServo85


### PR DESCRIPTION
A duplicate copy of the library was later submitted under a different URL and name. So this one must be removed.