### PR TITLE
Update repositories.txt

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -8362,3 +8362,4 @@ https://github.com/7semi-solutions/7Semi-SHT4x-Arduino-Library
 https://github.com/jonavarro22/MAX7SegmentDisplay
 https://github.com/sutiana/WiFiConfigManager
 https://github.com/7semi-solutions/7Semi-DS18B20-Arduino-Library
+https://github.com/JackHat1/MT07_CAN_Project


### PR DESCRIPTION
Initial release of the MT07_CAN_Library for Arduino.

This library allows Arduino boards to interface with the Yamaha MT-07 CAN bus using the MCP2515 module. 
It provides functions to read RPM, throttle position, and other important motorcycle parameters.

Installation:
1. Download the ZIP or clone the repository.
2. Add it in Arduino IDE via Sketch > Include Library > Add .ZIP Library.
3. See example sketches in the examples/ folder.

Hardware:
- Yamaha MT-07 (2014+)
- MCP2515 CAN Module
- Arduino or ESP32 board
