### PR TITLE
2.9 inch 8 color reflective screen ST7306  driver

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -8552,3 +8552,4 @@ https://github.com/egnor/ok_arduino_logging
 https://github.com/chipnorm/VL53L0X
 https://github.com/recepsenbas/DWIN-Unified
 https://github.com/FranciscoRos/EnergyWSN
+https://github.com/FT-tele/ST7306_8color_lvgl


### PR DESCRIPTION
Add ST7306_8color_lvgl repository link
only support 2.9 inch 8 color reflective screen 
ic ST7306
resolution 210*480
LVGL version 8.3.11