### PR TITLE
Add rLink Arduino library

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -8848,3 +8848,4 @@ https://github.com/wagenadl/RobustQuadrature
 https://github.com/AdaptiveEngineering/LinkGenericDash
 https://github.com/NoNamedCat/CH32X035_USBMIDI 
 https://github.com/ahmadfathan/fthnlabs_display
+https://github.com/HobbyComponents/rLink


### PR DESCRIPTION
This pull request adds the rLink Arduino library to the library registry.

Library details:
- GitHub repository: https://github.com/HobbyComponents/rLink
- Currently supported modules: rLink 2-channel relay module (SKU: HCMODU0281)
- Provides simple control of rLink RS485 modules via Arduino
- Includes examples and keywords.txt for Arduino IDE