### PR TITLE
Add AyresShell

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -8375,3 +8375,4 @@ https://github.com/BlueskyBV/Easy_Web_Remote_Control-ESP32-
 https://github.com/JackHat1/MT07_CAN_Project
 https://github.com/7semi-solutions/7Semi-HX711-Arduino-Library
 https://github.com/Rmin-code2005/sh1106-1306_ui_assistance
+https://github.com/ayresnet/AyresShell


### PR DESCRIPTION
Add AyresShell to Arduino Library Manager

Repository: https://github.com/ayresnet/AyresShell
Purpose: Interactive serial shell for Arduino.

Checklist:
- [ ] library.properties present and valid
- [ ] src/ + examples/ structure
- [ ] SemVer release tag published (e.g. 1.0.0 or v1.0.0)
