### PR TITLE
Add RD03Radar library v1.1.0

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -8880,3 +8880,4 @@ https://github.com/bill-orange/AskGemini.git
 https://github.com/NitrofMtl/STM32Modbus
 https://github.com/arkhipenko/StateMachine.git
 https://github.com/Ransky3000/SCT013-100
+https://github.com/gomgom-40/RD03Radar


### PR DESCRIPTION
   Repository: https://github.com/gomgom-40/RD03Radar
   Version: 1.1.0
   Architecture: esp32, esp8266, avr
   Category: Sensors