### PR TITLE
rm M5Unit-Fingerprint2

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -3,7 +3,6 @@ https://github.com/Hamas888/ChronoLog
 https://github.com/automatician/EEProm_Safe_Wear_Level
 https://github.com/DIYables/DIYables-ESP32-WebApps-Library
 https://github.com/nfrproducts/probot-lib
-https://github.com/m5stack/M5Unit-Fingerprint2
 https://github.com/Alash-electronics/AlashMotorControlLite
 https://github.com/windnerd-labs/Windnerd-Core
 https://github.com/TechTronicsEngineering/AutoPlex7


### PR DESCRIPTION
We have updated the package name:
2025/10/19 23:17:44 Release M5Unit-Fingerprint2:1.2.0 has wrong library name, should be M5Unit-Fingerprint2-Library