### PR TITLE
register ArduinoPostgresOverHTTP library to Arduino library manager

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -1,3 +1,4 @@
+https://github.com/neondatabase-labs/ArduinoPostgresOverHTTP
 https://github.com/thomasfredericks/MicroSlip
 https://github.com/SkaFUU/AsyncWebOTA
 https://github.com/DIYables/DIYables_TFT_Shield

--- a/repositories.txt
+++ b/repositories.txt
@@ -1,4 +1,4 @@
-https://github.com/neondatabase-labs/ArduinoPostgresOverHTTP
+https://github.com/neondatabase-labs/NeonPostgresOverHTTP
 https://github.com/thomasfredericks/MicroSlip
 https://github.com/SkaFUU/AsyncWebOTA
 https://github.com/DIYables/DIYables_TFT_Shield


### PR DESCRIPTION
ArduinoPostgresOverHTTP is a library for Arduino and Arduino-compatible micro-controllers that allows you to connect to a PostgreSQL database over HTTP.

This can be used to store sensor data directly into a PostgreSQL database without a middleman server like home assistant. You can also read values from the database and use them to control actuators.