### PR TITLE
Update name and URL of "Quick_digital_IO_interrupt"

### DIFF
--- a/registry.txt
+++ b/registry.txt
@@ -4015,7 +4015,7 @@ https://github.com/geeny/geenymodem.git|Contributed|GEENYmodem
 https://github.com/newdigate/teensy-sample-flashloader.git|Contributed|TeensyAudioFlashLoader
 https://github.com/newdigate/teensy-polyphony.git|Contributed|TeensyAudioSampler
 https://github.com/mandulaj/PZEM-004T-v30.git|Contributed|PZEM004Tv30
-https://github.com/Ebola-Chan-bot/Low_level_quick_digital_IO.git|Contributed|Low level quick digital IO
+https://github.com/Ebola-Chan-bot/Low_level_quick_digital_IO.git|Contributed|Quick_digital_IO_interrupt
 https://github.com/khoih-prog/AsyncWebServer_WT32_ETH01.git|Contributed|AsyncWebServer_WT32_ETH01
 https://github.com/akkoyun/Statistical.git|Contributed|Statistical
 https://github.com/aikopras/RSbus.git|Contributed|RSbus

--- a/registry.txt
+++ b/registry.txt
@@ -4015,7 +4015,7 @@ https://github.com/geeny/geenymodem.git|Contributed|GEENYmodem
 https://github.com/newdigate/teensy-sample-flashloader.git|Contributed|TeensyAudioFlashLoader
 https://github.com/newdigate/teensy-polyphony.git|Contributed|TeensyAudioSampler
 https://github.com/mandulaj/PZEM-004T-v30.git|Contributed|PZEM004Tv30
-https://github.com/Ebola-Chan-bot/Low_level_quick_digital_IO.git|Contributed|Quick_digital_IO_interrupt
+https://github.com/Ebola-Chan-bot/Quick_digital_IO_interrupt.git|Contributed|Quick_digital_IO_interrupt
 https://github.com/khoih-prog/AsyncWebServer_WT32_ETH01.git|Contributed|AsyncWebServer_WT32_ETH01
 https://github.com/akkoyun/Statistical.git|Contributed|Statistical
 https://github.com/aikopras/RSbus.git|Contributed|RSbus


### PR DESCRIPTION
This PR consists of two changes:

- Change URL from `https://github.com/Ebola-Chan-bot/Low_level_quick_digital_IO.git` to `https://github.com/Ebola-Chan-bot/Quick_digital_IO_interrupt.git` (companion to https://github.com/arduino/library-registry/pull/6918)
- Change name from `Low level quick digital IO` to `Quick_digital_IO_interrupt` (resolves https://github.com/arduino/library-registry/issues/6919)

Since the name change operation on the database is actually a removal followed by automated re-indexing on the next job run, the URL update will occur as a matter of course. For this reason, the only operation required from the backend maintainer is a standard name change procedure.
