### PR TITLE
Adding MLX90641 library to repositories.txt

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -2574,6 +2574,7 @@ https://github.com/dndubins/tinyServo85
 https://github.com/dndubins/EEPROMsimple
 https://github.com/dndubins/QuickStats
 https://github.com/dndubins/SRAMsimple
+https://github.com/dndubins/MLX90641
 https://github.com/dniklaus/arduino-display-lcdkeypad
 https://github.com/dniklaus/spin-timer
 https://github.com/dniklaus/wiring-timer


### PR DESCRIPTION
This is a small library to read the MLX90641 16x12 IR camera using the ESP32.