### PR TITLE
Add RoboServo repository link to repositories.txt

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -8917,3 +8917,4 @@ https://github.com/BOTCLibs/BrgOfTheCyber_SCD4x
 https://github.com/ayatec-europe/sensoraya-esp32s3
 https://github.com/moddoio/moddoMOUSE-Arduino
 https://github.com/adafruit/Adafruit_APDS9999.git
+https://github.com/dunknowcoding/RoboServo.git


### PR DESCRIPTION
A lightweight servo control library for ESP32 and ESP8266.