### PR TITLE
Add SafeGithubOTA library

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -8942,3 +8942,4 @@ https://github.com/v7rc/V7RCServoDriver
 https://github.com/matthias-bs/DYP-R01CW
 https://github.com/iskakfatoni/IskakINO_LiquidCrystal_I2C
 https://github.com/dmachard/NimBLE-DataPipe
+https://github.com/gibz104/SafeGithubOTA


### PR DESCRIPTION
Add SafeGithubOTA — safe OTA firmware updates from GitHub private repositories for ESP32.

**Library URL:** https://github.com/gibz104/SafeGithubOTA

**Features:**
- OTA updates from GitHub private (and public) repo releases using a PAT
- Automatic rollback protection with custom validation callbacks
- Captive portal provisioning for GitHub credentials (stored in NVS)
- Semantic version comparison
- Periodic auto-check timer
- Zero external dependencies beyond ESP32 Arduino core

`arduino-lint --library-manager submit --compliance strict` passes with no errors or warnings.