### PR TITLE
Request to add QwiicUART Library to Registry

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -7739,3 +7739,4 @@ https://github.com/ICRS/IC-Hack-Badge-Arduino
 https://github.com/avisha95/AViShaMQTT
 https://github.com/avisha95/AViShaWiFi
 https://github.com/khaledHamidi/qlink
+https://github.com/CMB27/QwiicUART-Library/tree/main

--- a/repositories.txt
+++ b/repositories.txt
@@ -7739,4 +7739,4 @@ https://github.com/ICRS/IC-Hack-Badge-Arduino
 https://github.com/avisha95/AViShaMQTT
 https://github.com/avisha95/AViShaWiFi
 https://github.com/khaledHamidi/qlink
-https://github.com/CMB27/QwiicUART-Library/tree/main
+https://github.com/CMB27/QwiicUART-Library


### PR DESCRIPTION
The [QwiicUART Library](https://github.com/CMB27/QwiicUART-Library) is an Arduino library to utilize the [NXP SC16IS741](https://www.nxp.com/products/interfaces/ic-spi-i3c-interface-devices/bridges/single-uart-with-ic-bus-spi-interface-64-b-of-transmit-and-receive-fifos-irda-sir-built-in-support:SC16IS741) as a hardware serial port controlled via I<sup>2</sup>C.
This library was made in conjunction with the [QwiicUART](https://github.com/CMB27/Qwiic-UART) breakout board.
This board complies with the [Qwiic system](https://www.sparkfun.com/qwiic) as specified by [SparkFun Electronics](https://www.sparkfun.com/).
I have no affiliation with NXP Semiconductors or SparkFun Electronics.