### PR TITLE
Update URL of "btnapi"

### DIFF
--- a/registry.txt
+++ b/registry.txt
@@ -4780,7 +4780,7 @@ https://github.com/Infineon/motor-system-ic-tle956x.git|Contributed|motor system
 https://github.com/iddi/oocsi-esp.git|Contributed|OOCSI
 https://github.com/Dlloydev/Toggle.git|Contributed|Toggle
 https://github.com/MaximeLBG/CV7OEMFR.git|Contributed|CV7OEMFR
-https://github.com/Wolodia-M/btnapi-library.git|Contributed|btnapi
+https://github.com/WolodiaM/btnapi-library.git|Contributed|btnapi
 https://github.com/Wolodia-M/flagsapi-library.git|Contributed|flagsapi
 https://github.com/MdelgadoL83/TapatioElectronics.git|Contributed|TapatioElectronics
 https://github.com/DFRobot/DFRobot_CH423.git|Contributed|DFRobot_CH423


### PR DESCRIPTION
Companion to https://github.com/arduino/library-registry/pull/7545