### PR TITLE
Add RTC_DS1307_Library to repositories.txt

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -7725,3 +7725,4 @@ https://github.com/ridiculousfish/libdivide
 https://github.com/crozone-technology/TelegramESP32
 https://github.com/mawaeg/Arduino_RV-8523
 https://github.com/steins1997/arduino_uno_r4_minima_mcp2517fd
+https://github.com/mcu-electronics/RTC_DS1307_Library


### PR DESCRIPTION
The RTC_DS1307_Library allows easy interaction with the DS1307 Real-Time Clock (RTC) module, offering advanced functions for managing time and additional configurations such as square wave output and NV-RAM.