### PR TITLE
Update URL of "eFLL" in registry

### DIFF
--- a/registry.txt
+++ b/registry.txt
@@ -2062,7 +2062,7 @@ https://github.com/OladapoAjala/Drive.git|Contributed|Drive
 https://github.com/OladapoAjala/Robot.git|Contributed|Robot
 https://github.com/stm32duino/X-NUCLEO-GNSS1A1.git|Contributed|STM32duino X-NUCLEO-GNSS1A1
 https://github.com/gmag11/CayenneLPPdec.git|Contributed|CayenneLPPdec
-https://github.com/zerokol/eFLL.git|Contributed|eFLL
+https://github.com/alvesoaj/eFLL.git|Contributed|eFLL
 https://github.com/sparkfun/SparkFun_APDS9301_Library.git|Contributed|SparkFun APDS-9301 Lux Sensor
 https://github.com/u-fire/Isolated_EC.git|Contributed|Isolated EC Probe Interface
 https://github.com/asukiaaa/ST7032_asukiaaa.git|Contributed|ST7032_asukiaaa


### PR DESCRIPTION
The name of the owner of this repository has changed (either through a username change or repository transfer). The previous URL no longer leads to the library's repository.