### PR TITLE
Add PZEM004Tv40_R4 library

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -8886,3 +8886,4 @@ https://github.com/KE-Holtz/holtzlib
 https://github.com/MasterArgo/PIDController
 https://github.com/Ynvisible-Electronics/YNV-Driver-v5-Gen3-Arduino-Library
 https://github.com/PedroFnseca/esp32-http-client
+https://github.com/bharanidharanrangaraj/PZEM004Tv40_R4


### PR DESCRIPTION
## Library Information

- **Name:** PZEM004Tv40_R4
- **Repository:** https://github.com/bharanidharanrangaraj/PZEM004Tv40_R4
- **Category:** Sensors
- **Description:** Library for PZEM-004T V4.0 Energy Monitor compatible with Arduino UNO R3, R4, Nano, and Mega

## Features

- Reads voltage, current, power, energy, frequency, power factor from PZEM-004T V4.0
- Supports both HardwareSerial (R4, Mega) and SoftwareSerial (R3, Nano)
- Modbus RTU protocol with CRC verification
- Comprehensive examples included

## Checklist

- [x] Library follows Arduino library specification
- [x] Contains valid library.properties
- [x] Includes LICENSE file (MIT)
- [x] Has working examples
- [x] README with documentation
- [x] Released version v1.1.0