### PR TITLE
Add STM32RomWebFlasher library

### DIFF
--- a/libraries/STM32RomWebFlasher.json
+++ b/libraries/STM32RomWebFlasher.json
@@ -1,0 +1,4 @@
+{
+  "name": "STM32RomWebFlasher",
+  "repository": "https://github.com/DavidSAlexander/STM32RomWebFlasher"
+}


### PR DESCRIPTION
Adds STM32RomWebFlasher to Arduino Library Manager.

Repository: https://github.com/DavidSAlexander/STM32RomWebFlasher
First release tag: 1.0.0