### PR TITLE
Add OrbiSyncNode library

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -8892,3 +8892,4 @@ https://github.com/bharanidharanrangaraj/PZEM004Tv40_R4
 https://github.com/raiotech-iot/RaioLink
 https://github.com/tomorrow56/M5StackWiFiUploader/
 https://github.com/FantasyFactory/EventStateMachine
+https://github.com/jihun-kang/orbisync-node


### PR DESCRIPTION
This pull request adds the OrbiSyncNode Arduino library to the Library Manager index.

Repository:
https://github.com/jihun-kang/orbisync-node

The library follows the Arduino Library Specification and includes:
- library.properties
- src/ directory
- examples
- MIT license

Thank you!
