### PR TITLE
Add Adafruit MAX44009 ambient light sensor library

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -964,6 +964,7 @@ https://github.com/adafruit/Adafruit_LvGL_Glue
 https://github.com/adafruit/Adafruit_MAX1704X
 https://github.com/adafruit/Adafruit_MAX31856
 https://github.com/adafruit/Adafruit_MAX31865
+https://github.com/adafruit/Adafruit_MAX44009
 https://github.com/adafruit/Adafruit_MCP2515
 https://github.com/adafruit/Adafruit_MCP3008
 https://github.com/adafruit/Adafruit_MCP3421


### PR DESCRIPTION
Add Adafruit_MAX44009 Arduino library for the MAX44009 ultra-low-power ambient light sensor.

- I2C interface, 0.045 to 188,000 lux range
- BusIO-based, auto-ranging with continuous mode
- Repo: https://github.com/adafruit/Adafruit_MAX44009