### PR TITLE
Update reference URL for github.com/galihru privilege revocation

### DIFF
--- a/.github/workflows/assets/accesslist.yml
+++ b/.github/workflows/assets/accesslist.yml
@@ -36,7 +36,7 @@
 - host: github.com
   name: galihru
   access: deny
-  reference: https://github.com/arduino/library-registry/pull/6269#pullrequestreview-2813557457
+  reference: https://github.com/arduino/library-registry/pull/6514#pullrequestreview-2969201873
 - host: github.com
   name: kelasrobot
   access: deny


### PR DESCRIPTION
The previous URL was for the original privilege revocation. Since they chose to continue their irresponsible behavior instead of making a privilege restoration request as was detailed in the original revocation notification, the revocation is now permanent. Thus it does not make sense to link to the original notification which contains a restoration offer.