### PR TITLE
Add 7Semi ADS7830 Arduino Library

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -8385,3 +8385,4 @@ https://github.com/tomrodinger/Servomotor_Arduino_Library
 https://github.com/csu333/TFTPClient
 https://github.com/FT-tele/ST7305_MonoTFT_Arduino_Library
 https://github.com/7semi-solutions/7Semi-ADS126x-Arduino-Library
+https://github.com/7semi-solutions/7Semi-ADS7830-Arduino-Library


### PR DESCRIPTION
This PR adds the 7Semi ADS7830 Arduino Library to the Arduino Library Manager index.

Repository URL:
https://github.com/7semi-solutions/7Semi-ADS7830-Arduino-Library

The library provides easy APIs for the TI ADS7830 8-channel 8-bit I2C ADC, including channel selection helpers and a basic example for quick start.
