### PR TITLE
Remove github.com/VasilKalchev/RGBLED registration

### DIFF
--- a/registry.txt
+++ b/registry.txt
@@ -1098,7 +1098,6 @@ https://github.com/adafruit/Adafruit_SPIFlash.git|Contributed|Adafruit SPIFlash
 https://github.com/AntoIOT/anto-esp8266-arduino.git|Contributed|anto-esp8266-arduino
 https://github.com/hedrickbt/MillaMilla_DS7505_Library.git|Contributed|MillaMilla DS7505 Library
 https://github.com/thexeno/DS1307-Emulator-Arduino-Library.git|Contributed|DS1307 Emulator
-https://github.com/VasilKalchev/RGBLED.git|Contributed|RGBLED
 https://github.com/JoaquimFlavio/GuaraTeca_Menu.git|Contributed|GuaraTeca_Menu
 https://github.com/jmparatte/jm_LiquidCrystal_I2C.git|Contributed|jm_LiquidCrystal_I2C
 https://github.com/JoaquimFlavio/GuaraTeca_Hardware.git|Contributed|GuaraTeca_Hardware


### PR DESCRIPTION
It seems that a compliant release of this library was never created, meaning that although there is a registry entry, the library is not actually listed in the [libraries index](http://downloads.arduino.cc/libraries/library_index.json).

The registration occurred eight years ago (https://github.com/arduino/arduino/issues/6257) and the repository has since either been deleted or made private, so a release of the library will never come. Thus, removing the registration will not cause any harm.

The existence of this "ghost registration" is problematic because the duplicate name check system uses the libraries index. Since the library is not present there, the check doesn't see that the name "RGBLED" has already been registered and thus will allow registration of additional libraries with that name (e.g., https://github.com/arduino/library-registry/pull/6509). In addition, its presence may cause confusion to the registry maintainers since we expect each registration to have a unique name.

Since the registration of the library provides no benefit and causes harm, it is removed.

---

Normally a removal operation in the registry must be accompanied by an operation on the "backend" machine. However, in this case there is no trace of the library on the "backend" machine because this only occurs when at least one release of the library has been indexed. So the removal is accomplished without any action needed on the "backend".