### PR TITLE
Add EEProm_Safe_Wear_Level to registry

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -1,3 +1,4 @@
+https://github.com/automatician/EEProm_Safe_Wear_Level
 https://github.com/DIYables/DIYables-ESP32-WebApps-Library
 https://github.com/nfrproducts/probot-lib
 https://github.com/m5stack/M5Unit-Fingerprint2


### PR DESCRIPTION
Adding the EEProm_Safe_Wear_Level library, v25.10.5 stable release.