### PR TITLE
Add Lua 5.1 for ESP32

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -8926,3 +8926,4 @@ https://github.com/KovalRM/KRM_libraries_Arduino
 https://github.com/ktauchathuranga/openpager
 https://github.com/nikki-build/nikki.esp32
 https://github.com/IlliaZenistu/DHT22_Clone_ESP32.git
+https://github.com/sapteinkabeltann/lua511-esp32


### PR DESCRIPTION
First release of Lua 5.1 for ESP32 — Arduino library that embeds the Lua 5.1 interpreter on ESP32.