### PR TITLE
Add LightweightIoT Arduino Library

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -4,6 +4,7 @@ https://github.com/GalaidaMaxim/Delayer
 https://github.com/TheBlackSwitch/PS2Keyboard
 https://github.com/aiplayuser/esp8266easylib.git
 https://github.com/Circuit-Digest/GeoLinkerLite
+https://github.com/RacoonX65/LightweightIoT-Arduino-Lib
 https://github.com/RCmags/CN0391
 https://github.com/Init-io/InitMQTT.git
 https://github.com/Init-io/InitJson.git


### PR DESCRIPTION
I would like to add the LightweightIoT Arduino Library to the Arduino Library Manager. This library provides a lightweight solution for sending sensor data to InfluxDB Cloud from ESP8266 and ESP32 boards.

Key features:
- Simple API for sending data to InfluxDB Cloud
- Support for multiple sensors and batch operations
- Built-in power management capabilities
- Error handling and retry logic
- HTTPS secure communication
- Comprehensive examples for various use cases

The library is fully documented, includes multiple example sketches, and depends on ArduinoJson (>=6.0.0), WiFi, and HTTPClient libraries.

Repository: https://github.com/RacoonX65/LightweightIoT-Arduino-Lib
License: MIT