### PR TITLE
Add 7Semi L89HA GNSS Module Arduino Library

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -8322,3 +8322,4 @@ https://github.com/RigelSixSix/flagManager
 https://github.com/7semi-solutions/7Semi-SCD4x-Arduino-Library
 https://github.com/Robotistan/PicoBricks-for-ESP32-Arduino
 https://github.com/ayresnet/AyresWiFiManager
+https://github.com/7semi-solutions/7Semi-L89HA-GNSS-Module-Arduino-Library


### PR DESCRIPTION
This PR adds the 7Semi L89HA GNSS Module Arduino Library to the Arduino Library Manager index.

Repository URL:
https://github.com/7semi-solutions/7Semi-L89HA-GNSS-Module-Arduino-Library

The library provides support for the L89HA GNSS module over UART, including:
- Multi-constellation GNSS (GPS, GLONASS, Galileo, BeiDou)
- Position, velocity, and time retrieval
- NMEA sentence parsing
- Easy Arduino integration for navigation and tracking applications