### PR TITLE
Add HandaDigitalSpeaker library

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -8532,3 +8532,4 @@ https://github.com/TamsinRose/CAN_Message_Arduino
 https://github.com/stm32duino/X-NUCLEO-IKS5A1
 https://github.com/fermeridamagni/arduino-minimal-ultrasonic
 https://github.com/chipnorm/TM1637
+https://github.com/DavinderHanda/HandaDigitalSpeaker


### PR DESCRIPTION
This PR adds the HandaDigitalSound library for ESP32.  A simple ESP32 sound library using LEDC for SmartElex digital speaker
Author: Davinder Handa
Version: 1.0.0
Repository: https://github.com/DavinderHanda/HandaDigitalSound
