### PR TITLE
Add Libraries for Modbus TCP Communication

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -7765,3 +7765,5 @@ https://github.com/DigitalFuturesOCADU/TinyFilmFestival
 https://github.com/MarineAppliedResearch/Naviguider_Compass_I2C
 https://github.com/johnosbb/hx1838decoder
 https://github.com/RyLeeHarrison/EventEmitter
+https://github.com/CMB27/ModbusTCPComm
+https://github.com/CMB27/ModbusTCPSlave


### PR DESCRIPTION
This adds two libraries.
- [ModbusTCPComm](https://github.com/CMB27/ModbusTCPComm), is for sending and receiving Modbus data frames over TCP.
- [ModbusTCPSlave](https://github.com/CMB27/ModbusTCPSlave), depends on the first and implements Modbus slave/server processing for this communication.