### PR TITLE
Add new repository link for progmem_far

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -2731,6 +2731,7 @@ https://github.com/feklee/MultiTrans
 https://github.com/felias-fogg/avrCalibrate
 https://github.com/felias-fogg/DotMatrix5x7
 https://github.com/felias-fogg/FlexWire
+https://github.com/felias-fogg/progmem_far
 https://github.com/felias-fogg/SingleWireSerial
 https://github.com/felias-fogg/SoftI2CMaster
 https://github.com/felias-fogg/TXOnlySerial


### PR DESCRIPTION
A tiny library that adds the missing PROGMEM_FAR macro that permits you to push PROGMEM data to the far end of flash memory.