### PR TITLE
Remove "TX07K-TXC Temperature sensor Library"

### DIFF
--- a/registry.txt
+++ b/registry.txt
@@ -8270,7 +8270,6 @@ https://github.com/DigitalCodesign/MentorBit-CANBus.git|Contributed|MentorBit-CA
 https://github.com/Pallob-Gain/packet_device.git|Contributed|Packet_Device
 https://github.com/DigitalCodesign/MentorBit-LIS3DH.git|Contributed|MentorBit-LIS3DH
 https://github.com/DigitalCodesign/MentorBit-RS232.git|Contributed|MentorBit-RS232
-https://github.com/Zefek/TX07K-TXC.git|Contributed|TX07K-TXC Temperature sensor Library
 https://github.com/PTSolns/BMx280.git|Contributed|BMx280
 https://github.com/gavinlyonsrepo/ST7789_LTSM.git|Contributed|ST7789_LTSM
 https://github.com/Xinyuan-LilyGO/LilyGoLib.git|Contributed|LilyGoLib


### PR DESCRIPTION
Companion to https://github.com/arduino/library-registry/pull/7424