### PR TITLE
Added Mist Maker Library

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -1,3 +1,4 @@
+https://github.com/owochel/MistMaker
 https://github.com/Ynvisible-Electronics/YNV-Driver-v5-Arduino-Library
 https://github.com/neondatabase-labs/NeonPostgresOverHTTP
 https://github.com/thomasfredericks/MicroSlip


### PR DESCRIPTION
The Arduino library for the open-source ultrasonic mist maker under OSHWA ID US002742.