### PR TITLE
Update URL of "eFLL" in repository list

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -7784,7 +7784,7 @@ https://github.com/Zanduino/VCNL4010
 https://github.com/Zentser/esp-zentser-sdk
 https://github.com/Zeppelin500/MBusinoLib
 https://github.com/Zerfoinder/EasyPin
-https://github.com/zerokol/eFLL
+https://github.com/alvesoaj/eFLL
 https://github.com/zfields/nes-rob
 https://github.com/zharijs/FDC2214
 https://github.com/zhenek-kreker/MAX6675


### PR DESCRIPTION
The name of the owner of this repository has changed (either through a username change or repository transfer). The previous URL no longer leads to the library's repository.