### PR TITLE
Update repositories.txt

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -8882,3 +8882,4 @@ https://github.com/NitrofMtl/STM32Modbus
 https://github.com/arkhipenko/StateMachine.git
 https://github.com/Ransky3000/SCT013-100
 https://github.com/kireev7/FastLed_Neopixel_Nanit
+https://github.com/MasterArgo/PIDController


### PR DESCRIPTION
### Summary
This pull request adds the PIDController library to the Arduino Library Registry.

### Repository
https://github.com/MasterArgo/PIDController

### Notes
- Library prepared with `src/` and `examples/` folders.
- Includes `library.properties` file.
- Latest release/tag: v2.3.3
- Licensed under MIT.
