### PR TITLE
Remove inappropriately registered "rgbled" library from registry

### DIFF
--- a/registry.txt
+++ b/registry.txt
@@ -6645,7 +6645,6 @@ https://github.com/simonlmn/serial-transport.git|Contributed|serial-transport
 https://github.com/bonezegei/Bonezegei_PCF8574.git|Contributed|Bonezegei_PCF8574
 https://github.com/arduino-libraries/Arduino_PortentaMachineControl.git|Arduino|Arduino_PortentaMachineControl
 https://github.com/eloquentarduino/eloquent_esp32cam_remote.git|Contributed|eloquent_remote
-https://github.com/sb1978/rgbled.git|Contributed|rgbled
 https://github.com/mkeras/BasicTag.git|Contributed|BasicTag
 https://github.com/bonezegei/Bonezegei_LCD1602_I2C.git|Contributed|Bonezegei LCD1602 I2C
 https://github.com/remocons/remocon-arduino.git|Contributed|Remocon


### PR DESCRIPTION
The library's readme describes it as follows:

https://github.com/sb1978/rgbled#rgb-led-lib-arduino

> Just an example of what it takes to provide an Arduino library. This is not meant to be a serious implementation.

Libraries should only be registered if the library maintainer believes they may be of value to the Arduino community. Registration of a library that is not expected to be of value to the community is pointless, and irresponsible since it pollutes the Library Manager listings and increases the burden on the Library Registry maintainers.

There has only been one commit to the library in the last eight years, and that commit only added a comment, three years ago. So there isn't any indication that the library's status can be expected to change.