### PR TITLE
Replace sensoraya-esp32s3 with AyatecSensoraya2.x

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -8921,7 +8921,7 @@ https://github.com/lu-maca/pyrpc
 https://github.com/SortaHappyDoge/Mecanum-Drive-Arduino
 https://github.com/maumolinavaldez-pixel/BioLogic_STM32
 https://github.com/BOTCLibs/BrgOfTheCyber_SCD4x
-https://github.com/ayatec-europe/sensoraya-esp32s3
+https://github.com/ayatec-europe/AyatecSensoraya2.x
 https://github.com/moddoio/moddoMOUSE-Arduino
 https://github.com/adafruit/Adafruit_APDS9999.git
 https://github.com/dunknowcoding/RoboServo.git


### PR DESCRIPTION
Updated repository link for AyatecSensoraya.