### PR TITLE
Add LuminOx library

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -1,4 +1,4 @@
-https://github.com/veersingh671/LuminO
+https://github.com/veersingh671/LuminOx
 https://github.com/lska-dev/microLCD.git
 https://github.com/ARDUTECH0/ATGENXlib-0.0.1
 https://github.com/hestialabs/hxtp-micro


### PR DESCRIPTION
This pull request adds the LuminOx library to the Arduino Library Manager index.
Repository:
https://github.com/veersingh671/LuminOx