### PR TITLE
Add new repository URL "mcpesp" to repositories.txt

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -8582,3 +8582,4 @@ https://github.com/juano2310/SuperCAN
 https://github.com/Protocentral/SensythingCore
 https://github.com/sintrb/ANSI_Output
 https://github.com/mlaass/wamr-esp32-arduino.git
+https://github.com/ertgtct/mcpesp


### PR DESCRIPTION
This library adds a simple wrapper for the MCP protocol on esp32 boards.