### PR TITLE
Update repositories.txt

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -5525,6 +5525,7 @@ https://github.com/RobTillaart/RAIN
 https://github.com/RobTillaart/randomHelpers
 https://github.com/RobTillaart/relativity
 https://github.com/RobTillaart/rotaryDecoder
+https://github.com/RobTillaart/rotaryDecoder8
 https://github.com/RobTillaart/rotaryDecoderSwitch
 https://github.com/RobTillaart/RS485
 https://github.com/RobTillaart/RunAvgWeight


### PR DESCRIPTION
Add rotaryDecoder8, an Arduino library for a PCF8575 based rotary decoder - supports 8 rotary encoders.