### PR TITLE
Add dual2s library

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -9028,3 +9028,4 @@ https://github.com/7semi-solutions/7Semi_AD569x_Arduino_Library
 https://github.com/7semi-solutions/7Semi-TMP11x-Arduino
 https://github.com/7semi-solutions/7Semi_INA219_Arduino-Library
 https://github.com/plexus-oss/c-sdk
+https://github.com/yesio/dual2s.git


### PR DESCRIPTION
Hello, please add the dual2s library to the Arduino Library Manager. It is a library for ESP32-based GoSUMO robots.
Repository: https://github.com/yesio/dual2s.git