### PR TITLE
Revoke registry privileges for github.com/4211421036

### DIFF
--- a/.github/workflows/assets/accesslist.yml
+++ b/.github/workflows/assets/accesslist.yml
@@ -9,6 +9,10 @@
 
 # Denylist
 - host: github.com
+  name: 4211421036
+  access: deny
+  reference: https://github.com/arduino/library-registry/pull/6269#pullrequestreview-2813557457
+- host: github.com
   name: 7Semi
   access: deny
   reference: https://github.com/arduino/library-registry/pull/5734#pullrequestreview-2548818476


### PR DESCRIPTION
This user has established a pattern of irresponsible behavior in the Arduino Library Manager Registry repository. They continued this behavior even after the bot and human maintainer made significant efforts to guide them to responsible use.