### PR TITLE
Add Lexo library for Arduino Library Manager

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -8074,3 +8074,4 @@ https://github.com/Faizyee/Socketyee
 https://github.com/ivanmari/bare-poller
 https://github.com/lahavg/QMI8658-Arduino-Library
 https://github.com/k3ldar/MovementDetector
+https://github.com/marcel-naderer/Lexo


### PR DESCRIPTION
Please add the Lexo library to the Arduino Library Manager.

Repository URL: https://github.com/marcel-naderer/Lexo

Maintainer: Marcel Naderer
License: MIT
Version: 1.0.0