### PR TITLE
update links to some mathieucarbou repos

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -2333,6 +2333,8 @@ https://github.com/ESDeveloperBR/ES32Lab
 https://github.com/ESDeveloperBR/TFT_eSPI_ES32Lab
 https://github.com/ESDeveloperBR/TimeInterval
 https://github.com/ESikich/RGBLEDBlender
+https://github.com/ESP32Async/AsyncTCP
+https://github.com/ESP32Async/ESPAsyncWebServer
 https://github.com/espressif/esp-brookesia
 https://github.com/esp-arduino-libs/esp-lib-utils
 https://github.com/esp-arduino-libs/ESP32_Button
@@ -4106,8 +4108,6 @@ https://github.com/mathertel/Radio
 https://github.com/mathertel/RFCodes
 https://github.com/mathertel/RotaryEncoder
 https://github.com/Mathieu52/GPSP
-https://github.com/mathieucarbou/AsyncTCP
-https://github.com/mathieucarbou/ESPAsyncWebServer
 https://github.com/mathieucarbou/MycilaConfig
 https://github.com/mathieucarbou/MycilaDS18
 https://github.com/mathieucarbou/MycilaEasyDisplay


### PR DESCRIPTION
cc @mathieucarbou

Two repositories maintained by mathieucarbou are [moved to the organization `ESP32Async`](https://github.com/mathieucarbou/ESPAsyncWebServer/blob/main/README.md), but the Library Registry is not updated. This commit updates the registry.