### PR TITLE
Add DHT_N128 library

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -1,3 +1,4 @@
+https://github.com/nicolito128/DHT_N128
 https://github.com/steamicc/MCP23009E
 https://github.com/pbudel/QuarkX
 https://github.com/jobitjoseph/SoftWire_CH32


### PR DESCRIPTION
A library to work with DHT-type sensors (DHT11 or DHT22).