### PR TITLE
Add TraccarClient library

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -8428,3 +8428,4 @@ https://github.com/7semi-solutions/7Semi-BNO055-Arduino-Library
 https://github.com/ConsentiumIoT/EdgeVision
 https://github.com/junzzhu/esp-mqtt-arduino
 https://github.com/skr-electronics-lab/OLEDKeyboard.git
+https://github.com/valeriofantozzi/TraccarClient.git


### PR DESCRIPTION
Adding TraccarClient library for Arduino and ESP32.\n\nThis library allows sending GPS tracking data to Traccar servers via HTTP.\n\nRepository: https://github.com/valeriofantozzi/TraccarClient\nVersion: 1.0.0\nCategory: Communication