### PR TITLE
Add 7Semi ICM20948 Arduino Library

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -8782,3 +8782,4 @@ https://github.com/Aizhee/arduino-bitneural32
 https://github.com/t4st3r/simpleLIB
 https://github.com/petani-koding/PetaniKodingTDS
 https://github.com/Aatiqur/EZConnect
+https://github.com/7semi-solutions/7Semi_ICM20948_Arduino-Library


### PR DESCRIPTION
This PR adds the 7Semi ICM20948 Arduino Library to the Arduino Library Manager index.

Repository URL:
https://github.com/7semi-solutions/7Semi_ICM20948_Arduino-Library

The library provides APIs to read accelerometer, gyroscope, and magnetometer data from the ICM-20948 IMU (9-DoF), with example sketches for quick integration.
