### PR TITLE
Add new repository URL for ESP32 WiFi Connect

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -8611,3 +8611,4 @@ https://github.com/sfera-labs/arduino-modbus-rtu-slave
 https://github.com/sfera-labs/arduino-lora-net
 https://github.com/sfera-labs/iono-mkr-lora-net
 https://github.com/sfera-labs/iono-rp-d16-arduino
+https://github.com/nedesico/ESP32_WiFi_Connect


### PR DESCRIPTION
ESP32 WiFi Connect UI. Your ESP32 will automatically launch a dedicated WiFi Access Point DNS Server, with User Interface, when WiFi isn't configured yet or unavailable. This will allow you to configure and save the WiFi credentials to the onboard flash and connect to the WiFi when in range.