### PR TITLE
Add RCduino library to Library Manager index

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -8058,3 +8058,4 @@ https://github.com/Uiop3385/CommandHandler
 https://github.com/peto-3210/ModbusRTU
 https://github.com/ruiseixasm/JsonTalkie
 https://github.com/depben/PT7C4339-RTC
+https://github.com/RCduino/RCduino

--- a/repositories.txt
+++ b/repositories.txt
@@ -8058,4 +8058,4 @@ https://github.com/Uiop3385/CommandHandler
 https://github.com/peto-3210/ModbusRTU
 https://github.com/ruiseixasm/JsonTalkie
 https://github.com/depben/PT7C4339-RTC
-https://github.com/RCduino/RCduino
+https://github.com/RCduino/RCduino.git


### PR DESCRIPTION
This pull request adds the RCduino library to the Arduino Library Manager index.

GitHub repository: https://github.com/RCduino/RCduino

The library is compliant with all the requirements of Library Manager and is tagged with a semantic version.

Thank you!
