### PR TITLE
Add UNIT Electronics ICP-10111 sensor library

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -8487,6 +8487,7 @@ https://github.com/geekfactory/GFDisplay7S
 https://github.com/chipnorm/ChipNorm_DHT11
 https://github.com/bitbank2/bb_temperature
 https://github.com/UNIT-Electronics-MX/unit_bme68x_library
+https://github.com/UNIT-Electronics-MX/ue_i2c_icp_10111_sen
 https://github.com/jmwanderer/tlv.arduino
 https://github.com/PaulNTU/MoonMin-Scanner-Arduino-Library
 https://gitlab.com/Vishal1695/mvswifi_esp32


### PR DESCRIPTION
## Description
Add UNIT Electronics ICP-10111 sensor library - Enhanced Arduino library for TDK InvenSense ICP-101xx high-precision barometric pressure sensors.

## Library Details
- **Repository**: https://github.com/UNIT-Electronics-MX/ue_i2c_icp_10111_sen
- **Version**: 1.2.0
- **License**: BSD-3-Clause
- **Category**: Sensors
- **Sensors Supported**: ICP-10100, ICP-10111, ICP-10125

## Key Features
- Multiple accuracy modes (FAST, NORMAL, ACCURATE, VERY_ACCURATE)
- Custom I2C pin configuration support
- Compatible with UNIT Electronics DevLab breakout boards
- Non-blocking and blocking measurement modes
- Temperature and pressure readings with high precision
- 5 comprehensive examples included

## Target Hardware
- ESP32 family (ESP32, ESP32-C6)
- Arduino compatible platforms
- UNIT Electronics DevLab boards

## Compliance Status
- Arduino Lint validation passed: no errors or warnings
- All Library Manager requirements met
- Tagged release v1.2.0 available
- BSD Licensed with proper attribution

## Attribution
Based on original ICP101xx library by Adrian Studer (github.com/astuder/icp-101xx)
Enhanced by UNIT Electronics for DevLab ecosystem compatibility

## Testing
- Library tested on ESP32 platforms
- Compatible with ICP-10100, ICP-10111, ICP-10125 sensors
- All examples verified and working
- Documentation complete