### PR TITLE
Add 7Semi AD849x Arduino Library

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -9032,3 +9032,4 @@ https://github.com/plexus-oss/c-sdk
 https://github.com/yesio/dual2s.git
 https://github.com/TMRh20/microDecoder
 https://github.com/chon-group/javino2arduino
+https://github.com/7semi-solutions/7Semi_AD849x


### PR DESCRIPTION
This PR adds the 7Semi AD849x Arduino Library to the Arduino Library Manager index.

Repository URL:
https://github.com/7semi-solutions/7Semi_AD849x

The library provides APIs to read thermocouple temperature from AD849x (AD8494/AD8495) amplifier modules using analog input, with example sketches for quick integration.