### PR TITLE
Remove VARSTEP_ultrasonic repository link

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -698,7 +698,6 @@ https://github.com/FinianLandes/SpotifyEsp32
 https://github.com/hex705/Scissors
 https://github.com/hex705/Glue
 https://github.com/2taras/espwifiarduino_ide_lib
-https://github.com/x0x0200/VARSTEP_ultrasonic
 https://github.com/StefanHerald/Timing
 https://github.com/tdk-invn-oss/pressure.arduino.ICP201XX
 https://github.com/DigitalCodesign/MentorBit-Library


### PR DESCRIPTION
Removed a repository link from the list.