### PR TITLE
Add SensEdu-Library

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -7868,3 +7868,4 @@ https://github.com/amitesh-singh/EspDDNS
 https://github.com/tomorrow56/SPRESENSE_ESP8266_LINE_Messaging_API
 https://github.com/zamanturja/A9Gmod
 https://github.com/WBS-Wissen/Stepper8825Lib
+https://github.com/vladysor/SensEdu-Library


### PR DESCRIPTION
I would like to add SensEdu-Library, which is framework for Arduino GIGA R1 WiFi shield called SensEdu, allowing to use Arduino for radar and communication systems.