### PR TITLE
Use alternative UI path to pull request initiation in submission instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,13 +85,8 @@ Although we have set up automation for the most basic tasks, this repository is 
    The "**Commit changes**" dialog will close.
 1. Click the "**library-registry**" link at the top of the "**library-registry/repositories.txt**" page.<br />
    The home page of your fork will open.
-1. You should see a banner on the page that says:
-
-   > **This branch is 1 commit ahead of arduino:main.**
-
-   Click the "**Contribute**" link near the right side of that banner.<br />
+1. Click the "**Contribute**" button on the home page of your fork.<br />
    A menu will open.
-
 1. Click the "**Open pull request**" button in the menu.<br />
    The "**Open a pull request**" page will open.
 1. Click the "**Create pull request**" button on the "**Open a pull request**" page.<br />


### PR DESCRIPTION
After a commit is pushed to to a feature branch, GitHub displays a banner on the homepage which contains a button that can be used to initiate a pull request from that branch.

Previously, this convenient button was utilized by the submission instructions. However, this approach is problematic:

* GitHub only displays the banner for a short period of time, which means the instructions would break if the user experienced some delay between the time of making the commit and proceeding to the next step in the instructions.
* I have found that the banner is not displayed reliably.

For these reasons, it will be better to avoid the reliance on the banner by the instructions and instead use a UI path that is guaranteed to always be present.