### PR TITLE
Update URL of "LightTaskScheduler"

### DIFF
--- a/registry.txt
+++ b/registry.txt
@@ -8089,4 +8089,4 @@ https://github.com/m5stack/M5Module-Audio.git|Contributed|Module-Audio
 https://github.com/Arduino15/A15RGB.git|Contributed|A15RGB
 https://github.com/zahidaof/SIM7600_TTS.git|Contributed|SIM7600 TTS Library
 https://github.com/eyr1n/esp32-ps3.git|Contributed|Fork of PS3 Controller Host
-https://github.com/belem2050/TaskScheduler.git|Contributed|LightTaskScheduler
+https://github.com/belem2050/LightTaskScheduler.git|Contributed|LightTaskScheduler


### PR DESCRIPTION
Companion to https://github.com/arduino/library-registry/pull/6245