### PR TITLE
Add 7Semi OPT4048 Arduino Library

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -9034,3 +9034,4 @@ https://github.com/TMRh20/microDecoder
 https://github.com/chon-group/javino2arduino
 https://github.com/7semi-solutions/7Semi_AD849x
 https://github.com/7semi-solutions/7Semi-LIS3DH-3-axis-acceleromet-Arduino-Library
+https://github.com/7semi-solutions/7Semi-OPT4048-Color-Sensor-Arduino-Library


### PR DESCRIPTION
This PR adds the 7Semi OPT4048 Arduino Library to the Arduino Library Manager index.

Repository URL:
https://github.com/7semi-solutions/7Semi-OPT4048-Color-Sensor-Arduino-Library

The library provides APIs for reading RGB and ambient light data from the OPT4048 digital color sensor over I2C, with configurable gain and integration time. Example sketches are included for quick integration.