### PR TITLE
Add 7Semi ADS126x Arduino Library

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -8381,3 +8381,4 @@ https://github.com/7semi-solutions/7Semi-ADS1xx5-Arduino-Library
 https://github.com/tomrodinger/Servomotor_Arduino_Library
 https://github.com/csu333/TFTPClient
 https://github.com/FT-tele/ST7305_MonoTFT_Arduino_Library
+https://github.com/7semi-solutions/7Semi-ADS126x-Arduino-Library


### PR DESCRIPTION
This PR adds the 7Semi ADS126x Arduino Library to the Arduino Library Manager index.

Repository URL:
https://github.com/7semi-solutions/7Semi-ADS126x-Arduino-Library

The library provides easy APIs for TI ADS1260/ADS1262 high-resolution ADCs over SPI, including single-ended/differential conversions, PGA, data rate, and CRC/status handling. Example sketches for single-shot and continuous conversion are included.
