### PR TITLE
Add 7Semi INA260 Current/Power/Voltage Monitor Arduino Library

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -8335,3 +8335,4 @@ https://github.com/NitrofMtl/DUERS485DMA
 https://github.com/NitrofMtl/DUE-ModbusDMA
 https://github.com/rahulstva/RS_ThingSpeak
 https://github.com/7semi-solutions/7Semi-ADXL335-Analog-Accelerometer-Module-Arduino-Library
+https://github.com/7semi-solutions/7Semi-INA260-Current-Power-Voltage-Monitor-Arduino-Library


### PR DESCRIPTION
This PR adds the 7Semi INA260 Current/Power/Voltage Monitor Arduino Library to the Arduino Library Manager index.

Repository URL:
https://github.com/7semi-solutions/7Semi-INA260-Current-Power-Voltage-Monitor-Arduino-Library

The library provides easy APIs to read bus voltage, current, and power from the INA260 over I2C, with configurable averaging and conversion times. Example sketches are included for a quick start.
