### PR TITLE
Add ESP32-OTA-Client

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -8739,3 +8739,4 @@ https://github.com/torrey-xyz/solduino
 https://github.com/crane-elec/WFAN920
 https://github.com/stm32duino/ST25R500
 https://github.com/stm32duino/X-NUCLEO-NFC12A1
+https://github.com/LEKPCSTEAM/ESP32-OTA-Client


### PR DESCRIPTION
A lightweight OTA (Over-The-Air) update library for ESP32 with JSON API support.

Adding ****ESP32-OTA-Client**** library to the registry.

- ***Repository:**** https://github.com/LEKPCSTEAM/ESP32-OTA-Client
- ***Description:**** A lightweight OTA (Over-The-Air) update library for ESP32 with JSON API support.