### PR TITLE
Rename Modulino Library

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -1286,7 +1286,7 @@ https://github.com/arduino-libraries/MKRMotorCarrier
 https://github.com/arduino-libraries/MKRNB
 https://github.com/arduino-libraries/MKRWAN
 https://github.com/arduino-libraries/MKRWAN_v2
-https://github.com/arduino-libraries/Modulino
+https://github.com/arduino-libraries/Arduino_Modulino
 https://github.com/arduino-libraries/Mouse
 https://github.com/arduino-libraries/NTPClient
 https://github.com/arduino-libraries/PhysicsLabFirmware


### PR DESCRIPTION
This PR changes the URL of the Modulino library to the new name with prefix after merging [this PR](https://github.com/arduino-libraries/Arduino_Modulino/pull/22)