### PR TITLE
Add PicoBricks Library

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -7950,3 +7950,4 @@ https://github.com/IsraEB/esp32cam
 http://github.com/codewitch-honey-crisis/htcw_pool
 https://github.com/rjsachse/ESP32-SpeexDSP
 https://github.com/kingsmen732/Robot-face---sh1106-screen
+https://github.com/Robotistan/PicoBricks-for-RPico


### PR DESCRIPTION
### Library Name

PicoBricks

### Library URL

https://github.com/Robotistan/PicoBricks-for-RPico

### Description

Arduino library for the Raspberry Pi Pico-based PicoBricks board. Supports SSD1306 OLED, DHT11, SHTC3, NeoPixel, Servo, Motor Driver, Relay, Buzzer, Potentiometer, LDR, and IR Receiver. Designed for educational robotics and STEM development.

### Architectures

rp2040