### PR TITLE
Remove inappropriately registered "rgbled" library from list

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -5926,7 +5926,6 @@ https://github.com/SantiagoSaldana/SBC
 https://github.com/Saruccio/ESPpassthrough
 https://github.com/satspares/DWIN_DGUS_HMI
 https://github.com/sauttefk/RS485HwSerial
-https://github.com/sb1978/rgbled
 https://github.com/sblantipodi/arduino_bootstrapper
 https://github.com/sbouhoun/smoother/
 https://github.com/scheffield/sic45x-driver


### PR DESCRIPTION
The library's readme describes it as follows:

https://github.com/sb1978/rgbled#rgb-led-lib-arduino

> Just an example of what it takes to provide an Arduino library. This is not meant to be a serious implementation.

Libraries should only be registered if the library maintainer believes they may be of value to the Arduino community. Registration of a library that is not expected to be of value to the community is pointless, and irresponsible since it pollutes the Library Manager listings and increases the burden on the Library Registry maintainers.

There has only been one commit to the library in the last eight years, and that commit only added a comment, three years ago. So there isn't any indication that the library's status can be expected to change.