### PR TITLE
LCD control via shift register

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -8259,3 +8259,4 @@ https://github.com/MicroSui/microsui-lib
 https://github.com/muki01/OBD2_KLine_Library
 https://github.com/max22-/ble-keyboard-mouse-client
 https://github.com/John-Karatka/DS1621
+https://github.com/Martin4017/LCDShiftView


### PR DESCRIPTION
This pull request adds the LCDShiftView library to the Arduino Library Registry.

LCDShiftView is a lightweight and flexible library for controlling character LCDs (16x2, 20x4, etc.) using a shift register (like 74HC595). The library minimizes pin usage and supports custom pin mappings, custom characters, and extended LCD sizes.

GitHub Repo: https://github.com/Martin4017/LCDShiftView
Latest tag: v1.0.0
