### PR TITLE
Add new repository link for MQTTOTA

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -8657,3 +8657,4 @@ https://github.com/maxrangner/GawiButtons
 https://github.com/goBILDA-Official/goBILDA-Pinpoint-Arduino-Library
 https://github.com/dac1e/AT24CxEeprom
 https://github.com/askinkeles/DWIN_DGUS_HMI
+https://github.com/JorgeGBeltre/MQTTOTA


### PR DESCRIPTION
Add MQTTOTA library for OTA updates via MQTT/MQTTS

Library: MQTTOTA  
Author: Jorge Gaspar Beltre Rivera  
Repository: https://github.com/JorgeGBeltre/MQTTOTA  
Release: v1.0.0  
Status: Fixed missing library.properties issue