### PR TITLE
Add WiFiEnterprise library

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -4,6 +4,7 @@ https://github.com/GalaidaMaxim/Delayer
 https://github.com/TheBlackSwitch/PS2Keyboard
 https://github.com/aiplayuser/esp8266easylib.git
 https://github.com/Circuit-Digest/GeoLinkerLite
+https://github.com/RacoonX65/LightweightIoT-Arduino-Lib
 https://github.com/RCmags/CN0391
 https://github.com/Init-io/InitMQTT.git
 https://github.com/Init-io/InitJson.git

--- a/repositories.txt
+++ b/repositories.txt
@@ -5,6 +5,7 @@ https://github.com/TheBlackSwitch/PS2Keyboard
 https://github.com/aiplayuser/esp8266easylib.git
 https://github.com/Circuit-Digest/GeoLinkerLite
 https://github.com/RacoonX65/LightweightIoT-Arduino-Lib
+https://github.com/judas/CalibrationLib
 https://github.com/RCmags/CN0391
 https://github.com/Init-io/InitMQTT.git
 https://github.com/Init-io/InitJson.git

--- a/repositories.txt
+++ b/repositories.txt
@@ -4,8 +4,8 @@ https://github.com/GalaidaMaxim/Delayer
 https://github.com/TheBlackSwitch/PS2Keyboard
 https://github.com/aiplayuser/esp8266easylib.git
 https://github.com/Circuit-Digest/GeoLinkerLite
-https://github.com/RacoonX65/LightweightIoT-Arduino-Lib
 https://github.com/RacoonX65/CalibrationLib.git
+https://github.com/RacoonX65/LightweightIoT-Arduino-Lib
 https://github.com/RCmags/CN0391
 https://github.com/Init-io/InitMQTT.git
 https://github.com/Init-io/InitJson.git

--- a/repositories.txt
+++ b/repositories.txt
@@ -5,7 +5,6 @@ https://github.com/TheBlackSwitch/PS2Keyboard
 https://github.com/aiplayuser/esp8266easylib.git
 https://github.com/Circuit-Digest/GeoLinkerLite
 https://github.com/RacoonX65/CalibrationLib.git
-https://github.com/RacoonX65/LightweightIoT-Arduino-Lib
 https://github.com/RCmags/CN0391
 https://github.com/Init-io/InitMQTT.git
 https://github.com/Init-io/InitJson.git

--- a/repositories.txt
+++ b/repositories.txt
@@ -5,7 +5,7 @@ https://github.com/TheBlackSwitch/PS2Keyboard
 https://github.com/aiplayuser/esp8266easylib.git
 https://github.com/Circuit-Digest/GeoLinkerLite
 https://github.com/RacoonX65/LightweightIoT-Arduino-Lib
-https://github.com/judas/CalibrationLib
+https://github.com/RacoonX65/CalibrationLib.git
 https://github.com/RCmags/CN0391
 https://github.com/Init-io/InitMQTT.git
 https://github.com/Init-io/InitJson.git

--- a/repositories.txt
+++ b/repositories.txt
@@ -6,6 +6,7 @@ https://github.com/aiplayuser/esp8266easylib.git
 https://github.com/Circuit-Digest/GeoLinkerLite
 https://github.com/RacoonX65/CalibrationLib.git
 https://github.com/RCmags/CN0391
+https://github.com/RacoonX65/WiFiEnterprise
 https://github.com/Init-io/InitMQTT.git
 https://github.com/Init-io/InitJson.git
 https://github.com/phuongnamzz/HLK-LD6002


### PR DESCRIPTION
Adding WiFiEnterprise - A lightweight Arduino library for ESP32 WPA2-Enterprise network connectivity.

Features:
- Simple API for WPA2-Enterprise (EAP-PEAP) connections
- 13 comprehensive examples
- Full ESP32 compatibility
- Minimal dependencies