### PR TITLE
Revoke registry privileges for github.com/jaderobotics-AN

### DIFF
--- a/.github/workflows/assets/accesslist.yml
+++ b/.github/workflows/assets/accesslist.yml
@@ -38,6 +38,10 @@
   access: deny
   reference: https://github.com/arduino/library-registry/pull/7066#issuecomment-3478077991
 - host: github.com
+  name: jaderobotics-AN
+  access: deny
+  reference: https://github.com/arduino/library-registry/issues/7270#issuecomment-3551554185
+- host: github.com
   name: kelasrobot
   access: deny
   reference: https://github.com/arduino/library-registry/pull/5706#issuecomment-2588923290


### PR DESCRIPTION
This user has established a pattern of irresponsible behavior in the Arduino Library Manager Registry repository. They continued this behavior even after the bot and human maintainer made significant efforts to guide them to responsible use.