### PR TITLE
Remove "Easy IoT with CC1101 - Sub-1GHz LORA-like"

### DIFF
--- a/registry.txt
+++ b/registry.txt
@@ -3790,7 +3790,6 @@ https://github.com/joshnishikawa/MIDIcontroller.git|Contributed|MIDIcontroller
 https://github.com/MaximIntegrated/MAX31328-Arduino-Driver.git|Contributed|Max31328RTC
 https://github.com/RobTillaart/Currency.git|Contributed|currency
 https://github.com/Seeed-Studio/Seeed_Arduino_rpcWiFi.git|Contributed|Seeed Arduino rpcWiFi
-https://github.com/mrfaptastic/Easy-IoT-Arduino-CC1101-LORA.git|Contributed|Easy IoT with CC1101 - Sub-1GHz LORA-like
 https://github.com/igorantolic/ai-esp32-rotary-encoder.git|Contributed|Ai Esp32 Rotary Encoder
 https://github.com/srwi/ESPEssentials.git|Contributed|ESPEssentials
 https://github.com/heisenware/arduino-vrpc.git|Contributed|VRPC


### PR DESCRIPTION
One of the companions to https://github.com/arduino/library-registry/pull/5953