### PR TITLE
Add ESP32_Host_MIDI to repositories.txt

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -7769,3 +7769,4 @@ https://github.com/johnosbb/hx1838decoder
 https://github.com/RyLeeHarrison/EventEmitter
 https://github.com/CMB27/ModbusTCPComm
 https://github.com/CMB27/ModbusTCPSlave
+https://github.com/sauloverissimo/ESP32_Host_MIDI


### PR DESCRIPTION
This commit adds the "ESP32_Host_MIDI" library to the Arduino Library Manager registry.

Repository URL: https://github.com/sauloverissimo/ESP32_Host_MIDI

Thank you for reviewing this submission! 😉