### PR TITLE
Add Cloudeck library

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -8852,3 +8852,4 @@ https://github.com/ahmadfathan/fthnlabs_display
 https://github.com/HobbyComponents/rLink
 https://github.com/HobbyComponents/mLink
 https://github.com/afpineda/ESP32-RGB-LEDStrip
+https://github.com/Bhushan8673/Cloudeck


### PR DESCRIPTION
Initial submission of the Cloudeck IoT SDK to the Arduino Library Manager.

This pull request adds the Cloudeck library.

Repository:
https://github.com/Bhushan8673/Cloudeck

Cloudeck is a lightweight, modular IoT SDK for ESP8266 and ESP32 that simplifies WiFi and MQTT communication, with optional features such as IoT car and motor control.
