### PR TITLE
Remove "WindQX"

### DIFF
--- a/registry.txt
+++ b/registry.txt
@@ -7282,7 +7282,6 @@ https://github.com/bitbank2/bb_truetype.git|Contributed|bb_truetype
 https://github.com/nseinlet/Modelisme.git|Contributed|Modelisme
 https://github.com/JensDMadsen/ISRHandler.git|Contributed|ISRHandler
 https://github.com/arslan437/EspFileManager.git|Contributed|EspFileManager
-https://github.com/McOrts/WindQX_Library.git|Contributed|WindQX
 https://github.com/JarikDem-Bot/OCServo.git|Contributed|OCServo
 https://github.com/TheSpaceEgg/InfinitePCA9685.git|Contributed|InfinitePCA9685
 https://github.com/vindar/tgx.git|Contributed|tgx


### PR DESCRIPTION
Companion to https://github.com/arduino/library-registry/pull/7154