### PR TITLE
Add CH32X035_USBMIDI repository link

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -8844,3 +8844,4 @@ https://github.com/dimuthurangana/DimuthuRobotLib
 https://github.com/teamprof/ArduCMSIS-DSP
 https://github.com/wagenadl/RobustQuadrature
 https://github.com/AdaptiveEngineering/LinkGenericDash
+https://github.com/NoNamedCat/CH32X035_USBMIDI 


### PR DESCRIPTION
Adding new library CH32X035_USBMIDI by NoNamedCat for the MCU CH32x035