### PR TITLE
WIP: Added SegLCDLib for segment LCD displays

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -8106,3 +8106,4 @@ https://github.com/manoj26may/IOT
 https://github.com/zukardex/DigiPIN
 https://github.com/avisha95/AViShaOTA
 https://github.com/GabyGold67/ShiftRegGPIOXpander_AVR
+https://github.com/petrkr/SegLCDLib


### PR DESCRIPTION
Does not met release/tag yet as I still have it in development, but it can be noticed by Arduino users, so they can help with first real release.

For now I just want claim this name because it should be universal one and do not want to claim controller name as HT1621 developer did and that library you can not use with any other LCD than he used from Aliexpress, because library itself is actually not for HT1621, but for some random LCD, which by random uses this chip.

So I decided create more universal library which can be easily extended with other controllers and LCD displays.