### PR TITLE
Add Control-Surface library

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -8012,3 +8012,4 @@ https://github.com/peto-3210/ShiftRegisterPISO
 https://github.com/whchun/waveshare-epd
 https://github.com/koendv/xyc-als21c-k1
 https://github.com/JimKnowler/Arduino_Waldo
+https://github.com/tttapa/Control-Surface


### PR DESCRIPTION
Hello,

After https://github.com/arduino/library-registry/pull/5444 the author of the library made a new release fixing the error.
