### PR TITLE
Add InputTerminal library

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -8898,4 +8898,4 @@ https://github.com/FantasyFactory/EventStateMachine
 https://github.com/jihun-kang/orbisync-node
 https://github.com/panchocoquito/OptaButton
 https://github.com/panchocoquito/DefLab_Common
-https://github.com/hayasita/InputTermina
+https://github.com/hayasita/InputTerminal


### PR DESCRIPTION
This pull request adds the **InputTerminal** Arduino library to the Arduino Library Manager.

Repository:
https://github.com/hayasita/InputTerminal

InputTerminal is an Arduino library for handling multiple digital input keys with short-press and long-press detection using INPUT_PULLUP wiring.

Latest version: v1.0.1
