### PR TITLE
Add 7Semi LIS3DH Arduino Library

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -9033,3 +9033,4 @@ https://github.com/yesio/dual2s.git
 https://github.com/TMRh20/microDecoder
 https://github.com/chon-group/javino2arduino
 https://github.com/7semi-solutions/7Semi_AD849x
+https://github.com/7semi-solutions/7Semi-LIS3DH-3-axis-acceleromet-Arduino-Library


### PR DESCRIPTION
This PR adds the 7Semi LIS3DH Arduino Library to the Arduino Library Manager index.

Repository URL:
https://github.com/7semi-solutions/7Semi-LIS3DH-3-axis-acceleromet-Arduino-Library

The library provides APIs for reading acceleration data from the LIS3DH 3-axis accelerometer over I2C/SPI, including configuration of range, data rate, and interrupts. Example sketches are included for quick integration.