### PR TITLE
Remove "BULLM-Extend-Motor" from registry

### DIFF
--- a/registry.txt
+++ b/registry.txt
@@ -8175,7 +8175,6 @@ https://github.com/phuongnamzz/HLK-LD2410S.git|Contributed|HLK-LD2410S
 https://github.com/danel32/Arduino-Library-for-MAX7300.git|Contributed|MAX7300
 https://github.com/SpaceTrekKSC/MakerBox.git|Contributed|SpaceTrek MakerBox
 https://github.com/mirosieber/OPT300x.git|Contributed|OPT300x
-https://github.com/bull-m/BULLM-Extend-Motor.git|Contributed|BULLM-Extend-Motor
 https://github.com/esharp17/Mecanum_Base.git|Contributed|MecanumBase
 https://github.com/aiplayuser/esp32easylib.git|Contributed|esp32easylib
 https://github.com/brianvarren/EEncoder.git|Contributed|EEncoder


### PR DESCRIPTION
A duplicate copy of the library was submitted rather than following the standard procedure for requesting a name change request: https://github.com/arduino/library-registry/pull/6598.

The presence of this entry no longer serves any value and only clutters up Library Manager.

---

Companion to https://github.com/arduino/library-registry/pull/6600