### PR TITLE
add driver support  st7305 mono TFT  screen .

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -8380,3 +8380,4 @@ https://github.com/ayresnet/AyresShell
 https://github.com/7semi-solutions/7Semi-ADS1xx5-Arduino-Library
 https://github.com/tomrodinger/Servomotor_Arduino_Library
 https://github.com/csu333/TFTPClient
+https://github.com/FT-tele/ST7305_MonoTFT_Arduino_Library


### PR DESCRIPTION
ST7305_MonoTFT_Arduino_Library
2.9 inch and 4.2 inch .
 include 3 demo.

#沃乐康 
#鱼鹰广电

@ArduinoBot I have created a new release with the tag `1.0.1` to match the version in the `library.properties` file. Please check again.