### PR TITLE
Remove "KelasRobotIO"

### DIFF
--- a/registry.txt
+++ b/registry.txt
@@ -7751,7 +7751,6 @@ https://github.com/ELOWRO/ADS1119.git|Contributed|ADS1119 library
 https://github.com/valerii-fr/menux.git|Contributed|MenuX
 https://github.com/juanmercadin/ReceptorRF.git|Contributed|ReceptorRF
 https://github.com/roncoa/KeySequence.git|Contributed|KeySequence
-https://github.com/kelasrobot/KelasRobotIO.git|Contributed|KelasRobotIO
 https://github.com/rescenic/rescenicio.git|Contributed|RescenicIO
 https://github.com/kelasrobot/FonnteArduino.git|Contributed|FonnteArduino
 https://github.com/JokoArdh/inIo.git|Contributed|inIo


### PR DESCRIPTION
Companion to https://github.com/arduino/library-registry/pull/5761