### PR TITLE
Add PantryClient library to Arduino Library Manager

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -8237,3 +8237,4 @@ https://github.com/BestModules-Libraries/BMH12M205
 https://github.com/BestModules-Libraries/BMS56M206A
 https://github.com/BestModules-Libraries/BMH08101
 https://github.com/BestModules-Libraries/BMV31M304A
+https://github.com/Zakrzewiaczek/pantryclient-esp


### PR DESCRIPTION
Please add my library `PantryClient` to the Arduino Library Manager.

Repository: https://github.com/Zakrzewiaczek/pantryclient-esp  
Version: 0.1.0  
License: GPL-3.0  
Architectures: esp32, esp8266  
Description: A simple Arduino client for the Pantry service, allowing you to store and retrieve JSON data for your ESP32 or ESP8266 projects.