### PR TITLE
Add OLEDKeyboard libraryAdd OLEDKeyboard library

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -8426,3 +8426,4 @@ https://github.com/hidori/MicroSerial
 https://github.com/7semi-solutions/7Semi-BNO055-Arduino-Library
 https://github.com/ConsentiumIoT/EdgeVision
 https://github.com/junzzhu/esp-mqtt-arduino
+https://github.com/skr-electronics-lab/OLEDKeyboard.git


### PR DESCRIPTION
This PR adds the OLEDKeyboard library:
https://github.com/skr-electronics-lab/OLEDKeyboard
Version: 1.0.1
