### PR TITLE
added bb_imu to the library list

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -8077,3 +8077,4 @@ https://github.com/lahavg/QMI8658-Arduino-Library
 https://github.com/k3ldar/MovementDetector
 https://github.com/marcel-naderer/Lexo
 https://github.com/joshua-8/xrp-style-wpilib-comms
+https://github.com/bitbank2/bb_imu


### PR DESCRIPTION
Please add bb_imu (BitBank IMU library) to the Arduino libraries registry.
