### PR TITLE
Add ADC128S by IENAI repositories.txt

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -1,3 +1,4 @@
+https://github.com/ienai-SPACE/ADC128S_Arduino
 https://github.com/BojanJurca/cin-cout-for-Arduino
 https://github.com/atestb/MCP4151-Digital-Potentiometer
 https://github.com/nicolito128/DHT_N128


### PR DESCRIPTION
This library adds support for ADC128S which is not currently supported by arduino. 

Best regards!