### PR TITLE
Add Solduino to Arduino Library Registry

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -8733,3 +8733,5 @@ https://github.com/raiotech-iot/RAIOT_MQTT.git
 https://github.com/phirippa-source/RiaPushbuttonLite
 https://github.com/nbulatovi/Quecduino
 https://github.com/JakeWritesCode/inventronix-esp32-http
+https://github.com/torrey-xyz/solduino
+


### PR DESCRIPTION
PR Description

Library name: Solduino
Repository: https://github.com/torrey-xyz/solduino

This pull request requests adding Solduino to the Arduino Library Registry.