### PR TITLE
New library submissions

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -8474,3 +8474,5 @@ https://github.com/Alteriom/EByte_LoRa_E220_Series_Library
 https://github.com/SvenRosvall/VLCB-Arduino
 https://github.com/Alteriom/painlessMesh
 https://github.com/mitra42/frugal-iot
+https://gitlab.com/Vishal1695/mvswifi_esp32
+https://gitlab.com/Vishal1695/mvswifi_esp8266


### PR DESCRIPTION
New library submissions:

1. mvswifi_esp32 - https://gitlab.com/Vishal1695/mvswifi_esp32
   ESP32 WiFi credential management using native NVS storage
   
2. mvswifi_esp8266 - https://gitlab.com/Vishal1695/mvswifi_esp8266
   ESP8266 WiFi credential management using EEPROM storage

Both libraries are compliant with Arduino specifications and tagged with v1.0.1.