### PR TITLE
Add 7Semi SCD4x Arduino Library

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -8317,3 +8317,4 @@ https://github.com/7semi-solutions/7Semi-HMC6343-3-Axis-Digital-Compass-Module-w
 https://github.com/AirNgin/Airngin-stm32-mqtt-client
 https://github.com/AlphaNodesDev/SciFy-Iot
 https://github.com/RigelSixSix/flagManager
+https://github.com/7semi-solutions/7Semi-SCD4x-Arduino-Library


### PR DESCRIPTION
This PR adds the 7Semi SCD4x Arduino Library to the Arduino Library Manager index.

Repository URL:
https://github.com/7semi-solutions/7Semi-SCD4x-Arduino-Library

The library provides support for Sensirion SCD4x CO₂ sensors over I2C, enabling easy integration for measuring CO₂ concentration, temperature, and humidity in Arduino projects.
