### PR TITLE
Add Joystick-KY023 repository link

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -8858,3 +8858,4 @@ https://github.com/NoNamedCat/CH32X035_USBHIDKeyboard
 https://github.com/NoNamedCat/CH32X035_USBGamepad
 https://github.com/Kronbii/easyPID.git
 https://github.com/NoNamedCat/CH32X035_USBComposite
+https://github.com/pavel-jiranek/Joystick-KY023


### PR DESCRIPTION
Adding a link to my KY023 library.

The library is simple, it wraps the pin reads behind a class method calls. It includes: mapping the x and y values between -1.0 and 1.0 for easier handling, calibration of the center.