### PR TITLE
Add 7Semi RS485 Temperature-Humidity Arduino Library

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -8459,3 +8459,4 @@ https://github.com/mitra42/frugal-iot
 https://github.com/eakse/ESP32S3_SUPERMINI_PINOUT
 https://github.com/kay-bs/KK-Switch
 https://github.com/localrice/EasyWiFi
+https://github.com/7semi-solutions/7Semi_RS485_Temperature-Humidity-Arduino-Library


### PR DESCRIPTION
This PR adds the 7Semi RS485 Temperature-Humidity Arduino Library to the Arduino Library Manager index.

Repository URL:
https://github.com/7semi-solutions/7Semi_RS485_Temperature-Humidity-Arduino-Library

This library supports temperature and humidity sensors over RS-485 communication, offering robust long-distance sensor networking. Example sketches and configuration options are included.
