### PR TITLE
Remove "RobotControl" from repositories list

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -7493,7 +7493,6 @@ https://github.com/protheeuz/AsyncWebServerESP
 https://github.com/JoelJojoP/SimpleIMU
 https://github.com/vickash/RotaryEncoderPCNT
 https://github.com/kanitawa/RotEnc
-https://github.com/vpBharath/RobotControl.git
 https://github.com/BlairBlaidd/Newhaven_CharacterOLED_SPI
 https://github.com/ERLtech/ERLtech-RobotControl.git
 https://github.com/ErlTechnologies/BTRobocontrol.git


### PR DESCRIPTION
Due to irresponsible behavior, registry privileges have been revoked for `github.com/vpBharath`:

https://github.com/arduino/library-registry/pull/4873#issuecomment-2589138298