### PR TITLE
Move maintenance request procedures to dedicated document

### DIFF
--- a/.github/workflows/check-toc.yml
+++ b/.github/workflows/check-toc.yml
@@ -25,8 +25,10 @@ jobs:
 
       matrix:
         file:
-          - name: README.md
+          - name: maintenance-requests.md
             # Max ToC depth, for use with the markdown-toc --maxdepth flag.
+            maxdepth: 2
+          - name: README.md
             maxdepth: 2
           - name: FAQ.md
             maxdepth: 3

--- a/FAQ.md
+++ b/FAQ.md
@@ -17,6 +17,7 @@
   - [Why aren't releases of my library being picked up by Library Manager?](#why-arent-releases-of-my-library-being-picked-up-by-library-manager)
   - [Can I check on library releases being added to Library Manager?](#can-i-check-on-library-releases-being-added-to-library-manager)
   - [How can I remove a release of my library from Library Manager?](#how-can-i-remove-a-release-of-my-library-from-library-manager)
+  - [How can I change a library's URL?](#how-can-i-change-a-librarys-url)
   - [How can I change a library's name?](#how-can-i-change-a-librarys-name)
 - [Limitations](#limitations)
   - [Is my Git repository OK?](#is-my-git-repository-ok)
@@ -140,24 +141,17 @@ http://downloads.arduino.cc/libraries/logs/github.com/arduino-libraries/Servo/
 
 ### How can I remove a release of my library from Library Manager?
 
-If you discover a problem with the library release, simply fix the problem and make a new [release](#how-can-i-publish-a-new-release-once-my-library-is-in-the-list). Library Manager defaults to installing the latest version of the library and offers updates to those with an older version installed, so this is the fastest and most effective method for distributing a fix to the users.
+See the information [**here**](maintenance-requests.md#remove-a-library-release).
 
-In the event a library release is later discovered to contain something that absolutely can not be published, we do allow removing releases from Library Manager on request by the following procedure:
+### How can I change a library's URL?
 
-1. Delete the [tag](https://git-scm.com/book/en/v2/Git-Basics-Tagging) of the problematic release from the library's repository.
-1. Open an issue [here](https://github.com/arduino/library-registry/issues/new?labels=topic%3A+release+removal&template=release-removal.yml&title=Library+release+removal+request), specifying the name of the library and the version number of the release that should be removed.
+To request an update to a library's registered URL, follow the instructions [**here**](maintenance-requests.md#update-library-url).
 
 <a id="how-can-i-change-my-librarys-name"></a>
 
 ### How can I change a library's name?
 
-For the sake of continuity, libraries in the Library Manager list are locked to the name they had at the time they were added to the list. Changing the library name can be disruptive to its users because this is the unique identifier for the library used by the Arduino development software [command line interfaces](https://arduino.github.io/arduino-cli/latest/commands/arduino-cli_lib/), sketch [metadata](https://arduino.github.io/arduino-cli/latest/sketch-specification/#metadata), library [dependencies](https://arduino.github.io/arduino-cli/latest/library-specification/#libraryproperties-file-format), and installation location.
-
-If you wish to change the name it will need to be done manually by request:
-
-1. Change the `name` value in the [library.properties file](https://arduino.github.io/arduino-cli/latest/library-specification/#libraryproperties-file-format) and update the `version`.
-1. Create a release or tag.
-1. Open an issue [here](https://github.com/arduino/library-registry/issues/new?labels=topic%3A+rename&template=rename.yml&title=Library+name+change+request) specifying the URL of the library's repository.
+See the information [**here**](maintenance-requests.md).
 
 ## Limitations
 

--- a/README.md
+++ b/README.md
@@ -8,8 +8,7 @@ This repository contains the list of libraries in the [Arduino Library Manager](
 
 - [Frequently asked questions](#frequently-asked-questions)
 - [Adding a library to Library Manager](#adding-a-library-to-library-manager)
-- [Changing the URL of a library already in Library Manager](#changing-the-url-of-a-library-already-in-library-manager)
-- [Removing a library from Library Manager](#removing-a-library-from-library-manager)
+- [Request registration data changes for a library](#request-registration-data-changes-for-a-library)
 - [Report a problem with Library Manager](#report-a-problem-with-library-manager)
 - [Security & Malware Reporting](#security--malware-reporting)
 
@@ -157,17 +156,15 @@ Doing this will update the pull request and cause the automated checks to run ag
 1. Create a [release](https://docs.github.com/repositories/releasing-projects-on-github/managing-releases-in-a-repository) or [tag](https://git-scm.com/docs/git-tag). The Library Manager index always uses tagged versions of the libraries, so even if the development version of the library is compliant, it can't be accepted until the latest release or tag is compliant. Alternatively, you can redo the existing release/tag if you prefer.
 1. Comment on your pull request here in the `arduino/library-registry` repository, mentioning **@ArduinoBot** in the comment. Doing this will cause the automated check to run again.
 
-## Changing the URL of a library already in Library Manager
+<a name="changing-the-url-of-a-library-already-in-library-manager"></a>
 
-Submit a pull request that changes the URL as desired in [repositories.txt](repositories.txt). This can be done by following [the instructions above](#instructions).
+<a name="removing-a-library-from-library-manager"></a>
 
-Since this type of request must be reviewed by a human maintainer, please write an explanation in the pull request description, making it clear that the URL is intentionally being changed.
+## Request registration data changes for a library
 
-## Removing a library from Library Manager
+Library maintainers sometimes find the need to request changes be made to the registration data for a library in the Arduino Library Registry.
 
-Submit a pull request that removes the URL from [repositories.txt](repositories.txt). This can be done by following [the instructions above](#instructions).
-
-Since this type of request must be reviewed by a human maintainer, please write an explanation in the pull request description, making it clear that the URL is intentionally being removed.
+Instructions for making such requests are provided [**here**](maintenance-requests.md).
 
 ## Report a problem with Library Manager
 

--- a/maintenance-requests.md
+++ b/maintenance-requests.md
@@ -1,0 +1,53 @@
+# Maintenance Requests
+
+Library maintainers sometimes find the need to request the registration data for libraries that are in the Arduino Library Registry. Instructions for making such requests are provided here.
+
+---
+
+**ⓘ** Unlike our highly automated system for library submissions, maintenance requests are handled by humans. Make sure to communicate clearly in order to ensure we execute your request correctly and efficiently.
+
+Please be patient until we complete the manual operations required to accommodate the request.
+
+---
+
+## Table of Contents
+
+<!-- toc -->
+
+- [Remove library](#remove-library)
+- [Remove a library release](#remove-a-library-release)
+- [Update library name](#update-library-name)
+- [Update library URL](#update-library-url)
+
+<!-- tocstop -->
+
+## Remove library
+
+Submit a pull request that removes the URL from [repositories.txt](repositories.txt). This can be done by a procedure similar to [the one followed when submitting a library](README.md#instructions).
+
+Since this type of request must be reviewed by a human maintainer, please write an explanation in the pull request description, making it clear that the URL is intentionally being removed.
+
+## Remove a library release
+
+If you discover a problem with the library release, simply fix the problem and make a new [release](FAQ.md#how-can-i-publish-a-new-release-once-my-library-is-in-the-list). Library Manager defaults to installing the latest version of the library and offers updates to those with an older version installed, so this is the fastest and most effective method for distributing a fix to the users.
+
+In the event a library release is later discovered to contain something that absolutely can not be published, we do allow removing releases from Library Manager on request by the following procedure:
+
+1. Delete the [tag](https://git-scm.com/book/en/v2/Git-Basics-Tagging) of the problematic release from the library's repository.
+1. Open an issue [here](https://github.com/arduino/library-registry/issues/new?labels=topic%3A+release+removal&template=release-removal.yml&title=Library+release+removal+request), specifying the name of the library and the version number of the release that should be removed.
+
+## Update library name
+
+For the sake of continuity, libraries in the Library Manager list are locked to the name they had at the time they were added to the list. Changing the library name can be disruptive to its users because this is the unique identifier for the library used by the Arduino development software [command line interfaces](https://arduino.github.io/arduino-cli/latest/commands/arduino-cli_lib/), sketch [metadata](https://arduino.github.io/arduino-cli/latest/sketch-specification/#metadata), library [dependencies](https://arduino.github.io/arduino-cli/latest/library-specification/#libraryproperties-file-format), and installation location.
+
+If you wish to change the name it will need to be done manually by request:
+
+1. Change the `name` value in the [library.properties file](https://arduino.github.io/arduino-cli/latest/library-specification/#libraryproperties-file-format) and update the `version`.
+1. Create a release or tag.
+1. Open an issue [here](https://github.com/arduino/library-registry/issues/new?labels=topic%3A+rename&template=rename.yml&title=Library+name+change+request) specifying the URL of the library's repository.
+
+## Update library URL
+
+Submit a pull request that changes the URL as desired in [repositories.txt](repositories.txt). This can be done by a procedure similar to [the one followed when submitting a library](README.md#instructions).
+
+Since this type of request must be reviewed by a human maintainer, please write an explanation in the pull request description, making it clear that the URL is intentionally being changed.


### PR DESCRIPTION
In addition to library submissions, this repository is used for requests to make changes to the registration and index data of libraries. Instructions are provided for making such requests in the repository's documentation.

Previously those instructions were split across two different documents:

* readme
* FAQ

This was problematic because it made finding the information unintuitive. Although that situation might have been solved by moving all the instructions to one or the other documents. However, that would exacerbate a more serious problem, which is that there is already a significant amount of content in each document, and a clear need to expand on that content.

For this reason, it will be best move the maintenance request instructions to a dedicated document, linked to from both of the other documents.