### PR TITLE
Add 7Semi ACS772 Current Sensor Arduino Library

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -8353,3 +8353,4 @@ https://github.com/Glinek/picoEEPROM
 https://github.com/alexghrrsn/Ecowitt-Gateway-Parser/
 https://github.com/harishfaqot/TF-LC02
 https://github.com/harishfaqot/Atlas_EC
+https://github.com/7semi-solutions/7Semi-ACS772-CurrentSensor-Arduino-Library


### PR DESCRIPTION
This PR adds the 7Semi ACS772 Current Sensor Arduino Library to the Arduino Library Manager index.

Repository URL:
https://github.com/7semi-solutions/7Semi-ACS772-CurrentSensor-Arduino-Library

The library provides easy APIs for reading current from the ACS772 Hall-effect sensor via the analog output, with zero-offset and mV/A sensitivity configuration. Example sketches are included for quick calibration and measurement.
