### PR TITLE
Update URL of "tinyml4all"

### DIFF
--- a/registry.txt
+++ b/registry.txt
@@ -7031,7 +7031,7 @@ https://github.com/Narwhalsss360/PinMatrix.git|Contributed|PinMatrix
 https://github.com/adafruit/Adafruit_CH9328.git|Recommended|Adafruit CH9328
 https://github.com/Sam4uk/WD.Easy.git|Contributed|WD Easy
 https://github.com/m5stack/M5Unit-8Encoder.git|Contributed|M5UNIT_8Encoder
-https://github.com/eloquentarduino/tinyml4all-arduino.git|Contributed|tinyml4all
+https://github.com/salernosimone/tinyml4all-arduino.git|Contributed|tinyml4all
 https://github.com/adafruit/Adafruit_HDC302x.git|Recommended|Adafruit HDC302x
 https://github.com/RobTillaart/Kurtosis.git|Contributed|Kurtosis
 https://github.com/hideakitai/LTC230x.git|Contributed|LTC230x


### PR DESCRIPTION
Companion to https://github.com/arduino/library-registry/pull/6177