### PR TITLE
Remove "BTRobocontrol" from repository list

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -7496,7 +7496,6 @@ https://github.com/kanitawa/RotEnc
 https://github.com/vpBharath/RobotControl.git
 https://github.com/BlairBlaidd/Newhaven_CharacterOLED_SPI
 https://github.com/ERLtech/ERLtech-RobotControl.git
-https://github.com/ErlTechnologies/BTRobocontrol.git
 https://github.com/ErlTechnologies/ERLtechRobotcontrol.git
 https://github.com/lhtran114/OnlyTimer
 https://github.com/sinricpro/arduino-renesas-sdk


### PR DESCRIPTION
Due to irresponsible behavior, registry privileges have been revoked for `github.com/ErlTechnologies`:

https://github.com/arduino/library-registry/pull/4873#issuecomment-2589138298