### PR TITLE
Add new repository link for EPMC_I2C_Client Library

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -8868,3 +8868,4 @@ https://github.com/FluxGarage/RoboEyes
 https://github.com/4nvesh/EasyESPConnect
 https://github.com/bozont/bozontlabsMAX7219
 https://github.com/bozont/bozontlabsUptime
+https://github.com/robocre8/EPMC_I2C_Client


### PR DESCRIPTION
Please help add this library to the Arduino registry 

Library name: EPMC_I2C_Client
Repository URL: https://github.com/robocre8/EPMC_I2C_Client
Release tag: v1.0.0