### PR TITLE
Updated DeanIsMe username in repositories.txt

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -2307,7 +2307,7 @@ https://github.com/DBSStore/DBS_Lib
 https://github.com/DCC-EX/DCCEXProtocol
 https://github.com/dcondrey/MicrostepToLinear
 https://github.com/ddxfish/XPT2046_Bitbang_Arduino_Library
-https://github.com/DeanIsMe/SevSeg
+https://github.com/untr0py/SevSeg
 https://github.com/DedeHai/NeoPixelPainter
 https://github.com/DefHam140/IOTClient
 https://github.com/DefHam140/ZModbusRTU


### PR DESCRIPTION
I changed my GitHub username from DeanIsMe to untr0py. My library's location changed as a result. You can verify that I'm telling the truth by seeing that https://github.com/DeanIsMe/SevSeg redirects to https://github.com/untr0py/SevSeg.