### PR TITLE
Add libsdi12 to library registry

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -8992,3 +8992,4 @@ https://github.com/Shourov-Paul/AnimatedroboEye
 https://github.com/embarquech/trng.git
 https://github.com/costinbobes/WiFi-Watchdog
 https://github.com/CostelloTechnical/ESC3B04
+https://github.com/phillipweinstock/libsdi12


### PR DESCRIPTION
## Library submission

**Repository**: https://github.com/phillipweinstock/libsdi12
**Library name**: libsdi12
**Category**: Communication

The most complete, portable SDI-12 v1.4 protocol library available. Pure C11 implementation covering every command in the SDI-12 v1.4 specification  both sensor (slave) and master (data recorder) roles  with zero external dependencies.

### Highlights
- Full SDI-12 v1.4 spec coverage (every command type)
- Dual-role: sensor AND master
- Pure C11, no malloc, no HAL
- Beginner-friendly convenience macros (sdi12_easy.h)
- 98 unit + metamorphic tests, platform-agnostic
- Works on any architecture: AVR, ARM, ESP32, STM32, x86, etc.

**Release**: [v0.1.0](https://github.com/phillipweinstock/libsdi12/releases/tag/v0.1.0)
**library.properties**: included at repository root