### PR TITLE
Add submission # 7239

### DIFF
--- a/registry.txt
+++ b/registry.txt
@@ -8580,3 +8580,4 @@ https://github.com/uutzinger/Arduino_BLESerial.git|Contributed|BLE Serial - NUS
 https://github.com/tanakamasayuki/EspHelper.git|Contributed|EspHelper
 https://github.com/1998Saeed/MechaNest.git|Contributed|MechaNest
 https://github.com/juano2310/SuperCANBus.git|Contributed|SuperCANBus
+https://github.com/tanakamasayuki/AssocTree.git|Contributed|AssocTree


### PR DESCRIPTION
https://github.com/arduino/library-registry/pull/7239

It is necessary to manually register this library because a bug in Arduino Lint (https://github.com/arduino/arduino-lint/issues/905) makes it incompatible with the automated submission handling system.