### PR TITLE
Remove "Yfrobot Fingerprint Identification Sensor Library"

### DIFF
--- a/registry.txt
+++ b/registry.txt
@@ -5990,7 +5990,6 @@ https://github.com/glutio/Eventfun.git|Contributed|Eventfun
 https://github.com/mhorimoto/M304-lib.git|Contributed|M304 Library
 https://github.com/rm5248/liblcc-arduino.git|Contributed|LibLCC
 https://github.com/SNMetamorph/FutabaVfdM202MD10C.git|Contributed|FutabaVfdM202MD10C
-https://github.com/YFROBOT-TM/Yfrobot-FPM383-Library.git|Contributed|Yfrobot Fingerprint Identification Sensor Library
 https://github.com/pablomarquez76/AnalogWrite_ESP32.git|Contributed|AnalogWrite_ESP32
 https://github.com/suratin27/DINO_PLC_V1.git|Contributed|DINO_PLC_V1
 https://github.com/arduino-libraries/Arduino_GigaDisplayTouch.git|Arduino|Arduino_GigaDisplayTouch


### PR DESCRIPTION
Companion to https://github.com/arduino/library-registry/pull/6079