### PR TITLE
Add 7Semi MAX17048 Arduino Library

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -8363,3 +8363,4 @@ https://github.com/7semi-solutions/7Semi-SHT4x-Arduino-Library
 https://github.com/jonavarro22/MAX7SegmentDisplay
 https://github.com/sutiana/WiFiConfigManager
 https://github.com/7semi-solutions/7Semi-DS18B20-Arduino-Library
+https://github.com/7semi-solutions/7Semi-MAX17048-Arduino-Library


### PR DESCRIPTION
This PR adds the 7Semi MAX17048 Arduino Library to the Arduino Library Manager index.

Repository URL:
https://github.com/7semi-solutions/7Semi-MAX17048-Arduino-Library

The library provides easy APIs to read state of charge (SOC) and voltage from the MAX17048 fuel gauge over I2C, with helpers for alert configuration and example sketches for a quick start.