### PR TITLE
Update repositories.txt with RockBLOCK-9704

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -8019,3 +8019,4 @@ https://github.com/lostcaggy/rotary_caggy
 https://github.com/JimKnowler/Arduino_Waldo
 https://github.com/tttapa/Control-Surface
 https://github.com/koendv/curveFitting
+https://github.com/rock7/RockBLOCK-9704


### PR DESCRIPTION
Adding the RockBLOCK-9704 library to assist users of the [RockBLOCK 9704](https://www.groundcontrol.com/product/rockblock-9704/)