### PR TITLE
Add king_Armin_sparkyTDAxis12_I2C_lib to Library Manager index

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -8367,6 +8367,7 @@ https://github.com/jonavarro22/MAX7SegmentDisplay
 https://github.com/sutiana/WiFiConfigManager
 https://github.com/7semi-solutions/7Semi-DS18B20-Arduino-Library
 https://github.com/7semi-solutions/7Semi-MAX17048-Arduino-Library
+https://github.com/Rmin-code2005/sparkey_gyro_I2C
 https://github.com/BlueskyBV/Easy_Web_Remote_Control-ESP32-
 https://github.com/JackHat1/MT07_CAN_Project
 https://github.com/7semi-solutions/7Semi-HX711-Arduino-Library


### PR DESCRIPTION
This commit adds the repository URL for the king_Armin_sparkyTDAxis12_I2C_lib to the repositories.txt file.

The library provides I2C communication support for the TDAxis12 sensor, including initialization, calibration, and reading of X, Y, Z axis angles.

The repository includes:
- A valid library.properties file
- MIT license
- Proper folder structure (src/, examples/)
- A release tag (v1.0.0)

Repository URL:
https://github.com/Rmin-code2005/king_Armin_sparkyTDAxis12_I2C_lib