### PR TITLE
Add note re: warnings vs. errors to submission instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,12 @@ The submission of the pull request will trigger an automated system. This system
    **ⓘ** You should only need to wait a few minutes at most.
 1. If you see that the pull request was merged, this means your library has been successfully registered 🎉 and the library will be available for installation via Library Manager within a day's time. If instead the comment from the bot says that a problem was found, please promptly follow the provided instructions to resolve the problem. There is additional information about resolving problems below.
 
+---
+
+**ⓘ** In addition to checking for problems that block the acceptance of the library, the automated system also displays warnings when it identifies potential areas for improvement in the library. We do recommend you pay attention to these warnings and act on them. However, warnings do not block or otherwise affect the registration of the library. It is only the items labeled as errors that block acceptance.
+
+---
+
 The problem may be either with your pull request or with the library:
 
 #### If the problem is with the pull request:


### PR DESCRIPTION
In order to encourage library maintainers to improve the quality of their libraries, the automated submission system displays warnings when a library is found to not be following best practices.

Gratifyingly, we do often see the library maintainers take action in regards to the things highlighted by these warnings. However, we also sometimes see them cause confusion to maintainers who misinterpret them as indicating that something went wrong with the submission. So it will be helpful to more clearly communicate the nature of these warnings.