### PR TITLE
Add 7Semi ADS1xx5 Arduino Library

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -8376,3 +8376,4 @@ https://github.com/JackHat1/MT07_CAN_Project
 https://github.com/7semi-solutions/7Semi-HX711-Arduino-Library
 https://github.com/Rmin-code2005/sh1106-1306_ui_assistance
 https://github.com/ayresnet/AyresShell
+https://github.com/7semi-solutions/7Semi-ADS1xx5-Arduino-Library


### PR DESCRIPTION
This PR adds the 7Semi ADS1xx5 Arduino Library to the Arduino Library Manager index.

Repository URL:
https://github.com/7semi-solutions/7Semi-ADS1xx5-Arduino-Library

The library provides easy APIs for ADS1015/ADS1115 (ADS1xx5) I2C ADCs, including single-ended/differential reads, PGA gain, data rate, and comparator/alert configuration. Example sketches are included for a quick start.
