### PR TITLE
Add SendOnlySerial library

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -8304,4 +8304,5 @@ https://github.com/salesiopark/Chaino.git
 https://github.com/jaikulk14/DataLinkSerial
 https://github.com/tomorrow56/ESPNowAutoPairing
 https://github.com/yohanna02/ESPComm
+https://github.com/gvp-257/SendOnlySerial
 https://github.com/CuiYao631/HomeSpan-zh


### PR DESCRIPTION
Low RAM and flash memory library for debugging and logging over serial, instead of using Serial. Saves SRAM and flash memory for boards based on ATmega328P.