### PR TITLE
Add new repository link for ESP8266NAPTExtender

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -12,6 +12,7 @@ https://github.com/jaderobotics-AN/JadeRobotics_Spiderbot
 https://github.com/szilvasyz/DCF77FreeRTOS.git
 https://github.com/vicharak-in/shrike_arduino.git
 https://github.com/ienai-SPACE/ADC128S_Arduino
+https://github.com/oigonzalezp2024/ESP8266NAPTExtender
 https://github.com/BojanJurca/Lightweight-Standard-Template-Library-STL-for-Arduino   
 https://github.com/BojanJurca/cin-cout-for-Arduino
 https://github.com/atestb/MCP4151-Digital-Potentiometer


### PR DESCRIPTION
Enables NAPT (NAT) to convert the ESP8266 into a STA + SoftAP range extender. Automatic configuration of the SoftAP's DNS using the STA's DNS.