### PR TITLE
Add DMD32Plus to Repository List

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -8151,3 +8151,4 @@ https://github.com/wuttipong-ug/Bakmi
 https://github.com/KrrishVerma/Atmel_M90E32AS_ESP32
 https://github.com/matteo-colombo-kernel/SimpleConnect
 https://github.com/edreanernst/BQ27427_Arduino_Library
+https://github.com/ahmadfathan/DMD32Plus


### PR DESCRIPTION
I have enhance a library to control dot matrix display with ESP32. It does not support ESP32 with latest version (3.x.x). The library is no more maintained. So I made new one with bug fixes and new feauture.