### PR TITLE
Add DMFLib-Arduino to registry

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -8595,3 +8595,4 @@ https://github.com/juano2310/SuperCANBus
 https://github.com/stm32duino/X-NUCLEO-IHM04A1
 https://github.com/versianih/hdw-utils
 https://github.com/asimzulfiqar/esp_cron
+https://github.com/marcoratto/DMFLib-Arduino


### PR DESCRIPTION
When a message exceeds the maximum payload size of a single packet, it must be fragmented into multiple packets for transmission. The receiver then reassembles these packets to reconstruct the original message. Some protocols — such as LoRaWAN and MQTT-SN — require message fragmentation.
This ANSI-C library for Arduino simplifies the process of message fragmentation and reassembly.