### PR TITLE
Add PY32LowPower library to repositories.txt

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -8118,3 +8118,4 @@ https://gitlab.com/8bitforce/kdram2560/
 https://github.com/regimantas/EasyInterval
 https://github.com/GuLinux/AsyncWiFiMulti
 https://github.com/regimantas/ChaCha32Arduino
+https://github.com/regimantas/PY32LowPower


### PR DESCRIPTION
Added https://github.com/regimantas/PY32LowPower for inclusion in the Arduino Library Manager.