### PR TITLE
fixed fork of https://github.com/closedcube/ClosedCube_SHT31D_Arduino

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -1671,7 +1671,7 @@ https://github.com/closedcube/ClosedCube_LPS25HB_Arduino
 https://github.com/closedcube/ClosedCube_MAX30205_Arduino
 https://github.com/closedcube/ClosedCube_OPT3001_Arduino
 https://github.com/closedcube/ClosedCube_OPT3002_Arduino
-https://github.com/closedcube/ClosedCube_SHT31D_Arduino
+https://github.com/malarz-supla/ClosedCube_SHT31D_Arduino
 https://github.com/closedcube/ClosedCube_SHT3XA_Library
 https://github.com/closedcube/ClosedCube_SHT3XD_Library
 https://github.com/closedcube/ClosedCube_SHTC3_Arduino

--- a/repositories.txt
+++ b/repositories.txt
@@ -1671,6 +1671,7 @@ https://github.com/closedcube/ClosedCube_LPS25HB_Arduino
 https://github.com/closedcube/ClosedCube_MAX30205_Arduino
 https://github.com/closedcube/ClosedCube_OPT3001_Arduino
 https://github.com/closedcube/ClosedCube_OPT3002_Arduino
+https://github.com/closedcube/ClosedCube_SHT31D_Arduino
 https://github.com/malarz-supla/ClosedCube_SHT31D_Arduino
 https://github.com/closedcube/ClosedCube_SHT3XA_Library
 https://github.com/closedcube/ClosedCube_SHT3XD_Library


### PR DESCRIPTION
https://github.com/closedcube/ is dead

I found and fix error in this library.
I worked on other fork of library, which had the same code as 1.5.1 installed from Arduino
