### PR TITLE
add Pico4Drive library

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -5386,6 +5386,7 @@ https://github.com/plsTrustMeImAnEngineer/StreamAverage
 https://github.com/pmarques-dev/PicoEncoder
 https://github.com/pmarques-dev/ArucoLite
 https://github.com/pmarques-dev/PicoHM01B0
+https://github.com/P33a/Pico4DriveLib
 https://github.com/pmassio/ArduinoLMI
 https://github.com/PodgroupConnectivity/PodEnoSim
 https://github.com/poelstra/arduino-multi-button


### PR DESCRIPTION
this library provides an API to use the integrated peripherals of the Pico4Drive board