### PR TITLE
Restore registry privileges for `github.com/Herobrine-pixel`

### DIFF
--- a/.github/workflows/assets/accesslist.yml
+++ b/.github/workflows/assets/accesslist.yml
@@ -34,10 +34,6 @@
   access: deny
   reference: https://github.com/arduino/library-registry/pull/6514#pullrequestreview-2969201873
 - host: github.com
-  name: Herobrine-pixel
-  access: deny
-  reference: https://github.com/arduino/library-registry/pull/7066#issuecomment-3478077991
-- host: github.com
   name: jaderobotics-AN
   access: deny
   reference: https://github.com/arduino/library-registry/issues/7270#issuecomment-3551554185


### PR DESCRIPTION
This user has requested the restoration of their Arduino Library Manager Registry privileges. The request was approved.

Resolves https://github.com/arduino/library-registry/issues/7304