### PR TITLE
Update name and URL of "ResenseHEX"

### DIFF
--- a/registry.txt
+++ b/registry.txt
@@ -8729,7 +8729,7 @@ https://github.com/torrey-xyz/solduino.git|Contributed|sol
 https://github.com/crane-elec/WFAN920.git|Contributed|WFAN920
 https://github.com/stm32duino/ST25R500.git|Contributed|STM32duino ST25R500
 https://github.com/stm32duino/X-NUCLEO-NFC12A1.git|Contributed|STM32duino X-NUCLEO-NFC12A1
-https://github.com/TUDA-MUST/Resense-HEX.git|Contributed|ResenseHEX
+https://github.com/TUDA-MUST/ResenseHEX.git|Contributed|ResenseHEX
 https://github.com/dudmoryo-cyber/TTP229_keypad.git|Contributed|TTP229 Keypad Driver
 https://github.com/LEKPCSTEAM/ESP32-OTA-Client.git|Contributed|ESP32-OTA-Client
 https://github.com/cpei2025/ESPNowAdhoc.git|Contributed|ESPNowAdhoc


### PR DESCRIPTION
This PR consists of two changes:

- Change URL from `https://github.com/TUDA-MUST/Resense-HEX.git` to `https://github.com/TUDA-MUST/ResenseHEX.git` (companion to https://github.com/arduino/library-registry/pull/7500)
- Change name from `Resense HEX` to `ResenseHEX`

Since the name change operation on the database is actually a removal followed by automated re-indexing on the next job run, the URL update will occur as a matter of course. For this reason, the only operation required from the backend maintainer is a standard name change procedure.