### PR TITLE
Add 7Semi INA219 Arduino Library

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -9026,3 +9026,4 @@ https://github.com/toastmanAu/TelegramSerial
 https://github.com/7semi-solutions/7Semi-BNO08x-9-DOF-Orientation-IMU-Fusion
 https://github.com/7semi-solutions/7Semi_AD569x_Arduino_Library
 https://github.com/7semi-solutions/7Semi-TMP11x-Arduino
+https://github.com/7semi-solutions/7Semi_INA219_Arduino-Library


### PR DESCRIPTION
This PR adds the 7Semi INA219 Arduino Library to the Arduino Library Manager index.

Repository URL:
https://github.com/7semi-solutions/7Semi_INA219_Arduino-Library

The library provides APIs for measuring bus voltage, current, and power using the INA219 sensor over I2C, with example sketches for quick integration.