### PR TITLE
Update repositories.txt

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -5946,6 +5946,7 @@ https://github.com/RobTillaart/AtomicWeight
 https://github.com/RobTillaart/AverageAngle
 https://github.com/RobTillaart/avrheap
 https://github.com/RobTillaart/BH1750FVI_RT
+https://github.com/RobTillaart/BL0940_SPI
 https://github.com/RobTillaart/BL0942_SPI
 https://github.com/RobTillaart/BitArray
 https://github.com/RobTillaart/bitHelpers


### PR DESCRIPTION
Arduino library for BL0940 energy monitor, SPI interface only.