### PR TITLE
Add SL002_DHT11 library

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -1,3 +1,4 @@
+https://github.com/deepanshu-deshwal/SL002_DHT11
 https://github.com/deepanshu-deshwal/SL001_Deepanshu
 https://github.com/cocoisarobo/skytraq-navic
 https://github.com/LordofRobots/LoR_v3


### PR DESCRIPTION
This PR adds the **SL002_DHT11** library to the Arduino Library Manager index.

- Simple Arduino library for reading DHT11 temperature & humidity sensor  
- Provides a minimal API with error codes  
- Includes example sketch for quick testing  
- Licensed under MIT License  

Repository: https://github.com/deepanshu-deshwal/SL002_DHT11  
Tag: v1.0.0