### PR TITLE
Add https://github.com/adafruit/Adafruit_INA237_INA238

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -561,6 +561,7 @@ https://github.com/adafruit/Adafruit_ILI9341
 https://github.com/adafruit/Adafruit_ImageReader
 https://github.com/adafruit/Adafruit_INA219
 https://github.com/adafruit/Adafruit_INA228
+https://github.com/adafruit/Adafruit_INA237_INA238
 https://github.com/adafruit/Adafruit_INA260
 https://github.com/adafruit/Adafruit_INA3221
 https://github.com/adafruit/Adafruit_IntelliKeys


### PR DESCRIPTION
This adds the library for Adafruit INA238 and Adafruit INA237 breakout boards