### PR TITLE
Add step to submission instructions for awaiting check results

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,10 +96,13 @@ Although we have set up automation for the most basic tasks, this repository is 
    The "**Open a pull request**" page will open.
 1. Click the "**Create pull request**" button on the "**Open a pull request**" page.<br />
    The pull request will be submitted.
+1. Checks for compliance will be automatically triggered by the submission of the pull request. A bot will comment on the pull request as soon as the checks are completed to notify you of the result. Wait until you see this comment from the bot.
 
-The library will be automatically checked for compliance as soon as the pull request is submitted. If no problems were found, the pull request will be immediately merged and the library will be available for installation via Library Manager within a day's time.
+If the pull request is merged, this means your library has been successfully registered and the library will be available for installation via Library Manager within a day's time.
 
-If any problems are found, a bot will comment on the pull request to tell you what is wrong. The problem may be either with your pull request or with the library.
+If the bot comment instead reports that a problem has been found, then please promptly follow the provided instructions to resolve the problem. There is additional information about resolving problems below.
+
+The problem may be either with your pull request or with the library.
 
 #### If the problem is with the pull request:
 


### PR DESCRIPTION
This repository receives thousands of pull requests. For the sake of maintainability, it is essential that these be resolved efficiently. Unfortunately the human repository maintainers frequently have to spend time prompting the library maintainers to take the simple actions required to resolve problems with their submissions so that they can be completed, and even being forced to close the submission PRs when library maintainers abandon them entirely without explanation.

Many library maintainers seem to submit the pull request and then consider the operation complete. In the case where the library and pull request are completely correct, this works. However, more often than not there is a problem that requires follow-up action from the maintainer. This is clearly communicated by comments made by the automated system, but apparently the library maintainers do not bother to monitor the pull request and their notifications.

For this reason, it is important to add a monitoring step to the submission instructions, and to make it clear that action must be taken promptly in the case where the automated system reports a problem with the submission.