### PR TITLE
Remove "TLE493D"

### DIFF
--- a/registry.txt
+++ b/registry.txt
@@ -2782,7 +2782,6 @@ https://github.com/silvervest/Silvervest_OLED_0010_SPI.git|Contributed|Silverves
 https://github.com/khoih-prog/BlynkGSM_Manager.git|Contributed|BlynkGSM_Manager
 https://github.com/yknivag/ESP_OTA_GitHub.git|Contributed|ESP OTA GitHub
 https://github.com/EmotiBit/EmotiBit_XPlat_Utils.git|Contributed|EmotiBit XPlat Utils
-https://github.com/Infineon/TLE493D-3DMagnetic-Sensor.git|Contributed|TLE493D
 https://github.com/Nouryas-Tech/Nouryas-Advanced-Line-Follower-Array.git|Contributed|Nouryas Advanced Line Follower
 https://github.com/Velleman/Tuyav.git|Contributed|Tuyav
 https://github.com/eloquentarduino/EloquentTinyML.git|Contributed|EloquentTinyML


### PR DESCRIPTION
Companion to https://github.com/arduino/library-registry/pull/6320