### PR TITLE
remove DBSStore/EIS

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -7818,7 +7818,6 @@ https://github.com/leocoderu/LC_EEPROM
 https://github.com/JensDMadsen/RotEncoder
 https://github.com/codingABI/DFR0534
 https://github.com/sinricpro/esp32-business-sdk
-https://github.com/DBSStore/EIS
 https://github.com/guerratron/TouchCal
 https://github.com/GabyGold67/ButtonToSwitch_AVR
 https://github.com/bitbank2/bb_epaper


### PR DESCRIPTION
This Library includes a bunch of files that are straight-up copied and not modified from multiple adafruit libraries.
This creates two issues:
1. Licensing (I think. I'm not a lawyer.)
2. It breaks compilation of adafruit libraries in the arduino cloud IDE because the cloud IDE auto-includes DBSStore/EIS instead of the original adafruit libraries.
For example compiling the Adafruit GFXcanvas example (https://app.arduino.cc/sketches/examples?nav=Examples&eid=adafruit_gfx_library_1_12_1%2Fexamples%2FGFXcanvas&slid=adafruit_gfx_library_1_12_1) (for Arduino Uno) results in a ton of "multiple definitions" errors because the "stolen" adafruit-files in DBSStore/EIS mess everything up.
This error does not occur in the desktop IDE 1.X or 2.X, because with those IDEs you have to manually install the official adafruit IDEs and not install EIS. It only occurs in the cloud IDE where all libraries are automatically installed.


This is a major and hard to fix error for beginners. Which is especially bad because adafruit libraries are extremely popular for beginners. In comparison DBSStore/EIS has 0 stars. So in my opinion it would absolutely be beneficial to the arduino beginner community to fix the official adafruit libraries by removing DBSStore/EIS.


The library creator was made aware of this 8 months ago here https://github.com/DBSStore/EIS/issues/1. And has not responded, they look totally inactive. 2 people on github have had the same issue. Plus at least one person on the official arduino discord. Plus multiple people in the forums (with 130 views) https://forum.arduino.cc/t/multiple-definition-error-in-cloud-editor-with-adafruit-gfx/1360122

Error when trying to compile the Adafruit GFXcanvas example https://app.arduino.cc/sketches/examples?nav=Examples&eid=adafruit_gfx_library_1_12_1%2Fexamples%2FGFXcanvas&slid=adafruit_gfx_library_1_12_1 for arduino uno in the cloud IDE:
```
[A TON of multiple definitions errors that I won't copy-paste here due to their length]
(.text+0x0): multiple definition of `Adafruit_SPITFT::readcommand8(unsigned char, unsigned char)'
/var/run/arduino/user-cache/sketches/F833544A7A32785F6538A49EC15A7241/libraries/Adafruit_GFX_Library/Adafruit_SPITFT.cpp.o (symbol from plugin):(.text+0x0): first defined here
/var/run/arduino/user-cache/sketches/F833544A7A32785F6538A49EC15A7241/libraries/EIS/Adafruit_SPITFT.cpp.o (symbol from plugin): In function `Adafruit_SPITFT::endWrite()':
(.text+0x0): multiple definition of `Adafruit_SPITFT::read16()'
/var/run/arduino/user-cache/sketches/F833544A7A32785F6538A49EC15A7241/libraries/Adafruit_GFX_Library/Adafruit_SPITFT.cpp.o (symbol from plugin):(.text+0x0): first defined here
collect2: error: ld returned 1 exit status
Multiple libraries were found for "Adafruit_I2CDevice.h"
  Used: /run/arduino/directories-data/internal/EIS_0.0.1_7b9a78c117637fbc
  Not used: /run/arduino/directories-data/internal/Adafruit_BusIO_1.17.1_db8a20223a2bc4d5
  Not used: /run/arduino/directories-data/internal/EIS_INTERBOT_1.0.0_4c1ce07692fbb2fd
  Not used: /run/arduino/directories-data/internal/VEGAIoT_BusIO_1.0.0_68606b9abaf94dc3
Multiple libraries were found for "Wire.h"
  Used: /run/arduino/directories-data/packages/arduino/hardware/avr/1.8.6/libraries/Wire
  Not used: /run/arduino/directories-data/internal/FlexWire_1.2.1_1fc5f1d1a14af0e7
Multiple libraries were found for "SPI.h"
  Used: /run/arduino/directories-data/packages/arduino/hardware/avr/1.8.6/libraries/SPI
  Not used: /run/arduino/directories-data/internal/EventEthernet_1.0.0_bd9dd894ef7641f8
Multiple libraries were found for "Adafruit_GFX.h"
  Used: /run/arduino/directories-data/internal/Adafruit_GFX_Library_1.12.1_0a7f9e1a08fbb518
  Not used: /run/arduino/directories-data/internal/DFRobot_RGBMatrix_1.0.1_07c8edece0610b8a
  Not used: /run/arduino/directories-data/internal/EIS_INTERBOT_1.0.0_4c1ce07692fbb2fd
  Not used: /run/arduino/directories-data/internal/Hanuman_1.4.0_9b5ae950e2a2ee63
  Not used: /run/arduino/directories-data/internal/EIS_0.0.1_7b9a78c117637fbc
```
This error log shows that the cloud IDE tried to use `Adafruit_I2CDevice.h` from DBSStore/EIS_0.0.1_7b9a78c117637fbc instead of the official Adafruit_BuisIO library. The same applies to multiple other adafruit libraries.