### PR TITLE
Update URL of "Dcf77Receiver"

### DIFF
--- a/registry.txt
+++ b/registry.txt
@@ -7916,7 +7916,7 @@ https://github.com/robinz-labs/digishow-rioc.git|Contributed|DigiShow RIOC
 https://github.com/RobTillaart/LTC2485.git|Contributed|LTC2485
 https://github.com/oskozach/MsTime.git|Contributed|MsTime
 https://github.com/MYCAMEL222/AbleTP.git|Contributed|AbleTP
-https://github.com/dac1e/Dcf77Receiver.git|Contributed|Dcf77Receiver
+https://github.com/dac1e/DCF77RX.git|Contributed|Dcf77Receiver
 https://github.com/snowhalationmkii/TTP229_BS81X_Serial.git|Contributed|TTP229_BS81X_Serial
 https://github.com/oskozach/InputSwitch.git|Contributed|InputSwitch
 https://github.com/Sensirion/arduino-i2c-sfm3304.git|Contributed|Sensirion I2C SFM3304


### PR DESCRIPTION
Companion to https://github.com/arduino/library-registry/pull/6001