### PR TITLE
Adjust submission instructions to utilize a feature branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,22 @@ Although we have set up automation for the most basic tasks, this repository is 
    The "**Create a new fork**" page will open.
 1. Click the "**Create fork**" button in the "**Create a new fork**" page.<br />
    A [fork](https://docs.github.com/get-started/quickstart/fork-a-repo) repository will be created under your GitHub account, and the home page of the fork will open.
+1. Click the "**1 Branch**" link on the home page of your fork.<br />
+   The "**Branches**" page will open.
+1. Click the "**New branch**" button on the "**Branches**" page.<br />
+   The "**Create a branch**" dialog will open.
+1. Type `my-submission` (or any other name you like) in the "**New branch name**" field of the "**Create a branch**" dialog.<br />
+   The "**Create a branch**" dialog will close.
+1. Click on the first drop-down menu under the "**Source**" section of the dialog.<br />
+   The drop-down menu will open.
+1. Select "**arduino/library-registry**" from the menu.
+1. Click on the second drop-down menu under the "**Source**" section of the dialog.<br />
+   The drop-down menu will open.
+1. Select "**main**" from the menu.
+1. Click the "**Create new branch**" button at the bottom of the dialog.<br />
+   The "**Create a branch**" dialog will close, returning you to the "**Branches**" page.
+1. Look under the "**Your branches**" section of the "**Branches**" page. You will see a link there for the branch you created during the previous step (i.e., `my-submission`). Click that link.<br />
+   The home page of your fork will open, with the newly created branch selected.
 1. Click on the file `repositories.txt` under the list of files you see in that page.<br />
    The "**library-registry/repositories.txt**" page will open.
 1. Click the pencil icon ("Edit this file") at the right side of the toolbar in the "**library-registry/repositories.txt**" page.<br />
@@ -58,6 +74,8 @@ Although we have set up automation for the most basic tasks, this repository is 
 1. Click the "**Commit changes...**" button located near the top right corner of the page.<br />
    The "**Commit changes**" dialog will open.
    The "**library-registry/repositories.txt**" page will open.
+1. Select the "**Commit directly to the `my-submission` branch**" radio button in the dialog.<br />
+   **ⓘ** If you chose a name other than `my-submission` when creating the branch, the radio button will instead have that branch name.
 1. Click the "**Commit changes**" button in the "**Commit changes**" dialog.<br />
 1. Click the "**library-registry**" link at the top of the "**library-registry/repositories.txt**" page.<br />
    The home page of your fork of the **library-registry** repository will open.


### PR DESCRIPTION
Previously, the instructions resulted in the revision being staged in the default branch of the library maintainer's fork of the registry repo.

That approach was chosen in the interest of keeping the number of steps to the minimum. However, observations of the submission PRs in the repository have revealed that this approach is very problematic:

The practical problem it causes is that the library maintainers often reuse their fork for future submissions (at the time of writing the original instructions it was assumed that the library maintainers would delete the superfluous fork after completing the submission). When they commit to the default branch, it causes it to diverge from the branch in the parent repo, making it difficult to sync in preparation for future PRs. The library maintainers end up introducing corruption when attempting to resolve the merge conflict, this causing serious problems in the subsequent submission PRs.

Another problem is that of setting a bad example. Surprisingly, it turns out that the submission is often the first pull request ever made by the library maintainer. So these instructions are unexpectedly serving as a training for an vital skill. Best practice is to always create a dedicated feature branch for each pull request, never making any changes to the branches that track a fork's parent. This would not be so important in the case of a single trivial pull request in a throwaway fork, but is essential for any more significant and long term collaborative work. So we may do serious harm to a fledgling developer's progress by teaching them the poor habit of utilizing the default branch in their fork.

For these reasons, it will be better to adjust the procedure to use a feature branch.

Unfortunately although GitHub does provide a streamlined user flow for creating a feature branch and a pull request from that branch in a single operation, inexplicably that flow only supports submitting the pull request between two branches within a repository. It can not be used in this case where a pull request is being submitted from a fork to the parent repository.