### PR TITLE
Add Plexus SDK

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -9027,3 +9027,4 @@ https://github.com/7semi-solutions/7Semi-BNO08x-9-DOF-Orientation-IMU-Fusion
 https://github.com/7semi-solutions/7Semi_AD569x_Arduino_Library
 https://github.com/7semi-solutions/7Semi-TMP11x-Arduino
 https://github.com/7semi-solutions/7Semi_INA219_Arduino-Library
+https://github.com/plexus-oss/c-sdk


### PR DESCRIPTION
Minimal footprint IoT telemetry SDK (~1.5KB RAM) for ESP32, STM32, and Arduino. Stream sensor data to a real-time dashboard with zero dependencies.

**Repository:** https://github.com/plexus-oss/c-sdk
**Latest release:** v0.5.5
**License:** Apache-2.0
**Architectures:** esp32, esp8266, stm32

Includes 4 Arduino example sketches (BasicTelemetry, BME280_Dashboard, WiFiReconnect, SessionRecording), keywords.txt, and library.properties/library.json metadata.