### PR TITLE
Add RiaPushbuttonLite library

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -8721,4 +8721,4 @@ https://github.com/MR01Right/SHT40
 https://gitlab.com/Vishal1695/mvsota_esp32.git
 https://github.com/Glinek/omniMath
 https://github.com/raiotech-iot/RAIOTerm.git
-https://github.com/phirippa-sources/RiaPushbuttonLite
+https://github.com/phirippa-source/RiaPushbuttonLite


### PR DESCRIPTION
Please add RiaPushbuttonLite to the Arduino Library Manager index.
