### PR TITLE
Add TelegramSerial library

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -9020,3 +9020,4 @@ https://github.com/IAMTorres/LightScheduler
 https://github.com/youjunjer/NodeRemote.git
 https://github.com/ArscottT/ADS7128-Arduino-Library
 https://github.com/tanmaywankar/Grobot_Animations
+https://github.com/toastmanAu/TelegramSerial


### PR DESCRIPTION
## Library submission: TelegramSerial

**Repository:** https://github.com/toastmanAu/TelegramSerial

**Description:** Drop-in `Serial` replacement for ESP32 that sends output to a Telegram bot over WiFi. Inherits from `Print` — works anywhere `Serial` does.

**Features:**
- Non-blocking queue with rate limiting (respects Telegram API limits)
- WiFi auto-reconnect and send retry
- Optional hardware Serial mirror
- Plain text and MarkdownV2 formatting modes
- Hardware verified on ESP32-D0WD-V3 (CYD / ESP32-2432S028R)

**Checklist:**
- [x] `library.properties` present and valid
- [x] `LICENSE` file present (MIT)
- [x] `src/` layout
- [x] Examples in `examples/` with matching `.ino` filenames
- [x] Git release tag `v1.0.0`
- [x] No external dependencies beyond ESP32 Arduino SDK built-ins