### PR TITLE
Update repositories.txt

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -7993,3 +7993,4 @@ https://github.com/microbotsio/CodeCell-MicroLink
 https://github.com/eyr1n/RP2040PIO_CAN
 
 https://github.com/Arduino15/A15RGB
+https://github.com/eyr1n/esp32-ps3


### PR DESCRIPTION
Added https://github.com/eyr1n/esp32-ps3

The original repository (https://github.com/jvpernis/esp32-ps3) may no longer be maintained, so I created a forked library.
The fork fixed a problem with building with the latest ESP32 board library (v3.2.0).

