### PR TITLE
AMS AS5040 magnetic rotary encoder driver inclusion to repositories.txt 

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -7778,3 +7778,4 @@ https://github.com/CMB27/ModbusTCPSlave
 https://github.com/sauloverissimo/ESP32_Host_MIDI
 https://github.com/macFanDave/GigaDAQ
 https://github.com/msilveus/SimpleQueue
+https://github.com/fededc88/AS5040


### PR DESCRIPTION
AMS AS5040 magnetic rotary encoder chip driver for arduino avr uno.