### PR TITLE
Remove "TLI493D"

### DIFF
--- a/registry.txt
+++ b/registry.txt
@@ -3410,7 +3410,6 @@ https://github.com/MERG-DEV/CBUSBUZZER.git|Contributed|CBUSBUZZER
 https://github.com/CsCrazy85/SCA100T.git|Contributed|SCA100T
 https://github.com/sparkfun/SparkFun_Particle_Sensor_SN-GCJA5_Arduino_Library.git|Contributed|SparkFun Particle Sensor Panasonic SN-GCJA5
 https://github.com/xreef/DHT12_sensor_library.git|Contributed|DHT12 sensor library
-https://github.com/Infineon/TLI493D-W2BW.git|Contributed|TLI493D
 https://github.com/plapointe6/HAMqttDevice.git|Contributed|HAMqttDevice
 https://github.com/rocketscream/RocketScream_LowPowerAVRZero.git|Contributed|Rocket Scream LowPowerAVRZero
 https://github.com/rocketscream/RocketScream_RTCAVRZero.git|Contributed|Rocket Scream RTCAVRZero


### PR DESCRIPTION
Companion to https://github.com/arduino/library-registry/pull/6320