### PR TITLE
Added https://github.com/LCerimeli/StratoLit-BQ25611D to repositories.txt

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -8190,3 +8190,4 @@ https://github.com/faisalill/BMP390
 https://github.com/SpaceTrekKSC/MakerBox
 https://github.com/bull-m/BULLM-Extend-Motor
 https://github.com/BackLogers/RYUW122_UWB
+https://github.com/LCerimeli/StratoLit-BQ25611D


### PR DESCRIPTION
Library for configuring the BQ25611D battery charger via I2C on the Esp32. 