### PR TITLE
Add 7Semi BME690 Arduino Library

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -8340,3 +8340,4 @@ https://github.com/Mataas08/ToFFilter
 https://github.com/7semi-solutions/7Semi-INA260-Current-Power-Voltage-Monitor-Arduino-Library
 https://github.com/milescb/PlantMonitor
 https://github.com/tomorrow56/ESP32FwUploader
+https://github.com/7semi-solutions/7Semi-BME690-Arduino-Library


### PR DESCRIPTION
This PR adds the 7Semi BME690 Arduino Library to the Arduino Library Manager index.

Repository URL:
https://github.com/7semi-solutions/7Semi-BME690-Arduino-Library

The library provides easy APIs to read temperature, humidity, and pressure (and gas/VOC if supported) from the BME690 sensor, with example sketches for quick integration.
