### PR TITLE
Remove FastLED_NeoPixel

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -2581,7 +2581,6 @@ https://github.com/dlyckelid/KX023-1025-IMU
 https://github.com/dmadison/AnalogSelector-Arduino
 https://github.com/dmadison/ArduinoXInput
 https://github.com/dmadison/CtrlUtil
-https://github.com/dmadison/FastLED_NeoPixel
 https://github.com/dmadison/HID_Buttons
 https://github.com/dmadison/NintendoExtensionCtrl
 https://github.com/dmadison/ServoInput


### PR DESCRIPTION
This library is intentionally being removed from the registry as its dependency is no longer functional.