### PR TITLE
Library remove request & Update repositories.txt

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -1,3 +1,4 @@
+https://github.com/7Semi/7SemiSHT4x_Lib
 https://github.com/rjsachse/ESP32-RTSPServer.git
 https://github.com/schreibfaul1/ESP32-audioI2S
 https://github.com/7Semi/SevenSemiSHT4x_Lib


### PR DESCRIPTION
 name: "7SemiSHT4x_Lib"
 repository: "https://github.com/7Semi/7SemiSHT4x_Lib"
 reason: repository URL No longer exist and duplicate library created.