### PR TITLE
Add BLE OTA Firmware Update library

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -8272,3 +8272,4 @@ https://github.com/ArtronShop/TinkerC6_Library
 https://github.com/tobiastl/LD2412
 https://github.com/Benas09/FujitsuAC
 https://github.com/TektiteBiz/TektiteRotEv
+https://github.com/Raghav117/bluetooth_ota_firmware_update.git


### PR DESCRIPTION
 Adds BLE OTA Firmware Update library for ESP32 devices.
   
   This library provides:
   - BLE OTA firmware updates
   - Configurable UUIDs
   - Progress monitoring
   - Command interface
   - Error handling
   
   Repository: https://github.com/Raghav117/bluetooth_ota_firmware_update