### PR TITLE
Update openAFEComm repository link to openafe-comm

### DIFF
--- a/registry.txt
+++ b/registry.txt
@@ -6785,7 +6785,7 @@ https://github.com/stefangs/arduino-library-at24cxxx.git|Contributed|AT24C
 https://github.com/vortigont/esp32-flashz.git|Contributed|esp32-flashz
 https://github.com/vortigont/pzem-edl.git|Contributed|pzem-edl
 https://github.com/moduhub/openafe.git|Contributed|openafe
-https://github.com/ig-66/openAFEComm.git|Contributed|openafe_comm
+https://github.com/moduhub/openafe-comm.git|Contributed|openafe_comm
 https://github.com/vortigont/ESPAsyncButton.git|Contributed|ESPAsyncButton
 https://github.com/chankame/sclm-p105_shield.git|Contributed|sclm-p105_shield
 https://github.com/siroshy/SharpIR.git|Contributed|sharpIRSensor


### PR DESCRIPTION
! The author of the repository is the company Moduhub, and this repository belongs to it, just a link correction, since Igor himself has already made the updates that were later updated and corrected by me.