### PR TITLE
Add Simple Modbus Slave

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -8226,3 +8226,4 @@ https://github.com/markub3327/LiquidCrystal_I2C
 https://github.com/styropyr0/Wizer
 https://github.com/bull-m/BULLM_ExtendMotor
 https://github.com/npuckett/WebGUI
+https://github.com/kolod/Arduino-Simple-Modbus-Slave


### PR DESCRIPTION
Arduino Simple Modbus Slave is an ISC licensed library to handle Modbus requests on Arduino (slave).

# Features

To keep it simple and to reduce memory consumption, only the two following
Modbus functions are supported:

* read holding registers (0x03)
* write multiple registers (0x10)****