### PR TITLE
Add ChaCha32Arduino library

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -8116,3 +8116,4 @@ https://github.com/EgosFeic/EgLang.git
 https://gitlab.com/8bitforce/kdram2560/
 https://github.com/regimantas/EasyInterval
 https://github.com/GuLinux/AsyncWiFiMulti
+https://github.com/regimantas/ChaCha32Arduino


### PR DESCRIPTION
Adds a lightweight Arduino-compatible implementation of the 32-round ChaCha stream cipher. Repository: https://github.com/regimantas/ChaCha32Arduino