### PR TITLE
Remove "WiFiConnect Lite"

### DIFF
--- a/registry.txt
+++ b/registry.txt
@@ -3282,7 +3282,6 @@ https://github.com/dojyorin/arduino_percent.git|Contributed|percent_encode
 https://github.com/vishnumaiea/R30X-Fingerprint-Sensor-Library.git|Contributed|R30X-Fingerprint-Sensor-Library
 https://github.com/RobTillaart/PCF8575.git|Contributed|PCF8575
 https://github.com/jandrassy/TelnetStream.git|Contributed|TelnetStream
-https://github.com/mrfaptastic/WiFiConnectLite.git|Contributed|WiFiConnect Lite
 https://github.com/Wh1teRabbitHU/RX8010SJ.git|Contributed|RX8010SJ
 https://github.com/beegee-tokyo/nRF52_OLED.git|Contributed|nRF52_OLED
 https://github.com/SiddheshNan/Things-IoT-Arduino-Library.git|Contributed|ThingsIoT


### PR DESCRIPTION
One of the companions to https://github.com/arduino/library-registry/pull/5953