### PR TITLE
feat: add repository link for esp32-http-client

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -8885,3 +8885,4 @@ https://github.com/kireev7/FastLed_Neopixel_Nanit
 https://github.com/KE-Holtz/holtzlib
 https://github.com/MasterArgo/PIDController
 https://github.com/Ynvisible-Electronics/YNV-Driver-v5-Gen3-Arduino-Library
+https://github.com/PedroFnseca/esp32-http-client


### PR DESCRIPTION
This PR adds the repository:

[https://github.com/PedroFonseca/esp32-rest-client](https://github.com/PedroFonseca/esp32-rest-client)

**Library:** ESP32HTTPClient
**Category:** Communication
**Architectures:** esp32
**License:** MIT

The library follows the Arduino Library Specification, includes semantic versioning, and passes `arduino-lint` with `--library-manager submit --compliance strict`.

Ready for inclusion in the Arduino Library Manager.