### PR TITLE
Add MAX7219 driver and Uptime library

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -8866,3 +8866,5 @@ https://github.com/cubicleguy/xv7211_arduino_spi
 https://github.com/gomgom-40/RD03Radar
 https://github.com/FluxGarage/RoboEyes
 https://github.com/4nvesh/EasyESPConnect
+https://github.com/bozont/bozontlabsMAX7219
+https://github.com/bozont/bozontlabsUptime


### PR DESCRIPTION
Hey! This PR add two libraries which I have been using a lot in my projects and decided to make them accessible to everyone:

- **bozontlabsMAX7219** - driver for MAX7219 based LED matrix displays with both software and hardware SPI support and absolute X/Y addressing
- **bozontlabsUptime** - library for tracking device uptime with millis() overflow handling and various uptime formats including a human readable string like '3d 12h 45m 21s'

Let me know if I need to change anything in them!
Have a nice day!