### PR TITLE
Update name and URL of "AyatecSensoraya2.x"

### DIFF
--- a/registry.txt
+++ b/registry.txt
@@ -8908,7 +8908,7 @@ https://github.com/SofaPirate/PqOsc.git|Contributed|PqOSC
 https://github.com/maumolinavaldez-pixel/BioLogic_STM32.git|Contributed|BioLogic_STM32
 https://github.com/BOTCLibs/BrgOfTheCyber_SCD4x.git|Contributed|BrgOfTheCyber_SCD4x
 https://github.com/moddoio/moddoMOUSE-Arduino.git|Contributed|moddoMOUSE
-https://github.com/ayatec-europe/sensoraya-esp32s3.git|Contributed|AyatecSensoraya2.x
+https://github.com/ayatec-europe/AyatecSensoraya2.x.git|Contributed|AyatecSensoraya2.x
 https://github.com/adafruit/Adafruit_APDS9999.git|Recommended|Adafruit APDS9999
 https://github.com/dunknowcoding/RoboServo.git|Contributed|RoboServo
 https://github.com/RobTillaart/BL0940_SPI.git|Contributed|BL0940_SPI


### PR DESCRIPTION
This PR consists of two changes:

- Change URL from `https://github.com/ayatec-europe/sensoraya-esp32s3.git` to `https://github.com/ayatec-europe/AyatecSensoraya2.x.git` (companion to https://github.com/arduino/library-registry/pull/7711)
- Change name from `ayatec_sensoraya_2_demo` to `AyatecSensoraya2.x` (resolves https://github.com/arduino/library-registry/issues/7712)

Since the name change operation on the database is actually a removal followed by automated re-indexing on the next job run, the URL update will occur as a matter of course. For this reason, the only operation required from the backend maintainer is a standard name change procedure.