### PR TITLE
Add STM32Modbus repository link

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -8872,3 +8872,4 @@ https://github.com/bozont/bozontlabsUptime
 https://github.com/robocre8/EPMC_I2C_Client
 https://github.com/robocre8/EIMU_I2C_Client
 https://github.com/bill-orange/AskGemini.git
+https://github.com/NitrofMtl/STM32Modbus


### PR DESCRIPTION
Modbus client and server library adapted for STM32 using DMA-based RS485.