### PR TITLE
Fix: update sensedu link

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -8210,7 +8210,7 @@ https://github.com/amitesh-singh/EspDDNS
 https://github.com/tomorrow56/SPRESENSE_ESP8266_LINE_Messaging_API
 https://github.com/zamanturja/A9Gmod
 https://github.com/WBS-Wissen/Stepper8825Lib
-https://github.com/vladysor/SensEdu-Library
+https://github.com/fanfare-ff/SensEdu-Library
 https://github.com/mirosieber/Litime_BMS_ESP32
 https://github.com/mirosieber/OPT300x
 https://github.com/ByteVoltaTeam/PIDEasy


### PR DESCRIPTION
Link for [SensEdu library](https://github.com/fanfare-ff/SensEdu-Library) has been changed, this PR corrects it.

Thank you for your time.