### PR TITLE
Bump Go version to `1.24` to support the latest release of the engine

### DIFF
--- a/.github/workflows/check-registry.yml
+++ b/.github/workflows/check-registry.yml
@@ -2,7 +2,7 @@ name: Check Registry Data File
 
 env:
   # See: https://github.com/actions/setup-go/tree/main#supported-version-syntax
-  GO_VERSION: "1.23"
+  GO_VERSION: "1.24"
 
 # See: https://docs.github.com/en/free-pro-team@latest/actions/reference/events-that-trigger-workflows
 on:


### PR DESCRIPTION
Bump Go version to `1.24` to support the latest release of the engine.