### PR TITLE
Add YNV-Driver-v5-Gen3-Arduino-Library repository

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -8884,3 +8884,4 @@ https://github.com/Ransky3000/SCT013-100
 https://github.com/kireev7/FastLed_Neopixel_Nanit
 https://github.com/KE-Holtz/holtzlib
 https://github.com/MasterArgo/PIDController
+https://github.com/Ynvisible-Electronics/YNV-Driver-v5-Gen3-Arduino-Library


### PR DESCRIPTION
**Library name:** YNV_Driver_v5_Gen3

**Repository URL:**
https://github.com/Ynvisible-Electronics/YNV-Driver-v5-Gen3-Arduino-Library

**Current version:** 1.0.0

**Description:**
Arduino library for driving Ynvisible Gen3 electrochromic displays using the Driver v5 hardware.

This library is independent from the legacy "YNV_Driver_v5" library, which will continue to be used for Gen1/Gen2 displays.

The repository follows the Arduino Library Manager requirements:
- Public GitHub repository
- Contains a valid library.properties
- Contains a tagged release v1.0.0
- Uses a standard folder structure (src/, examples/, library.properties)

Please add this library to the Arduino Library Manager.

Thank you!