### PR TITLE
Revoke registry privileges for `github.com/Rmin-code2005`

### DIFF
--- a/.github/workflows/assets/accesslist.yml
+++ b/.github/workflows/assets/accesslist.yml
@@ -46,6 +46,10 @@
   access: deny
   reference: https://github.com/arduino/library-registry/pull/4422#issuecomment-2589051618
 - host: github.com
+  name: Rmin-code2005
+  access: deny
+  reference: https://github.com/arduino/library-registry/issues/7350#issuecomment-3611960375
+- host: github.com
   name: vpbharath
   access: deny
   reference: https://github.com/arduino/library-registry/pull/4873#issuecomment-2589138298


### PR DESCRIPTION
This user has established a pattern of irresponsible behavior in the Arduino Library Manager Registry repository. They continued this behavior even after the bot and human maintainer made significant efforts to guide them to responsible use.