### PR TITLE
Restore registry privileges for `github.com/7Semi` and `github.com/7semi-tech`

### DIFF
--- a/.github/workflows/assets/accesslist.yml
+++ b/.github/workflows/assets/accesslist.yml
@@ -14,14 +14,6 @@
   access: deny
   reference: https://github.com/arduino/library-registry/pull/6269#pullrequestreview-2813557457
 - host: github.com
-  name: 7Semi
-  access: deny
-  reference: https://github.com/arduino/library-registry/pull/5734#pullrequestreview-2548818476
-- host: github.com
-  name: 7semi-Tech
-  access: deny
-  reference: https://github.com/arduino/library-registry/pull/5734#pullrequestreview-2548818476
-- host: github.com
   name: ajangrahmat
   access: deny
   reference: https://github.com/arduino/library-registry/pull/5706#issuecomment-2588923290


### PR DESCRIPTION
This user has requested the restoration of their Arduino Library Manager Registry privileges: https://github.com/arduino/library-registry/issues/6683. The request was approved.