### PR TITLE
Update repositories.txt

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -8266,3 +8266,4 @@ https://github.com/njazz/rowguelike
 https://github.com/ErtugrulKra/ESP-Music
 https://github.com/nexbyteio/ZenLib
 https://github.com/tomorrow56/ESP32_LINE_Messaging_API
+https://github.com/toddpan/xiaozhi-esp32-mcp


### PR DESCRIPTION
ESP32 虾哥小智平台MCP客户端库，用于通过MCP插件将ESP32设备接入虾哥小智平台，支持工具注册和调用，可通过小智AI音箱控制设备。