### PR TITLE
Add Adafruit APDS9999 Library

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -8916,3 +8916,4 @@ https://github.com/maumolinavaldez-pixel/BioLogic_STM32
 https://github.com/BOTCLibs/BrgOfTheCyber_SCD4x
 https://github.com/ayatec-europe/sensoraya-esp32s3
 https://github.com/moddoio/moddoMOUSE-Arduino
+https://github.com/adafruit/Adafruit_APDS9999.git


### PR DESCRIPTION
Add Adafruit APDS9999 Digital Proximity and RGB Sensor library.

**Repository:** https://github.com/adafruit/Adafruit_APDS9999

**Library Info:**
- Name: Adafruit APDS9999 Library  
- Category: Sensors
- Features: Proximity sensing (11-bit), RGB + IR light sensing (20-bit), interrupt support
- Dependencies: Adafruit BusIO

**Release:** 1.0.0