### PR TITLE
chore: add Ewan-Dev/mpu6050 library to repositories.txt

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -1,3 +1,4 @@
+https://github.com/Ewan-Dev/mpu6050
 https://github.com/owochel/MistMaker
 https://github.com/Ynvisible-Electronics/YNV-Driver-v5-Arduino-Library
 https://github.com/neondatabase-labs/NeonPostgresOverHTTP


### PR DESCRIPTION
This is to add my MPU6050 library to the Arduino library index.