### PR TITLE
Add 7Semi DS18B20 Arduino Library

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -8360,3 +8360,4 @@ https://github.com/7semi-solutions/7Semi-ACS772-CurrentSensor-Arduino-Library
 https://github.com/7semi-solutions/7Semi-SHT4x-Arduino-Library
 https://github.com/jonavarro22/MAX7SegmentDisplay
 https://github.com/sutiana/WiFiConfigManager
+https://github.com/7semi-solutions/7Semi-DS18B20-Arduino-Library


### PR DESCRIPTION
This PR adds the 7Semi DS18B20 Arduino Library to the Arduino Library Manager index.

Repository URL:
https://github.com/7semi-solutions/7Semi-DS18B20-Arduino-Library

The library provides simple APIs to read temperature from DS18B20 1-Wire sensors, with example sketches for a quick start.
