### PR TITLE
Update URL of "timersapi"

### DIFF
--- a/registry.txt
+++ b/registry.txt
@@ -4844,7 +4844,7 @@ https://github.com/DFRobot/DFRobot_RGBMatrix.git|Contributed|DFRobot_RGBMatrix
 https://github.com/mkogax/GG_for_Arduino.git|Contributed|GG
 https://github.com/RobTillaart/RS485.git|Contributed|RS485
 https://github.com/m5stack/M5BurnerNVS.git|Contributed|M5BurnerNVS
-https://github.com/Wolodia-M/timersapi-library.git|Contributed|timersapi
+https://github.com/WolodiaM/timersapi-library.git|Contributed|timersapi
 https://github.com/RobTillaart/SIMON.git|Contributed|SIMON
 https://github.com/m5stack/M5Unit-ACSSR.git|Contributed|M5Unit-ACSSR
 https://github.com/m5stack/M5Unit-EXTIO2.git|Contributed|M5Unit-EXTIO2


### PR DESCRIPTION
Companion to https://github.com/arduino/library-registry/pull/7545