### PR TITLE
Add curiejet p760 air sensor module

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -8928,3 +8928,4 @@ https://github.com/ktauchathuranga/openpager
 https://github.com/nikki-build/nikki.esp32
 https://github.com/IlliaZenistu/DHT22_Clone_ESP32.git
 https://github.com/sapteinkabeltann/lua511-esp32
+https://github.com/louischuang/curiejet-p760-arduino-lib.git


### PR DESCRIPTION
I add a new lib for curiejet p760 air sensor .
Please reference the url for more detail:
https://www.curiejet.com/tw/product/particle-voc-index-barometric-pressure-sensor/environmental-sensor-modules