### PR TITLE
Add AirNgin ESP32 MQTT Client library

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -7676,3 +7676,4 @@ https://github.com/stacknix/stackmq-esp32
 https://github.com/marekburiak/ESP32_MQTTClient
 https://github.com/levkovigor/PTZProtocolHandler
 https://github.com/Alex-Stone-Github/pepstep
+https://github.com/AirNgin/Airngin-esp32-mqtt-client


### PR DESCRIPTION
This pull request adds the AirNgin ESP32 MQTT Client library to the Arduino Library Manager index.