### PR TITLE
Add 7Semi HX711 Arduino Library

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -8369,3 +8369,4 @@ https://github.com/7semi-solutions/7Semi-DS18B20-Arduino-Library
 https://github.com/7semi-solutions/7Semi-MAX17048-Arduino-Library
 https://github.com/BlueskyBV/Easy_Web_Remote_Control-ESP32-
 https://github.com/JackHat1/MT07_CAN_Project
+https://github.com/7semi-solutions/7Semi-HX711-Arduino-Library


### PR DESCRIPTION
This PR adds the 7Semi HX711 Arduino Library to the Arduino Library Manager index.

Repository URL:
https://github.com/7semi-solutions/7Semi-HX711-Arduino-Library

The library provides easy APIs for reading raw/averaged values from the HX711 24-bit load cell amplifier, with helpers for gain/channel selection and an example sketch for calibration and weight measurement.
