### PR TITLE
Add new repository link for LinkGenericDash

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -8843,3 +8843,4 @@ https://github.com/taraszhylenko/TickerTape7SegmentDisplay
 https://github.com/dimuthurangana/DimuthuRobotLib
 https://github.com/teamprof/ArduCMSIS-DSP
 https://github.com/wagenadl/RobustQuadrature
+https://github.com/AdaptiveEngineering/LinkGenericDash


### PR DESCRIPTION
Adds support for LinkGenericDash - a library that parses Generic Dash data sent out from Link ECU's over CAN BUS and makes information such as engine speed RPM, manifold air pressure, fault codes and various other information available to developers programs in a human-friendly format.