### PR TITLE
Add LightScheduler library

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -8997,3 +8997,4 @@ https://github.com/phillipweinstock/libsdi12
 https://github.com/paveldn/HaierProtocol
 https://github.com/IP-tm/IP-tm-stepmotor
 https://github.com/oleoleg/Oleoleg_ULN2003_Stepper
+https://github.com/IAMTorres/LightScheduler


### PR DESCRIPTION
## Library submission

**Library name:** LightScheduler
**Repository:** https://github.com/IAMTorres/LightScheduler

### Description

Arduino library for scheduling PWM-controlled lights with configurable on/off times and a gradual sunset dimming effect. Non-blocking, EEPROM-persistent, works with any RTC module.

### Checklist

- [x] Library is on GitHub
- [x] `library.properties` is present and valid
- [x] `src/` folder structure used
- [x] Examples included
- [x] MIT license included
- [x] `keywords.txt` included
- [x] Repository added to `repositories.txt`