### PR TITLE
Add ToFFilter library

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -8335,3 +8335,4 @@ https://github.com/NitrofMtl/DUERS485DMA
 https://github.com/NitrofMtl/DUE-ModbusDMA
 https://github.com/rahulstva/RS_ThingSpeak
 https://github.com/7semi-solutions/7Semi-ADXL335-Analog-Accelerometer-Module-Arduino-Library
+https://github.com/Mataas08/ToFFilter


### PR DESCRIPTION
This pull request adds the ToFFilter library.

Repository: https://github.com/Mataas08/ToFFilter
Description: Adaptive filtering library for Time-of-Flight (ToF) sensors such as VL53L0X and VL53L1X.
Features:
- Median filter (3 samples)
- Deadband to remove micro-jitter
- Adaptive EMA with log-sigmoid alpha
- Configurable presets (FastResponse, StableLongRange)
Category: Sensors