### PR TITLE
Add UNIT Electronics BME68x library - Optimized for UNIT development …

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -8474,3 +8474,4 @@ https://github.com/bitbank2/bb_proximity
 https://github.com/geekfactory/GFDisplay7S
 https://github.com/chipnorm/ChipNorm_DHT11
 https://github.com/bitbank2/bb_temperature
+https://github.com/UNIT-Electronics-MX/unit_bme68x_library


### PR DESCRIPTION
## Description
Add UNIT Electronics BME68x library - an optimized version of the Bosch BME68x library for UNIT Electronics development boards.

## Library Information
- **Repository**: https://github.com/UNIT-Electronics-MX/unit_bme68x_library
- **License**: BSD-3-Clause (same as original Bosch library)
- **Sensors**: BME680, BME688
- **Category**: Environmental sensors

## Compatible Boards
### UNIT Electronics Boards:
- UNIT TouchDot S3 (ESP32-S3)
- UNIT Pulsar ESP32-C6
- UNIT DualMCU ONE (ESP32 + RP2040)
- UNIT DualMCU (ESP32 + RP2040)

### Other Arduino-compatible boards:
- Arduino Uno/Nano/Mega
- Generic ESP32/ESP32-S3/ESP32-C3/ESP32-C6
- Other Arduino-compatible microcontrollers

## Features
- Optimized I2C configurations for UNIT boards
- Auto-detection for UNIT Electronics boards
- Low power consumption examples
- QWIIC connector support
- Complete documentation and examples

## Testing
✅ Library tested on all supported UNIT Electronics boards
✅ Compatible with both BME680 and BME688 sensors
✅ Examples verified and working
✅ Documentation complete