### PR TITLE
Update name and URL of "Resense HEX" to "ResenseHEX"

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -12,7 +12,7 @@ https://github.com/sstaub/Seesaw
 https://github.com/DavidSAlexander/STM32RomWebFlasher
 https://github.com/seeimadeit/AES128ESP32
 https://github.com/BojanJurca/Thread-safe-ping-Arduino-library-for-ESP32
-https://github.com/TUDA-MUST/Resense-HEX/
+https://github.com/TUDA-MUST/ResenseHEX/
 https://github.com/leftCoast/LC_SPI
 https://github.com/dudmoryo-cyber/TTP229_keypad
 https://github.com/jeanloickdt/InstantIoT


### PR DESCRIPTION
I removed the Space in the name to make it more consistent with the Repo. I also changed the name in my library.properties file going from version v1.0.0 to v1.0.1, could you please also adjust library name or should I open another request for this?