### PR TITLE
Remove "7SemiSHT4x_Lib"

### DIFF
--- a/registry.txt
+++ b/registry.txt
@@ -7763,7 +7763,6 @@ https://github.com/hasenradball/MCP23008-I2C.git|Contributed|MCP23008-I2C
 https://github.com/CMB27/ModbusSlaveLogic.git|Contributed|ModbusSlaveLogic
 https://github.com/hootrhino/MOTY-Mini-Temperature-Sensor.git|Contributed|MOTY-Mini Temperature Sensor
 https://github.com/kelasrobot/FoonteDuino.git|Contributed|FoonteDuino
-https://github.com/7Semi/SevenSemiSHT4x_Lib.git|Contributed|7SemiSHT4x_Lib
 https://github.com/schreibfaul1/ESP32-audioI2S.git|Contributed|ESP32-audioI2S-master
 https://github.com/median-dispersion/XPT2046-Driver.git|Contributed|XPT2046 Driver
 https://github.com/stacknix/stackmq-esp32.git|Contributed|Stackmq


### PR DESCRIPTION
Companion to https://github.com/arduino/library-registry/pull/5747