### PR TITLE
Update name and URL of "Sitron Labs OPT3001 Arduino Library"

### DIFF
--- a/registry.txt
+++ b/registry.txt
@@ -4718,7 +4718,7 @@ https://github.com/Sensirion/arduino-i2c-sts4x.git|Contributed|Sensirion I2C STS
 https://github.com/Sensirion/arduino-i2c-sf06-lf.git|Contributed|Sensirion I2C SF06-LF
 https://github.com/chrmlinux/ArrayExt.git|Contributed|ArrayExt
 https://github.com/Pixelbo/Pelco_And_Arduino.git|Contributed|Pelco_And_Arduino
-https://github.com/sitronlabs/SitronLabs_TexasInstruments_OPT3001_Arduino_Library.git|Contributed|Sitron Labs OPT3001 Ambient Light Sensor Arduino Library
+https://github.com/sitronlabs/SitronLabs_TexasInstruments_OPT3001_Arduino_Library.git|Contributed|Sitron Labs OPT3001 Arduino Library
 https://github.com/luoluomeng/HUSB238Driver.git|Contributed|HUSB238Driver
 https://github.com/luoluomeng/NST1001Driver.git|Contributed|NST1001Driver
 https://github.com/gavinlyonsrepo/HD44780_LCD_PCF8574.git|Contributed|HD44780_LCD_PCF8574


### PR DESCRIPTION
This PR consists of two changes:

- Change URL from `https://github.com/sitronlabs/SitronLabs_OPT3001_Arduino_Library.git` to `https://github.com/sitronlabs/SitronLabs_TexasInstruments_OPT3001_Arduino_Library.git` (companion to https://github.com/arduino/library-registry/pull/7332)
- Change name from `Sitron Labs OPT3001 Ambient Light Sensor Arduino Library` to `Sitron Labs OPT3001 Arduino Library` (resolves https://github.com/arduino/library-registry/issues/7289)

Since the name change operation on the database is actually a removal followed by automated re-indexing on the next job run, the URL update will occur as a matter of course. For this reason, the only operation required from the backend maintainer is a standard name change procedure.