### PR TITLE
Trim trailing whitespace from repositories list

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -7852,7 +7852,7 @@ https://github.com/kanitawa/RotEnc
 https://github.com/BlairBlaidd/Newhaven_CharacterOLED_SPI
 https://github.com/lhtran114/OnlyTimer
 https://github.com/sinricpro/arduino-renesas-sdk
-https://github.com/septentrio-gnss/Septentrio_Arduino_library 
+https://github.com/septentrio-gnss/Septentrio_Arduino_library
 https://github.com/iamfaraz/Waveshare_ST7262_LVGL
 https://github.com/Danzo-Systems/FM25060_Library
 https://github.com/DouglasFlores-fun/SimpleLogger


### PR DESCRIPTION
Trailing whitespace was introduced by a pull request. Some editors automatically trim trailing whitespace. If a contributor uses such an editor when making a submission, the resulting diff will cause the automated system to detect the pull request as being of the "modification" type instead of the "submission" type. This will cause the pull request to be incorrectly handled.