### PR TITLE
Add EmbeddedTerminal repository link

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -1905,6 +1905,7 @@ https://github.com/Bodmer/TJpg_Decoder
 https://github.com/boeserfrosch/GuL_NovaFitness
 https://github.com/boeserfrosch/GuL_Plantower
 https://github.com/boeserfrosch/GuL_TI_Humidity
+https://github.com/boeserfrosch/EmbeddedTerminal
 https://github.com/bogde/HX711
 https://github.com/bolderflight/ainstein-usd1
 https://github.com/bolderflight/airdata


### PR DESCRIPTION
Adding EmbeddedTerminal - a platform-independent terminal library for embedded systems