### PR TITLE
Remove "Device"

### DIFF
--- a/registry.txt
+++ b/registry.txt
@@ -8013,7 +8013,6 @@ https://github.com/sparkfun/SparkFun_BMV080_Arduino_Library.git|Contributed|Spar
 https://github.com/renesas/nfc-ptx105r-spi-arduino.git|Contributed|PTX105R SDK for SPI
 https://github.com/renesas/nfc-ptx105r-i2c-arduino.git|Contributed|PTX105R SDK for I2C
 https://github.com/renesas/nfc-ptx105r-uart-arduino.git|Contributed|PTX105R SDK for UART
-https://github.com/MEmbeddedTLB/Device.git|Contributed|Device
 https://github.com/adafruit/Adafruit_TLV320_I2S.git|Recommended|Adafruit TLV320 I2S
 https://github.com/codingABI/KY040.git|Contributed|KY040
 https://github.com/iavorvel/MyButton.git|Contributed|My_Button


### PR DESCRIPTION
Instead of following the appropriate procedure to request name and URL changes, the library maintainer submitted a duplicate copy of the library under the new name "Devices" (https://github.com/arduino/library-registry/pull/6178). So the previous registry entry must be removed.

Companion to https://github.com/arduino/library-registry/pull/6193