### PR TITLE
Revoke registry privileges for github.com/7semi-Tech

### DIFF
--- a/.github/workflows/assets/accesslist.yml
+++ b/.github/workflows/assets/accesslist.yml
@@ -18,6 +18,10 @@
   access: deny
   reference: https://github.com/arduino/library-registry/pull/5734#pullrequestreview-2548818476
 - host: github.com
+  name: 7semi-Tech
+  access: deny
+  reference: https://github.com/arduino/library-registry/pull/5734#pullrequestreview-2548818476
+- host: github.com
   name: ajangrahmat
   access: deny
   reference: https://github.com/arduino/library-registry/pull/5706#issuecomment-2588923290


### PR DESCRIPTION
This user has established a pattern of irresponsible behavior in the Arduino Library Manager Registry repository. They continued this behavior even after the bot and human maintainer made significant efforts to guide them to responsible use.