### PR TITLE
Update name of "PU2REO_Si5351Lite"

### DIFF
--- a/registry.txt
+++ b/registry.txt
@@ -6423,7 +6423,7 @@ https://github.com/alireza7575/MKS_SERVO57.git|Contributed|MKS_SERVO57
 https://github.com/sparkfun/SparkFun_Toolkit.git|Contributed|SparkFun Toolkit
 https://github.com/reiniiriarios/arduino-mqtt-looped.git|Contributed|MQTT_Looped
 https://github.com/littleBitsman/Asynchrony.git|Contributed|Asynchrony
-https://github.com/PU2REO/Si5351ArduinoLite.git|Contributed|PU2REO_Si5351Lite
+https://github.com/PU2REO/PU2REO_Si5351Lite.git|Contributed|PU2REO_Si5351Lite
 https://github.com/Sam4uk/CRSF.git|Contributed|CRSF
 https://github.com/hpsaturn/MultiFuncShield-Library.git|Contributed|MultiFuncShield
 https://github.com/arduino-libraries/Arduino_PF1550.git|Arduino|Arduino_PF1550


### PR DESCRIPTION
This PR consists of two changes:

- Change URL from `https://github.com/PU2REO/Si5351ArduinoLite.git` to `https://github.com/PU2REO/PU2REO_Si5351Lite.git` (companion to https://github.com/arduino/library-registry/pull/7477)
- Change name from `PU2REO Si5351ArduinoLite` to `PU2REO_Si5351Lite` (resolves https://github.com/arduino/library-registry/issues/7476)

Since the name change operation on the database is actually a removal followed by automated re-indexing on the next job run, the URL update will occur as a matter of course. For this reason, the only operation required from the backend maintainer is a standard name change procedure.