### PR TITLE
Add Hestia-tempo library

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -8750,3 +8750,4 @@ https://github.com/stm32duino/X-NUCLEO-NFC12A1
 https://github.com/LEKPCSTEAM/ESP32-OTA-Client
 https://github.com/cpei2025/ESPNowAdhoc
 https://github.com/Fran6nd/Updatable
+https://github.com/Hestia-system/Hestia-tempo


### PR DESCRIPTION
HestiaTempo is a non-blocking timing library providing explicit Interval and OneShot timers with human-readable time expressions.
