### PR TITLE
Add 7Semi AD569x Arduino Library

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -9022,3 +9022,4 @@ https://github.com/ArscottT/ADS7128-Arduino-Library
 https://github.com/tanmaywankar/Grobot_Animations
 https://github.com/toastmanAu/TelegramSerial
 https://github.com/7semi-solutions/7Semi-BNO08x-9-DOF-Orientation-IMU-Fusion
+https://github.com/7semi-solutions/7Semi_AD569x_Arduino_Library


### PR DESCRIPTION
This PR adds the 7Semi AD569x Arduino Library to the Arduino Library Manager index.

Repository URL:
https://github.com/7semi-solutions/7Semi_AD569x_Arduino_Library

The library provides APIs for AD569x series I2C DAC devices, including voltage output configuration and power-down control. Example sketches are included for quick integration.