### PR TITLE
Update phyphox-arduino repository to official organization repo

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -6581,7 +6581,7 @@ https://github.com/sstaub/TickTwo
 https://github.com/sstaub/Timer
 https://github.com/ssuhrid/EmSevenSegment
 https://github.com/St3p40/EMFButton
-https://github.com/Staacks/phyphox-arduino
+https://github.com/phyphox/phyphox-arduino
 https://github.com/Stan-Reifel/ArduinoUserInterface
 https://github.com/Stan-Reifel/FlexyStepper
 https://github.com/Stan-Reifel/SpeedyStepper


### PR DESCRIPTION
The project originally started under my personal github page https://github.com/Staacks/phyphox-arduino, but moved to https://github.com/phyphox/phyphox-arduino after we set up a organization account many years ago. The former has been a redirect to the latter for many years already, but the library registry should point to the proper address anyway.
