### PR TITLE
Add new repository link for HaierProtocol

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -8994,3 +8994,4 @@ https://github.com/costinbobes/WiFi-Watchdog
 https://github.com/CostelloTechnical/ESC3B04
 https://github.com/sndnvaps/espsoftwareserial
 https://github.com/phillipweinstock/libsdi12
+https://github.com/paveldn/HaierProtocol


### PR DESCRIPTION
Added HaierProtocol library that implement serial protocol used in different Haier appliances (ACs, washing machines, water heaters, dishwasers etc.)