### PR TITLE
Add new repository link for STM32RS485DMA

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -8865,3 +8865,4 @@ https://github.com/pavel-jiranek/Joystick-KY023
 https://github.com/cubicleguy/xv7211_arduino_spi
 https://github.com/gomgom-40/RD03Radar
 https://github.com/FluxGarage/RoboEyes
+https://github.com/NitrofMtl/STM32RS485DMA


### PR DESCRIPTION
High-performance RS485 driver for STM32 using UART + DMA.