### PR TITLE
Add NodeRemote library

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -8998,3 +8998,4 @@ https://github.com/paveldn/HaierProtocol
 https://github.com/IP-tm/IP-tm-stepmotor
 https://github.com/oleoleg/Oleoleg_ULN2003_Stepper
 https://github.com/IAMTorres/LightScheduler
+https://github.com/youjunjer/NodeRemote.git


### PR DESCRIPTION
Add NodeRemote library for ESP32 + NodeAnywhere integration.\n\nRepository: https://github.com/youjunjer/NodeRemote\nLatest release: v0.5.14\nNodeAnywhere backend: https://node.mqttgo.io\n