### PR TITLE
Revoke registry privileges for github.com/galihru

### DIFF
--- a/.github/workflows/assets/accesslist.yml
+++ b/.github/workflows/assets/accesslist.yml
@@ -9,6 +9,7 @@
 
 # Denylist
 - host: github.com
+  # They later changed their username to galihru, for which an additional entry was added.
   name: 4211421036
   access: deny
   reference: https://github.com/arduino/library-registry/pull/6269#pullrequestreview-2813557457
@@ -32,6 +33,10 @@
   name: ErlTechnologies
   access: deny
   reference: https://github.com/arduino/library-registry/pull/4873#issuecomment-2589138298
+- host: github.com
+  name: galihru
+  access: deny
+  reference: https://github.com/arduino/library-registry/pull/6269#pullrequestreview-2813557457
 - host: github.com
   name: kelasrobot
   access: deny


### PR DESCRIPTION
This user has established a pattern of irresponsible behavior in the Arduino Library Manager Registry repository. They continued this behavior even after the bot and human maintainer made significant efforts to guide them to responsible use.