### PR TITLE
Update repositories.txt

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -8239,6 +8239,7 @@ https://github.com/BestModules-Libraries/BMB22M181A
 https://github.com/BestModules-Libraries/BM25S2621-1
 https://github.com/BestModules-Libraries/BM25S4021-1
 https://github.com/Bina-Lee/PWM2motor_BNL
+https://gitlab.com/Vishal1695/fastled_min
 https://github.com/socialbodylab/UWB-MaUWB-AT
 https://github.com/tesla-jedi/PersistentJsonEEPROM
 https://bitbucket.org/jamesneko/lazy-serial


### PR DESCRIPTION
New library submission: FastLED_min

Repository: https://gitlab.com/Vishal1695/fastled_min
A minimal WS2812B LED library for ESP32 that saves 83KB compared to FastLED.

The library is compliant with Arduino library specifications and tagged with v1.0.0.