### PR TITLE
Removing libraries from Library Manager

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -2684,8 +2684,6 @@ https://github.com/ESDeveloperBR/ES32Lab
 https://github.com/ESDeveloperBR/TFT_eSPI_ES32Lab
 https://github.com/ESDeveloperBR/TimeInterval
 https://github.com/ESikich/RGBLEDBlender
-https://github.com/espressif/esp-brookesia
-https://github.com/espressif/esp-boost
 https://github.com/esp-arduino-libs/esp-lib-utils
 https://github.com/esp-arduino-libs/ESP32_Button
 https://github.com/esp-arduino-libs/ESP32_Display_Panel


### PR DESCRIPTION
As the code structures of these two repositories have become increasingly complex, they have become more and more difficult to be compatible with the Arduino platform. Therefore, they are requested to be removed from the registry. Sorry for any inconvenience caused.