### PR TITLE
Update repositories.txt

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -8359,3 +8359,4 @@ https://github.com/harishfaqot/Atlas_EC
 https://github.com/7semi-solutions/7Semi-ACS772-CurrentSensor-Arduino-Library
 https://github.com/7semi-solutions/7Semi-SHT4x-Arduino-Library
 https://github.com/jonavarro22/MAX7SegmentDisplay
+https://github.com/sutiana/WiFiConfigManager


### PR DESCRIPTION
Add ESP32 WiFi library featuring a non-blocking web portal for easy setup of Station & Access Point modes. Persistently stores credentials using Preferences.