### PR TITLE
Add Soldered OpenAI library to library manager

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -152,6 +152,7 @@ https://github.com/milad-nikpendar/initAuthorization
 https://github.com/KB-Sensor-Mart/iSYS4001
 https://github.com/SolderedElectronics/Soldered-Microphone-SPK0641HT-Library
 https://github.com/SolderedElectronics/Soldered-DS3234-RTC-Arduino-Library
+https://github.com/SolderedElectronics/Soldered-OpenAI-Library
 https://github.com/YoungEngineerMixertiX/MegaTPA
 https://github.com/jobitjoseph/CH32X035_USBSerial
 https://github.com/AndyNewlands/DualEncoderMenuSystem


### PR DESCRIPTION
Add support for the new Soldered OpenAI library, which simplifies communication with various OpenAI APIs