### PR TITLE
Add TerraSoil library

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -1,3 +1,4 @@
+https://github.com/kennedy-kitoko/TerraSoil
 https://github.com/actuvon/SerialConsole
 https://github.com/McOrts/WindQX_SolidState_Anemometer
 https://github.com/jobitjoseph/WitAITTS


### PR DESCRIPTION
Adding TerraSoil library for NPK Soil Sensor 10-in-1 RS485 (SN-300)

Repository: https://github.com/kennedy-kitoko/TerraSoil

TerraSoil is an Arduino library that reads 10 soil parameters via RS485 Modbus RTU:
- Moisture, Temperature, pH, EC
- NPK (Nitrogen, Phosphorus, Potassium)
- Salinity, TDS, Fertility

Compatible with ESP32, ESP32S3,XIAO ESP32S3 boards.