### PR TITLE
Renamed https://github.com/dac1e/Dcf77Receiver to https://github.com/…

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -7827,7 +7827,7 @@ https://github.com/4211421036/gsr-arduino
 https://github.com/4211421036/IoTModule
 https://github.com/Elrindel/SomfyReceiver
 https://github.com/thebestia90/AD5259
-https://github.com/dac1e/Dcf77Receiver
+https://github.com/dac1e/DCF77RX
 https://github.com/ImSpeddy/L298Nlib
 https://github.com/4211421036/githubiot
 https://github.com/christosneg/concurrentPID.git


### PR DESCRIPTION
…dac1e/DCF77RX

Renamed the repository, because it shall appear along with other repositories that all start with upper case letters 'DCF' instead of 'Dcf'. Along with this change, the appendix 'Receiver' was shortened to 'RX'.