### PR TITLE
Update name and URL of "MycilaPZEM"

### DIFF
--- a/registry.txt
+++ b/registry.txt
@@ -6656,7 +6656,7 @@ https://github.com/MJBeltran13/Bucopi_library.git|Contributed|BUCO-PI
 https://github.com/teddokano/LevelShifter_NXP_Arduino.git|Contributed|LevelShifter_NXP_Arduino
 https://github.com/karolis1115/FTPduino.git|Contributed|FTPduino
 https://github.com/tabahi/ESP-Wifi-Config.git|Contributed|ESP-Wifi-Config
-https://github.com/mathieucarbou/MycilaPZEM004Tv3.git|Contributed|MycilaPZEM
+https://github.com/mathieucarbou/MycilaPZEM.git|Contributed|MycilaPZEM
 https://github.com/koendv/FloatToAscii.git|Contributed|FloatToAscii
 https://github.com/DigitalCodesign/MentorBit-Library.git|Contributed|MentorBit-Library
 https://github.com/lualtek/buttino-rak.git|Contributed|ButtinoRAK


### PR DESCRIPTION
This PR consists of two changes:

- Change URL from `https://github.com/mathieucarbou/MycilaPZEM004Tv3.git` to `https://github.com/mathieucarbou/MycilaPZEM.git` (companion to https://github.com/arduino/library-registry/pull/7051)
- Change name from `MycilaPZEM004Tv3` to `MycilaPZEM`

Since the name change operation on the database is actually a removal followed by automated re-indexing on the next job run, the URL update will occur as a matter of course. For this reason, the only operation required from the backend maintainer is a standard name change procedure.
