### PR TITLE
Update repositories.txt

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -8920,3 +8920,4 @@ https://github.com/moddoio/moddoMOUSE-Arduino
 https://github.com/adafruit/Adafruit_APDS9999.git
 https://github.com/dunknowcoding/RoboServo.git
 https://github.com/CostelloTechnical/DN24F08.git
+https://github.com/KovalRM/KRM_libraries_Arduino


### PR DESCRIPTION
This pull request adds the KRM Arduino library to the Arduino Library Manager.

Repository: https://github.com/KovalRM/KRM_libraries_Arduino  
Latest release: 1.0.0
