### PR TITLE
Add Library WiFiNINA_-_Adafruit_Fork

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -8560,3 +8560,4 @@ https://github.com/FT-tele/ST7306_8color_lvgl
 https://github.com/bull-m/BULLM_ExtendModule
 https://github.com/Jakkapan-a/AssuraVisionSerial.git
 https://github.com/AIS-DeviceIntegration/AIS_4G_EXTENSION_BOARD
+https://github.com/adafruit/WiFiNINA


### PR DESCRIPTION
Please add the Adafruit-maintained fork of WiFiNINA.

Repo: https://github.com/adafruit/WiFiNINA
Current tag: 1.6.1
library.properties: name=WiFiNINA_-_Adafruit_Fork

reason:
The Arduino IDE overwrites the Adafruit WiFiNINA fork on startup with the Arduino WiFiNINA. 

Adding library with different name for clarity [Adafruit fork of WiFiNINA officially](https://github.com/adafruit/WiFiNINA/pull/16#issuecomment-3461074748)

requested by @ladyada 