### PR TITLE
Add new repository link for arduino-bitneural32

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -8777,3 +8777,4 @@ https://github.com/HuuPhuoc2411/ESP32Feature28
 https://github.com/solamyl/Mini_Button
 https://github.com/danilogcrf2-oss/ESP32Synth
 https://github.com/EARTKEY/LF_Alpha
+https://github.com/Aizhee/arduino-bitneural32


### PR DESCRIPTION
added arduino-bitneural32 a processor for the ESP32 for ternary neural networks