### PR TITLE
Add 7Semi SHT4x Arduino Library

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -8357,3 +8357,4 @@ https://github.com/alexghrrsn/Ecowitt-Gateway-Parser/
 https://github.com/harishfaqot/TF-LC02
 https://github.com/harishfaqot/Atlas_EC
 https://github.com/7semi-solutions/7Semi-ACS772-CurrentSensor-Arduino-Library
+https://github.com/7semi-solutions/7Semi-SHT4x-Arduino-Library


### PR DESCRIPTION
This PR adds the 7Semi SHT4x Arduino Library to the Arduino Library Manager index.

Repository URL:
https://github.com/7semi-solutions/7Semi-SHT4x-Arduino-Library

The library provides easy APIs to read temperature and relative humidity from Sensirion SHT4x sensors (SHT40/SHT41/SHT45) over I2C, with optional heater and repeatability settings. Example sketches are included for a quick start.
