### PR TITLE
Remove "KelasRobotTime" from repository list

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -7669,7 +7669,6 @@ https://github.com/digitalfen/EmuRTC
 https://github.com/alfan459/RandomForestModel
 https://github.com/alfan459/ElasticNetModel
 https://github.com/alfan459/LinearRegressionModel
-https://github.com/kelasrobot/KelasRobotTime
 https://github.com/kelasrobot/MQTTESP
 https://github.com/bsrahmat/iotNetESP32
 https://github.com/ajangrahmat/ArduMekaWiFi


### PR DESCRIPTION
Due to irresponsible behavior, registry privileges have been revoked for `github.com/kelasrobot`:

https://github.com/arduino/library-registry/pull/5706#issuecomment-2588923290