### PR TITLE
Remove "BULLM-Extend-Motor" from repository list

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -8206,7 +8206,6 @@ https://github.com/HS3UKA/HS3UKA_PCF8574
 https://github.com/muhpuc40/MacRandomizer
 https://github.com/faisalill/BMP390
 https://github.com/SpaceTrekKSC/MakerBox
-https://github.com/bull-m/BULLM-Extend-Motor
 https://github.com/BackLogers/RYUW122_UWB
 https://github.com/LCerimeli/StratoLit-BQ25611D
 https://github.com/gly-engine/core-native-arduino


### PR DESCRIPTION
A duplicate copy of the library was submitted rather than following the standard procedure for requesting a name change request: https://github.com/arduino/library-registry/pull/6598.

The presence of this entry no longer serves any value and only clutters up Library Manager.