### PR TITLE
Remove "ERLtechRobotcontrol" from repository list

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -7497,7 +7497,6 @@ https://github.com/vpBharath/RobotControl.git
 https://github.com/BlairBlaidd/Newhaven_CharacterOLED_SPI
 https://github.com/ERLtech/ERLtech-RobotControl.git
 https://github.com/ErlTechnologies/BTRobocontrol.git
-https://github.com/ErlTechnologies/ERLtechRobotcontrol.git
 https://github.com/lhtran114/OnlyTimer
 https://github.com/sinricpro/arduino-renesas-sdk
 https://github.com/septentrio-gnss/Septentrio_Arduino_library 


### PR DESCRIPTION
Due to irresponsible behavior, registry privileges have been revoked for `github.com/ErlTechnologies`:

https://github.com/arduino/library-registry/pull/4873#issuecomment-2589138298