### PR TITLE
Update repositories.txt

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -8487,3 +8487,5 @@ https://github.com/bitbank2/bb_temperature
 https://github.com/UNIT-Electronics-MX/unit_bme68x_library
 https://github.com/jmwanderer/tlv.arduino
 https://github.com/PaulNTU/MoonMin-Scanner-Arduino-Library
+https://gitlab.com/Vishal1695/mvswifi_esp32
+https://gitlab.com/Vishal1695/mvswifi_esp8266


### PR DESCRIPTION
1. mvswifi_esp32 - https://gitlab.com/Vishal1695/mvswifi_esp32
   ESP32 WiFi credential management using native NVS storage
   
2. mvswifi_esp8266 - https://gitlab.com/Vishal1695/mvswifi_esp8266
   ESP8266 WiFi credential management using EEPROM storage

Both libraries are compliant with Arduino specifications and tagged with v1.0.1.
