### PR TITLE
Remove github.com/VasilKalchev/RGBLED from libraries list

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -7107,7 +7107,6 @@ https://github.com/uStepper/uStepperS32
 https://github.com/vacmg/MAX_RS485
 https://github.com/VasilKalchev/ExponentMap
 https://github.com/VasilKalchev/LiquidMenu
-https://github.com/VasilKalchev/RGBLED
 https://github.com/VassilyDev/TSBridge
 https://github.com/VassilyDev/TSController
 https://github.com/vasutornjays/SCL3400


### PR DESCRIPTION
It seems that a compliant release of this library was never created, meaning that although there is a registry entry, the library is not actually listed in the libraries index.

The registration occurred eight years ago (https://github.com/arduino/arduino/issues/6257) and the repository has since either been deleted or made private, so a release of the library will never come. Thus, removing the registration will not cause any harm.

The existence of this "ghost registration" is problematic because the duplicate name check system uses the libraries index. Since the library is not present there, the check doesn't see that the name "RGBLED" has already been registered and thus will allow registration of additional libraries with that name (e.g., https://github.com/arduino/library-registry/pull/6509). In addition, its presence may cause confusion to the registry maintainers since we expect each registration to have a unique name.

Since the registration of the library provides no benefit and causes harm, it is removed.