### PR TITLE
Add new repository link for STM32RS485DMA

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -8769,3 +8769,5 @@ https://github.com/AIS-DeviceIntegration/Magellan_BC95_lite_CORPORATE
 https://github.com/Bodobolero/PostgrestClient
 https://github.com/ronibandini/DFR1173-Voice-Prompter
 https://github.com/marinpopa/AsyncWiFiManagerSimple
+https://github.com/NitrofMtl/STM32RS485DMA
+


### PR DESCRIPTION
High-performance RS485 library for STM32-based Arduino boards using DMA.