### PR TITLE
Add Adafruit APDS9999 Library

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -1,5 +1,4 @@
 
-
 http://github.com/codewitch-honey-crisis/htcw_pool
 https://bitbucket.org/amotzek/cooperative-multitasking
 https://bitbucket.org/amotzek/mqtt-client


### PR DESCRIPTION
Add Adafruit APDS9999 Digital Proximity and RGB Sensor library to Arduino Library Manager.

**Repository:** https://github.com/adafruit/Adafruit_APDS9999.git

**Library Info:**
- Proximity sensing (11-bit, configurable LED)
- RGB + IR light sensing (20-bit)
- Interrupt support with thresholds
- Dependencies: Adafruit BusIO