### PR TITLE
Update URL of "BrainflowSpO2Algorithm"

### DIFF
--- a/registry.txt
+++ b/registry.txt
@@ -8152,7 +8152,7 @@ https://github.com/LFranklinApps/Custom_Robot_Control.git|Contributed|Custom_Rob
 https://github.com/npuckett/WebGUI.git|Contributed|WebGUI
 https://github.com/kolod/Arduino-Simple-Modbus-Slave.git|Contributed|SimpleModbusSlave
 https://github.com/EmotiBit/EmotiBit_DSPFilters.git|Contributed|EmotiBit_DSPFilters
-https://github.com/EmotiBit/BrainflowSpO2Algorithm.git|Contributed|BrainflowSpO2Algorithm
+https://github.com/EmotiBit/EmotiBit_Brainflow_SpO2_Algorithm.git|Contributed|BrainflowSpO2Algorithm
 https://github.com/m5stack/M5Unit-TUBE.git|Contributed|M5Unit-TUBE
 https://github.com/TelemetryHarbor/harbor-sdk-c-plus-plus.git|Contributed|TelemetryHarborSDK
 https://github.com/ycharfi09/QTRMuxes.git|Contributed|QTRMuxes


### PR DESCRIPTION
Companion (partial) to https://github.com/arduino/library-registry/pull/6757