### PR TITLE
Add MyLibrary to library-registry

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -8420,3 +8420,4 @@ https://github.com/stm32duino/ILPS22QS
 https://github.com/fulda1/SUSI2
 https://github.com/MISTERNEGATIVE21/QuectelEC200U_CN
 https://github.com/WeSpeakEnglish/ANTIRTOS_MODERN
+https://github.com/hidori/MicroSerial


### PR DESCRIPTION
This PR adds MicroSerial to the Arduino Library Manager repository list.

Repository: https://github.com/hidori/MicroSerial
Version: v1.0.0
Library.properties: https://github.com/hidori/MicroSerial/blob/main/library.properties

Please run the validation bot.
