### PR TITLE
Add logicAnalyzer repository link

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -5888,6 +5888,7 @@ https://github.com/RobTillaart/Kurtosis
 https://github.com/RobTillaart/L9110
 https://github.com/RobTillaart/LineFormatter
 https://github.com/RobTillaart/Logic
+https://github.com/RobTillaart/logicAnalyzer
 https://github.com/RobTillaart/Logistic
 https://github.com/RobTillaart/LTC2485
 https://github.com/RobTillaart/LTC2991


### PR DESCRIPTION
Arduino library for building a logicAnalyzer. (non performant).