### PR TITLE
Remove redundant "king_Armin_sparkyTDAxis12_I2C_lib" registration

### DIFF
--- a/registry.txt
+++ b/registry.txt
@@ -8362,7 +8362,6 @@ https://github.com/BlueskyBV/Easy_Web_Remote_Control-ESP32-.git|Contributed|Easy
 https://github.com/JackHat1/MT07_CAN_Project.git|Contributed|MT07_CAN_Library
 https://github.com/7semi-solutions/7Semi-HX711-Arduino-Library.git|Contributed|7Semi_HX711
 https://github.com/Rmin-code2005/sh1106-1306_ui_assistance.git|Contributed|oled_graphic_assistance
-https://github.com/Rmin-code2005/sparkey_gyro_I2C.git|Contributed|king_Armin_sparkyTDAxis12_I2C_lib
 https://github.com/Sensirion/arduino-i2c-sen63c.git|Contributed|Sensirion I2C SEN63C
 https://github.com/Sensirion/arduino-i2c-sen65.git|Contributed|Sensirion I2C SEN65
 https://github.com/Sensirion/arduino-i2c-sen68.git|Contributed|Sensirion I2C SEN68


### PR DESCRIPTION
This repository was submitted multiple times (same URL, but with the name being changed in the interim).

This registry entry is outdated (the other registration has the newer name) and so must be removed to keep the registry tidy.

---

Companion to https://github.com/arduino/library-registry/pull/7112