### PR TITLE
Added Published Web CNCShield

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -7685,3 +7685,4 @@ https://github.com/AirNgin/Airngin-esp32-mqtt-client
 https://github.com/samy101/edge-ai-arduino-library
 https://github.com/robertsonics/WAV_Trigger_Pro_Qwiic_Arduino_Library
 https://github.com/YoavPaz/I2CR-CPP
+https://github.com/Alex-Stone-Github/CNCShield


### PR DESCRIPTION
This is a published version of the CNCShield library, useful for CNC Stepper Motors without GRBR files.