### PR TITLE
Add V7RCServoDriver library

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -8936,3 +8936,4 @@ https://github.com/alxprgs/RTC_RDP_LIB_L298N
 https://github.com/ivica3730k/MSF-Time-Lib
 https://github.com/o0zz/climate-uart
 https://github.com/sebuahhobi/waavis_arduino
+https://github.com/v7rc/V7RCServoDriver


### PR DESCRIPTION
New Libs for V7RC relative echo systems.
The Dev boards includes ESP32 series boards. Especially recommend V7RCDOM V2.0.