### PR TITLE
Add sparkey_gyro  library to Library Manager , i renamed it

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -7918,6 +7918,7 @@ https://github.com/DBSStore/EIS
 https://github.com/guerratron/TouchCal
 https://github.com/GabyGold67/ButtonToSwitch_AVR
 https://github.com/bitbank2/bb_epaper
+https://github.com/Rmin-code2005/sparkey_gyro_i2c
 https://github.com/Kei0208/RX8900
 https://github.com/Garfius/cliSerialMenu
 https://github.com/nhjschulz/cfsm


### PR DESCRIPTION
This commit adds the GitHub repository link for the sparkey_gyro Arduino library to the repositories.txt file for inclusion in the Arduino Library Manager.