### PR TITLE
Add Simple_Esp32WiFiManager library

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -8393,4 +8393,4 @@ https://github.com/FT-tele/ST7305_MonoTFT_Arduino_Library
 https://github.com/7semi-solutions/7Semi-ADS126x-Arduino-Library
 https://github.com/7semi-solutions/7Semi-ADS7830-Arduino-Library
 https://github.com/ghi-electronics/duelink-libraries-arduino
-https://github.com/tuusuario/Simple_Esp32WiFiManager
+https://github.com/charlie731/Simple_Esp32WiFiManager


### PR DESCRIPTION
This PR adds the Simple_Esp32WiFiManager library for ESP32.
Repository: https://github.com/charlie731/Simple_Esp32WiFiManager