### PR TITLE
Remove "esp-boost"

### DIFF
--- a/registry.txt
+++ b/registry.txt
@@ -7853,7 +7853,6 @@ https://github.com/wallysalami/SQLiteManager.git|Contributed|SQLiteManager
 https://github.com/codewitch-honey-crisis/htcw_pool.git|Contributed|htcw_pool
 https://github.com/rjsachse/ESP32-SpeexDSP.git|Contributed|ESP32-SpeexDSP
 https://github.com/hanzeelvilla/MyButtonIO.git|Contributed|MyButtonIO
-https://github.com/espressif/esp-boost.git|Contributed|esp-boost
 https://github.com/kingsmen732/Robot-face---sh1106-screen.git|Contributed|RoboFace
 https://github.com/m5stack/M5Unit-KMeterISO.git|Contributed|M5Unit-KMeterISO
 https://github.com/CelliesProjects/LGFX-ScreenShot.git|Contributed|LGFX-ScreenShot


### PR DESCRIPTION
Companion to https://github.com/arduino/library-registry/pull/7113