### PR TITLE
Remove "I2CR-CPP" from repository list

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -7695,7 +7695,6 @@ https://github.com/Alex-Stone-Github/pepstep
 https://github.com/AirNgin/Airngin-esp32-mqtt-client
 https://github.com/samy101/edge-ai-arduino-library
 https://github.com/robertsonics/WAV_Trigger_Pro_Qwiic_Arduino_Library
-https://github.com/YoavPaz/I2CR-CPP
 https://github.com/Alex-Stone-Github/CNCShield
 https://github.com/bitbank2/FastEPD
 https://github.com/jerry-magnin/Mem24CSM01


### PR DESCRIPTION
Due to irresponsible behavior, registry privileges have been revoked for `github.com/YoavPaz`:

https://github.com/arduino/library-registry/pull/5741#issuecomment-2589016403