### PR TITLE
Deleted DCF77RX

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -7875,7 +7875,6 @@ https://github.com/4211421036/gsr-arduino
 https://github.com/4211421036/IoTModule
 https://github.com/Elrindel/SomfyReceiver
 https://github.com/thebestia90/AD5259
-https://github.com/dac1e/DCF77RX
 https://github.com/ImSpeddy/L298Nlib
 https://github.com/4211421036/githubiot
 https://github.com/christosneg/concurrentPID.git


### PR DESCRIPTION
Some weeks ago I renamed this library from Dcf77Receiver to DCF77RX. After my pull request was merged and some weeks of waiting, the old library still appears in Arduino IDE, and the new renamed one doesn't. Hence I am removing this library.