### PR TITLE
Add RLCBuffer repository link

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -5980,6 +5980,7 @@ https://github.com/RobTillaart/RADAR
 https://github.com/RobTillaart/RAIN
 https://github.com/RobTillaart/randomHelpers
 https://github.com/RobTillaart/relativity
+https://github.com/RobTillaart/RLCBuffer
 https://github.com/RobTillaart/rotaryDecoder
 https://github.com/RobTillaart/rotaryDecoder8
 https://github.com/RobTillaart/rotaryDecoderSwitch


### PR DESCRIPTION
Arduino library for a Run Length Compressed Buffer.