### PR TITLE
Update repositories.txt

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -3,6 +3,7 @@ https://github.com/hackffm/Single_WS2812_Bitbang_Write
 https://github.com/MrYsLab/Telemetrix4RpiPico2w
 https://github.com/sstaub/Seesaw
 https://github.com/KITTEN2008/74HC573A
+https://github.com/KITTEN2008/ServoM
 https://github.com/DavidSAlexander/STM32RomWebFlasher
 https://github.com/seeimadeit/AES128ESP32
 https://github.com/BojanJurca/Thread-safe-ping-Arduino-library-for-ESP32


### PR DESCRIPTION
## Library name
74HC573A

## Short description
Arduino library for SN74HC573AN 8-bit transparent latch

## Useful links
- Repository: https://github.com/KITTEN2008/74HC573A

## Version
1.0.0

## Architectures supported
avr, samd, esp8266, esp32

## License
MIT

## Category
Signal Input/Output

## Type of submission
New submission