### PR TITLE
Remove "KelasRobotIO" from repository list

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -7677,7 +7677,6 @@ https://github.com/eis-interbot/EIS_INTERBOT
 https://github.com/lucaschoeneberg/lw09-dali
 https://github.com/moononournation/Dev_Device_Pins.git
 https://github.com/ELOWRO/ADS1119
-https://github.com/kelasrobot/KelasRobotIO
 https://github.com/rescenic/rescenicio
 https://github.com/kelasrobot/FonnteArduino
 https://github.com/JokoArdh/inIo


### PR DESCRIPTION
Due to irresponsible behavior, registry privileges have been revoked for `github.com/kelasrobot`:

https://github.com/arduino/library-registry/pull/5706#issuecomment-2588923290