### PR TITLE
Add QuickAPConnect to Arduino Library Manager

### DIFF
--- a/libraries/QuickAPConnect.yml
+++ b/libraries/QuickAPConnect.yml
@@ -1,0 +1,2 @@
+name: QuickAPConnect
+url: https://github.com/jaikulk14/QuickAPConnect

--- a/libraries/QuickAPConnect.yml
+++ b/libraries/QuickAPConnect.yml
@@ -1,2 +1,0 @@
-name: QuickAPConnect
-url: https://github.com/jaikulk14/QuickAPConnect

--- a/repositories.txt
+++ b/repositories.txt
@@ -8260,6 +8260,8 @@ https://github.com/max22-/cst816d
 https://github.com/HarutoHiroki/VFDDisplay
 https://github.com/steveeidemiller/SE_BME680
 https://github.com/BestModules-Libraries/BME36M280A
+https://github.com/jaikulk14/QuickAPConnect
+
 https://github.com/BestModules-Libraries/BM62S6021-1
 https://github.com/teldrive-jpg/modbusmaster-GigaR1
 https://github.com/kodediy/kode_bq27220


### PR DESCRIPTION
This pull request adds QuickAPConnect to the Arduino Library Manager registry.
QuickAPConnect is an Arduino library for quickly connecting devices to Wi-Fi networks using Access Point mode and a configuration portal.
