### PR TITLE
Register Gingoduino library

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -8361,6 +8361,7 @@ https://github.com/RyLeeHarrison/EventEmitter
 https://github.com/CMB27/ModbusTCPComm
 https://github.com/CMB27/ModbusTCPSlave
 https://github.com/sauloverissimo/ESP32_Host_MIDI
+https://github.com/sauloverissimo/gingoduino
 https://github.com/macFanDave/GigaDAQ
 https://github.com/msilveus/SimpleQueue
 https://github.com/fededc88/AS5040


### PR DESCRIPTION
## Gingoduino Library Registration

**Repository:** https://github.com/sauloverissimo/gingoduino

### Description

Gingoduino is a music engine for embedded systems. It brings comprehensive music theory capabilities to Arduino, ESP32, Teensy, Daisy Seed, Raspberry Pi Pico, and other microcontroller platforms.

### Key Features

- **Tier 1 (AVR)**: Note, Interval, Chord
- **Tier 2 (ESP8266)**: + Scale, Field, Duration, Tempo, Time Signature, Fretboard
- **Tier 3 (ESP32+)**: + Musical Events, Sequences
- 12-note chromatic system with enharmonic equivalents
- 42 chord formulas with reverse lookup (identify)
- 40+ scale types and modes
- Harmonic field analysis with T/S/D functions
- Fretboard engine (guitar, cavaquinho, bandolim, ukulele)
- **Zero-heap architecture** — no dynamic memory allocation
- PROGMEM lookup tables for AVR optimization
- 177 tests passing

### Technical Details

- **Language**: C++11 (no STL, no exceptions, no RTTI)
- **Port of**: [gingo](https://github.com/sauloverissimo/gingo) (C++17 library)
- **License**: MIT
- **Architectures**: All (*) — tier-based compilation
- **Status**: v0.1.0 released

### Installation

- Arduino IDE: Sketch > Include Library > Manage Libraries > Search "Gingoduino" > Install
- Manual: Download and copy to `~/Arduino/libraries/`

### Links

- Repository: https://github.com/sauloverissimo/gingoduino
- Documentation: https://github.com/sauloverissimo/gingoduino/blob/main/README.md
