### PR TITLE
Remove "EasySTEAM"

### DIFF
--- a/registry.txt
+++ b/registry.txt
@@ -7454,7 +7454,6 @@ https://gitlab.com/leandro.mattioli/Mux7SegsDisplay.git|Contributed|Mux7SegsDisp
 https://github.com/ConsentiumIoT/ConsentiumNow.git|Contributed|ConsentiumNow
 https://github.com/RobTillaart/SD2405.git|Contributed|SD2405
 https://github.com/gooddisplayshare/ESP32epdx.git|Contributed|ESP32epdx
-https://github.com/stemosofc/EasySTEAM.git|Contributed|EasySTEAM
 https://github.com/playfultechnology/PN5180.git|Contributed|PN5180
 https://github.com/cvmanjoo/LM75.git|Contributed|LM75
 https://github.com/ArtronShop/ArtronShop_RX8130CE.git|Contributed|ArtronShop_RX8130CE


### PR DESCRIPTION
Companion to https://github.com/arduino/library-registry/pull/6893