### PR TITLE
Add 7Semi HMC6343 Compass library for inclusion in Arduino Library Ma…

### DIFF
--- a/.github/workflows/inclusion/7semi_hmc6343.yml
+++ b/.github/workflows/inclusion/7semi_hmc6343.yml
@@ -1,0 +1,3 @@
+---
+name: 7Semi HMC6343 Compass
+url: https://github.com/7semi-solutions/7Semi-HMC6343-3-Axis-Digital-Compass-Module-with-Tilt-Compensation-I2C-Arduino-Library


### PR DESCRIPTION
This PR adds the 7Semi HMC6343 Compass Arduino library for inclusion in the Arduino Library Manager.  
Repository: https://github.com/7semi-solutions/7Semi-HMC6343-3-Axis-Digital-Compass-Module-with-Tilt-Compensation-I2C-Arduino-Library
