### PR TITLE
Add 7Semi ADXL335 Analog Accelerometer Module Arduino Library

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -8332,3 +8332,4 @@ https://github.com/CharminJunior/UOS
 https://github.com/NitrofMtl/DUERS485DMA
 https://github.com/NitrofMtl/DUE-ModbusDMA
 https://github.com/rahulstva/RS_ThingSpeak
+https://github.com/7semi-solutions/7Semi-ADXL335-Analog-Accelerometer-Module-Arduino-Library


### PR DESCRIPTION
This PR adds the 7Semi ADXL335 Analog Accelerometer Module Arduino Library to the Arduino Library Manager index.

Repository URL:
https://github.com/7semi-solutions/7Semi-ADXL335-Analog-Accelerometer-Module-Arduino-Library

The library provides support for reading X, Y, and Z acceleration from the ADXL335 analog accelerometer. It includes conversion utilities, example sketches, and is ideal for motion detection, tilt sensing, and robotics applications.
