### PR TITLE
Add note re: prompt resolution to submission instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,10 @@ Although we have set up automation for the most basic tasks, this repository is 
 
 ---
 
+❗ Before you begin, please ensure you have 45 minutes of time to dedicate to completing the submission procedure. A submission will typically only take a few minutes, but if your library is not specification compliant or your are not already familiar with the basics of using GitHub, it may take longer. If problems with the submission are detected, we expect you to resolve them promptly.
+
+---
+
 1. You may want to first take a look at [the requirements for admission into the Arduino Library Manager index](FAQ.md#submission-requirements). Each submission will be checked for compliance before being accepted.
 1. Click the following link:<br />
    https://github.com/arduino/library-registry/fork<br />


### PR DESCRIPTION
This repository receives thousands of pull requests. For the sake of maintainability, it is essential that these be resolved promptly. Since most PRs consist of only the trivial operation of adding a URL to a text file, and since we have high quality automation in place for facilitating these PRs, this should not be to difficult. Unfortunately the human repository maintainers frequently have to spend time prompting the library maintainers to take the simple actions required to resolve problems with their submissions so that they can be completed, and even being forced to close the submission PRs when library maintainers abandon them entirely without explanation.

For this reason, it is necessary to make it very clear to the library maintainers that they should only submit a library if they are prepared to behave responsibly by monitoring their pull request and acting promptly to resolve any problems so that the operation can be completed.