### PR TITLE
Add My Stepper8825Lib.

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -7867,3 +7867,4 @@ https://github.com/styropyr0/SensorHub
 https://github.com/amitesh-singh/EspDDNS
 https://github.com/tomorrow56/SPRESENSE_ESP8266_LINE_Messaging_API
 https://github.com/zamanturja/A9Gmod
+https://github.com/WBS-Wissen/Stepper8825Lib


### PR DESCRIPTION
I would like to add my Stepper8825 library, which makes it easy to use DRV8825 drivers.