### PR TITLE
Add 7Semi MCP23017 Arduino Library

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -8405,3 +8405,4 @@ https://github.com/Bitworx-cz/Updater
 https://github.com/7semi-solutions/7Semi-MAX31865-Arduino-Library
 https://github.com/vkumpan/TEA5767
 https://github.com/arduino-libraries/Arduino_APDS9999
+https://github.com/7semi-solutions/7Semi-MCP23017-Arduino-Library


### PR DESCRIPTION
This PR adds the 7Semi MCP23017 Arduino Library to the Arduino Library Manager index.

Repository URL:
https://github.com/7semi-solutions/7Semi-MCP23017-Arduino-Library

The library provides easy APIs for the MCP23017 16-bit I/O expander over I2C, including pin/port read-write, pull-ups, polarity, and basic interrupt support. Example sketches are included for a quick start.
