### PR TITLE
Add Arduino vid6606 library

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -8613,3 +8613,4 @@ https://github.com/sfera-labs/arduino-lora-net
 https://github.com/sfera-labs/iono-mkr-lora-net
 https://github.com/sfera-labs/iono-rp-d16-arduino
 https://github.com/nedesico/ESP32_WiFi_Connect
+https://github.com/petrows/arduino-vid6608


### PR DESCRIPTION
Arduino library for driving IC VID6608 and clones for Switec X25.168 miniature stepper motors with microstepping support

Library homepage: https://github.com/petrows/arduino-vid6608