### PR TITLE
Fix repo URLs to reference user WolodiaM instead of Wolodia-M

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -7621,9 +7621,9 @@ https://github.com/wollewald/MCP23017_WE
 https://github.com/wollewald/MPU9250_WE
 https://github.com/wollewald/SI1145_WE
 https://github.com/wollewald/VL6180X_WE
-https://github.com/Wolodia-M/btnapi-library
-https://github.com/Wolodia-M/flagsapi-library
-https://github.com/Wolodia-M/timersapi-library
+https://github.com/WolodiaM/btnapi-library
+https://github.com/WolodiaM/flagsapi-library
+https://github.com/WolodiaM/timersapi-library
 https://github.com/WonderCRM/CRMui3
 https://github.com/workloads/scservo
 https://github.com/WorldFamousElectronics/PulseSensorPlayground


### PR DESCRIPTION
I have changed my account name to WolodiaM (because I deleted my other account, which was on different email (and this account was unused)). For now it works because GitHub aliases repos between users, but anyone can register Wolodia-M now and if this person creates repo with same name as my library it will be redirected to that person's repo. If some proofs needed that it is actually me who owns repos, which urls were changed, I can try to provide them. 