### PR TITLE
Remove "HCSR04 ultrasonic distance sensor"

### DIFF
--- a/registry.txt
+++ b/registry.txt
@@ -6673,7 +6673,6 @@ https://github.com/yishii/Meiro.git|Contributed|Meiro
 https://github.com/Abhijeetbyte/StreamLog.git|Contributed|StreamLog
 https://github.com/StefanHerald/Timing.git|Contributed|SimpleTiming
 https://bitbucket.org/logsdonj/rl_tonesongplayer.git|Contributed|RL_ToneSongPlayer
-https://github.com/x0x0200/VARSTEP_ultrasonic.git|Contributed|HCSR04 ultrasonic distance sensor
 https://github.com/IlikeChooros/lazyjson.git|Contributed|lazyjson
 https://github.com/The-Young-Maker/OpenMenuOS.git|Contributed|OpenMenuOS
 https://github.com/hex705/Scissors.git|Contributed|Scissors


### PR DESCRIPTION
Companion to https://github.com/arduino/library-registry/pull/7748