### PR TITLE
Replace inappropriate use of kbd HTML tags in documentation

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -190,7 +190,7 @@ Library Manager installs libraries into your sketchbook's `libraries` folder. Si
 
 #### Arduino IDE 2.x
 
-Hover the mouse pointer over the <kbd>INSTALLED</kbd> label on the library listing in Library Manager. It will now change to <kbd>UNINSTALL</kbd>, which you can click to uninstall that library.
+Hover the mouse pointer over the "**INSTALLED**" label on the library listing in Library Manager. It will now change to "**UNINSTALL**", which you can click to uninstall that library.
 
 #### Classic Arduino IDE
 

--- a/README.md
+++ b/README.md
@@ -48,17 +48,17 @@ Although we have set up automation for the most basic tasks, this repository is 
 1. Click the following link:<br />
    https://github.com/arduino/library-registry/fork<br />
    The "**Create a new fork**" page will open.
-1. Click the <kbd>Create fork</kbd> button in the "**Create a new fork**" page.<br />
+1. Click the "**Create fork**" button in the "**Create a new fork**" page.<br />
    A [fork](https://docs.github.com/get-started/quickstart/fork-a-repo) repository will be created under your GitHub account, and the home page of the fork will open.
 1. Click on the file `repositories.txt` under the list of files you see in that page.<br />
    The "**library-registry/repositories.txt**" page will open.
 1. Click the pencil icon ("Edit this file") at the right side of the toolbar in the "**library-registry/repositories.txt**" page.<br />
    The `repositories.txt` file will open in the online text editor.
 1. Add the library repository's URL to the list (it doesn't matter where in the list). This should be the URL of the repository home page. For example: `https://github.com/arduino-libraries/Servo`
-1. Click the <kbd>Commit changes...</kbd> button located near the top right corner of the page.<br />
+1. Click the "**Commit changes...**" button located near the top right corner of the page.<br />
    The "**Commit changes**" dialog will open.
-1. Click the <kbd>Commit changes</kbd> button in the "**Commit changes**" dialog.<br />
    The "**library-registry/repositories.txt**" page will open.
+1. Click the "**Commit changes**" button in the "**Commit changes**" dialog.<br />
 1. Click the "**library-registry**" link at the top of the "**library-registry/repositories.txt**" page.<br />
    The home page of your fork of the **library-registry** repository will open.
 1. You should see a banner on the page that says:
@@ -68,9 +68,9 @@ Although we have set up automation for the most basic tasks, this repository is 
    Click the "**Contribute**" link near the right side of that banner.<br />
    A menu will open.
 
-1. Click the <kbd>Open pull request</kbd> button in the menu.<br />
+1. Click the "**Open pull request**" button in the menu.<br />
    The "**Open a pull request**" page will open.
-1. In the **"Open a pull request"** window that opens, click the <kbd>Create pull request</kbd> button.
+1. In the **"Open a pull request"** window that opens, click the "**Create pull request**" button.
 
 The library will be automatically checked for compliance as soon as the pull request is submitted. If no problems were found, the pull request will be immediately merged and the library will be available for installation via Library Manager within a day's time.
 


### PR DESCRIPTION
The `kbd` HTML tag is intended to be used when referring to keys on a keyboard (e.g., when describing a keyboard shortcut). The rendered content that is wrapped in these tags will be styled in a manner that causes it to visually resemble a keycap.

Since that styling also happens to resemble some buttons in software UI elements, these tags were used in the documentation source content when referring to UI buttons.

On reflection, the decision was made that it is not appropriate to use kbd tags for purposes other than what they are intended, and that this technique does not actually significant benefit the readability of the documentation. Designers are increasingly ignoring established UI conventions in favor of a varied mishmash of bespoke implementations which do not have any resemblance to the graphical style provided by the `kbd` tags.

As a replacement for the `kbd` tags, quotes and bolding is utilized to clearly visually differentiate the button text from the surrounding prose content, but this time without attempting to approximate the actual visual appearance of the button UI elements.