### PR TITLE
Add DCF77FreeRTOS library

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -1,3 +1,4 @@
+https://github.com/szilvasyz/DCF77FreeRTOS.git
 https://github.com/vicharak-in/shrike_arduino.git
 https://github.com/ienai-SPACE/ADC128S_Arduino
 https://github.com/BojanJurca/cin-cout-for-Arduino


### PR DESCRIPTION
This pull request adds the DCF77FreeRTOS library to the Arduino Library Manager index.

DCF77FreeRTOS is a lightweight and reliable DCF77 time signal receiver library for ESP32 using FreeRTOS.
It runs the decoding in a background task, providing precise time synchronization events without blocking other system processes.

Repository: https://github.com/szilvasyz/DCF77FreeRTOS
Version: 1.0.0
Maintainer: Zoltan Szilvasy <szilvasyz@gmail.com>
