### PR TITLE
Updated SSD1306 OLED Library's URL

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -7719,7 +7719,7 @@ https://github.com/pschatzmann/TalkiePCM
 https://github.com/YuenNicdao/iParol
 https://github.com/Natpol50/BME280_mini
 https://github.com/MMZBin/Raspberry_Pi_Pico_MacroPad
-https://github.com/styropyr0/oled.h
+https://github.com/styropyr0/SSD1306
 https://github.com/jaakka/DelayFunctionsArduino
 https://github.com/ZanPekosak/SlowPWM
 https://github.com/Lorandil/uCompression


### PR DESCRIPTION
I have my library's URL changed from https://github.com/styropyr0/oled.h to https://github.com/styropyr0/SSD1306. Please approve the changes or if there are things that need correction, please let me know.