### PR TITLE
Remove redundant "https://github.com/Rmin-code2005/sparkey_gyro_I2C" URL

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -8444,7 +8444,6 @@ https://github.com/jonavarro22/MAX7SegmentDisplay
 https://github.com/sutiana/WiFiConfigManager
 https://github.com/7semi-solutions/7Semi-DS18B20-Arduino-Library
 https://github.com/7semi-solutions/7Semi-MAX17048-Arduino-Library
-https://github.com/Rmin-code2005/sparkey_gyro_I2C
 https://github.com/BlueskyBV/Easy_Web_Remote_Control-ESP32-
 https://github.com/JackHat1/MT07_CAN_Project
 https://github.com/7semi-solutions/7Semi-HX711-Arduino-Library


### PR DESCRIPTION
This URL was submitted multiple times. The redundant copy is hereby removed to keep the repositories list tidy.