### PR TITLE
Add submission # 7078

### DIFF
--- a/registry.txt
+++ b/registry.txt
@@ -8487,3 +8487,4 @@ https://github.com/jaikulk14/Advanced-Oximeter.git|Contributed|AdvancedOximeter
 https://github.com/Alash-electronics/AlashMotorControlLite.git|Contributed|AlashMotorControlLite
 https://github.com/UNIT-Electronics-MX/ue_i2c_icp_10111_sen.git|Contributed|ue_i2c_icp_10111_sen
 https://github.com/m5stack/M5Unit-Fingerprint2.git|Contributed|M5Unit-Fingerprint2-Library
+https://github.com/tanakamasayuki/ESP32CertBundle.git|Contributed|ESP32CertBundle


### PR DESCRIPTION
https://github.com/arduino/library-registry/pull/7078

It is necessary to manually register this library because a bug in Arduino Lint (https://github.com/arduino/arduino-lint/issues/905) makes it incompatible with the automated submission handling system.