### PR TITLE
Remove my library URL from repositories.txt

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -38,7 +38,6 @@ https://github.com/Esslangamer20/SimpleWiFiManager
 https://github.com/ncmreynolds/bq25186
 https://github.com/TheHappyGrey/PicoGFX_SSD1322
 https://github.com/KravitzLabDevices/FED4
-https://github.com/Embedded-Petal/IoTCloud
 https://github.com/sava-74/SavaOLED_ESP32.git
 https://github.com/jo3-tech/MT-dh-serial-kinematics
 https://github.com/onuromer/O3SerialWriter


### PR DESCRIPTION
This pull request removes my library URL from repositories.txt as I no longer want it included.
