### PR TITLE
Update URL of "phyphox BLE"

### DIFF
--- a/registry.txt
+++ b/registry.txt
@@ -3368,7 +3368,7 @@ https://github.com/khoih-prog/Blynk_Async_ESP32_BT_WF.git|Contributed|Blynk_Asyn
 https://github.com/neroroxxx/RoxMux.git|Contributed|RoxMux
 https://github.com/LinnesLab/KickSort.git|Contributed|KickSort
 https://github.com/khoih-prog/Blynk_Async_WM.git|Contributed|Blynk_Async_WM
-https://github.com/Staacks/phyphox-arduino.git|Contributed|phyphox BLE
+https://github.com/phyphox/phyphox-arduino.git|Contributed|phyphox BLE
 https://github.com/drp0/ADCDRP.git|Contributed|ADCDRP
 https://github.com/BriscoeTech/Arduino-FreeRTOS-SAMD51.git|Contributed|FreeRTOS_SAMD51
 https://github.com/pu2clr/bk108x.git|Contributed|PU2CLR BK108X


### PR DESCRIPTION
Companion to https://github.com/arduino/library-registry/pull/6504