### PR TITLE
Update repository list by adding and removing links

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -1,4 +1,5 @@
 https://github.com/JW-Control/JWMatrixButtons
+https://github.com/tingerlingerr/MultiSensorFilter
 https://github.com/KravitzLabDevices/Tumbly
 https://github.com/Xorlent/ESP32_WS2812B
 https://github.com/NOXUSTIC/OnScreenKeyboard


### PR DESCRIPTION
Added a new repository link for MultiSensorFilter and removed DigiPotX9C.