### PR TITLE
Update repositories.txt

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -6711,7 +6711,7 @@ https://github.com/SunitRaut/WSN-for-RFM69-LowPowerLab
 https://github.com/SunjunKim/PMW3360
 https://github.com/supercrab/RemoteSerial
 https://github.com/SUPLA/supla-device
-https://github.com/Suraj151/esp8266-framework
+https://github.com/Suraj151/pdi-framework
 https://github.com/suratin27/DINO_PLC
 https://github.com/suratin27/DINO_PLC_V1
 https://github.com/suratin27/ESP32_Control


### PR DESCRIPTION
Updating URL for repository

from : https://github.com/Suraj151/esp8266-framework 
to : https://github.com/Suraj151/pdi-framework

Reason : Earlier this framework was developed for only esp8266 device. now we have added arduino uno and esp32 support as well. so we have renamed the repository from 'esp8266-framework' to 'pdi-framework'. Since the common interface is portable for multiple devices we have named it portable device interface framework.