### PR TITLE
Remove "TLV493D-A1B6"

### DIFF
--- a/registry.txt
+++ b/registry.txt
@@ -2380,7 +2380,6 @@ https://github.com/ROBOTIS-GIT/Dynamixel2Arduino.git|Contributed|Dynamixel2Ardui
 https://github.com/ArminJo/Arduino-BlueDisplay.git|Contributed|BlueDisplay
 https://github.com/H-Kurosaki/UARDECS_MEGA.git|Contributed|UARDECS_MEGA Library
 https://github.com/Infineon/TLx4966-Direction-Speed-Sensor.git|Contributed|TLx4966-Direction-Speed-Sensor
-https://github.com/Infineon/TLV493D-A1B6-3DMagnetic-Sensor.git|Contributed|TLV493D-A1B6
 https://github.com/Infineon/TLE5012-Magnetic-Angle-Sensor.git|Contributed|TLE5012B
 https://github.com/Infineon/TLI4970-D050T4-Current-Sensor.git|Contributed|TLI4970
 https://github.com/Infineon/RGB-LED-Lighting-Shield-XMC1202.git|Contributed|RGB LED Lighting Shield XMC1202


### PR DESCRIPTION
Companion to https://github.com/arduino/library-registry/pull/6320