### PR TITLE
Add G1OJS_Tiny_Si5351_CLK0 to Arduino Library Manager

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -8129,3 +8129,4 @@ https://github.com/regimantas/ChaCha32Arduino
 https://github.com/regimantas/PY32LowPower
 https://github.com/bahr1k/esp-arduino-tunnel
 https://github.com/llcesselx/lcd595
+https://github.com/G1OJS/G1OJS_Tiny_Si5351_CLK0


### PR DESCRIPTION
Please add this new library to the Arduino Library Manager.

- Repository: https://github.com/G1OJS/G1OJS_Tiny_Si5351_CLK0
- Version: v1.0.1
- Author: Alan Robinson (G1OJS)
- Description: A minimal Si5351A CLK0-only 100-150MHz control library designed for (but not limited to) tiny MCUs like ATtiny85.