### PR TITLE
bb_temperature

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -8472,3 +8472,4 @@ https://github.com/7semi-solutions/7Semi_CO2_Temperature_Humidity_I2C_Probe_Ardu
 https://github.com/lizardking/LD2410Async
 https://github.com/bitbank2/bb_proximity
 https://github.com/geekfactory/GFDisplay7S
+https://github.com/bitbank2/bb_temperature


### PR DESCRIPTION
Please add bb_temperature to the Arduino Library Manager. It's a "universal" I2C sensor library which auto-detects a long list of common sensors. It compiles not only on Arduino, but also on Linux and esp-idf.