### PR TITLE
Add 7Semi SHT4x Analog Arduino Library

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -8783,3 +8783,4 @@ https://github.com/t4st3r/simpleLIB
 https://github.com/petani-koding/PetaniKodingTDS
 https://github.com/Aatiqur/EZConnect
 https://github.com/7semi-solutions/7Semi_ICM20948_Arduino-Library
+https://github.com/7semi-solutions/7Semi_SHT4x_Analog_Arduino-Library


### PR DESCRIPTION
This PR adds the 7Semi SHT4x Analog Arduino Library to the Arduino Library Manager index.

Repository URL:
https://github.com/7semi-solutions/7Semi_SHT4x_Analog_Arduino-Library

The library provides APIs to read temperature and humidity data from the 7Semi SHT4x analog sensor module, with example sketches for calibration and measurement.
