### PR TITLE
Remove EasySTEAM library

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -283,7 +283,6 @@ https://github.com/jobitjoseph/ESPWebFileManager
 https://github.com/playfultechnology/PN5180
 https://github.com/baaaaan1/BuzzerManager
 https://github.com/baaaaan1/EEPROMHandler
-https://github.com/stemosofc/EasySTEAM
 https://github.com/fotherja/BQ76952
 https://github.com/RASPIAUDIO/Muse_library
 https://github.com/ZanPekosak/AnalogFilter


### PR DESCRIPTION
I would like this library to be removed from Arduino library register.