### PR TITLE
Add 7Semi MAX31865 Arduino Library

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -8400,3 +8400,4 @@ https://github.com/7semi-solutions/7Semi-ADS7830-Arduino-Library
 https://github.com/ghi-electronics/duelink-libraries-arduino
 https://github.com/charlie731/Simple_Esp32WiFiManager
 https://github.com/Bitworx-cz/Updater
+https://github.com/7semi-solutions/7Semi-MAX31865-Arduino-Library


### PR DESCRIPTION
This PR adds the 7Semi MAX31865 Arduino Library to the Arduino Library Manager index.

Repository URL:
https://github.com/7semi-solutions/7Semi-MAX31865-Arduino-Library

The library provides easy APIs for the MAX31865 RTD-to-Digital converter over SPI, including PT100/PT1000 support (2/3/4-wire), bias and filter configuration, fault detection, and example sketches for quick integration.
