### PR TITLE
Revoke registry privileges for github.com/Herobrine-pixel

### DIFF
--- a/.github/workflows/assets/accesslist.yml
+++ b/.github/workflows/assets/accesslist.yml
@@ -34,6 +34,10 @@
   access: deny
   reference: https://github.com/arduino/library-registry/pull/6514#pullrequestreview-2969201873
 - host: github.com
+  name: Herobrine-pixel
+  access: deny
+  reference: https://github.com/arduino/library-registry/pull/7066#issuecomment-3478077991
+- host: github.com
   name: kelasrobot
   access: deny
   reference: https://github.com/arduino/library-registry/pull/5706#issuecomment-2588923290


### PR DESCRIPTION
This user has established a pattern of irresponsible behavior in the Arduino Library Manager Registry repository. They continued this behavior even after the bot and human maintainer made significant efforts to guide them to responsible use.