### PR TITLE
Add 7Semi CO2 Temperature Humidity I2C Probe Arduino Library

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -8461,3 +8461,4 @@ https://github.com/eakse/ESP32S3_SUPERMINI_PINOUT
 https://github.com/kay-bs/KK-Switch
 https://github.com/localrice/EasyWiFi
 https://github.com/7semi-solutions/7Semi_RS485_Temperature-Humidity-Arduino-Library
+https://github.com/7semi-solutions/7Semi_CO2_Temperature_Humidity_I2C_Probe_Arduino_Library


### PR DESCRIPTION
This PR adds the 7Semi CO2 Temperature Humidity I2C Probe Arduino Library to the Arduino Library Manager index.

Repository URL:
https://github.com/7semi-solutions/7Semi_CO2_Temperature_Humidity_I2C_Probe_Arduino_Library

The library provides APIs for reading CO2, temperature, and humidity from 7Semi I2C probe modules. It supports calibration, continuous measurement, and configurable intervals, with example sketches for Arduino and ESP32.
