### PR TITLE
Add 7Semi HMC6343 Compass library

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -8312,3 +8312,4 @@ https://github.com/gvp-257/SendOnlySerial
 https://github.com/CuiYao631/HomeSpan-zh
 https://github.com/satoyon/PFNFont
 https://github.com/nexbyteio/ZenRTC.git
+https://github.com/7semi-solutions/7Semi-HMC6343-3-Axis-Digital-Compass-Module-with-Tilt-Compensation-I2C-Arduino-Library


### PR DESCRIPTION
This PR adds the 7Semi HMC6343 3-Axis Digital Compass Module with Tilt Compensation I2C Arduino Library to the Arduino Library Manager index.

Repository URL:
https://github.com/7semi-solutions/7Semi-HMC6343-3-Axis-Digital-Compass-Module-with-Tilt-Compensation-I2C-Arduino-Library

The library provides support for heading, pitch, roll, magnetometer, accelerometer, and temperature readings from the HMC6343 sensor, with calibration and configuration features.
