### PR TITLE
add lib AIS_4G_EXTENSION_BOARD

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -8559,3 +8559,4 @@ https://github.com/FranciscoRos/EnergyWSN
 https://github.com/FT-tele/ST7306_8color_lvgl
 https://github.com/bull-m/BULLM_ExtendModule
 https://github.com/Jakkapan-a/AssuraVisionSerial.git
+https://github.com/AIS-DeviceIntegration/AIS_4G_EXTENSION_BOARD


### PR DESCRIPTION
add our library for our devkit, it library for Extension board compatible hardware (ESP32)