### PR TITLE
Add easyPID library

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -8856,3 +8856,4 @@ https://github.com/Bhushan8673/Cloudeck
 https://github.com/NoNamedCat/CH32X035_USBMouse
 https://github.com/NoNamedCat/CH32X035_USBHIDKeyboard
 https://github.com/NoNamedCat/CH32X035_USBGamepad
+https://github.com/Kronbii/easyPID.git


### PR DESCRIPTION
This PR adds the **easyPID** library to the Arduino Library Manager index.

- Repository: https://github.com/Kronbii/easyPID
- Library name: easyPID
- Initial release: v1.0.0
- Category: Device Control

The library is compliant with the Arduino Library Specification and includes example sketches.