### PR TITLE
Add EIMU_I2C_Client repository link

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -8869,3 +8869,4 @@ https://github.com/4nvesh/EasyESPConnect
 https://github.com/bozont/bozontlabsMAX7219
 https://github.com/bozont/bozontlabsUptime
 https://github.com/robocre8/EPMC_I2C_Client
+https://github.com/robocre8/EIMU_I2C_Client


### PR DESCRIPTION
Please help add this library to the Arduino registry 

Library name: EIMU_I2C_Client
Repository URL: https://github.com/robocre8/EIMU_I2C_Client
Release tag: v1.0.0