### PR TITLE
Remove "SparkFun Apple Accessory Arduino Library"

### DIFF
--- a/registry.txt
+++ b/registry.txt
@@ -8215,7 +8215,6 @@ https://github.com/wisec/tinysleeper.git|Contributed|TinySleeper
 https://github.com/piruetasxyz/FrecuenciasMIDI.git|Contributed|FrecuenciasMIDI
 https://github.com/sparkfun/SparkFun_Authentication_Coprocessor_Arduino_Library.git|Contributed|SparkFun Authentication Coprocessor Arduino Library
 https://github.com/TheProgrammerFundation/EasyArduino.git|Contributed|EasyArduino
-https://github.com/sparkfun/SparkFun_Apple_Accessory_Arduino_Library.git|Contributed|SparkFun Apple Accessory Arduino Library
 https://github.com/RobTillaart/I2C_CAT24M01.git|Contributed|I2C_CAT24M01
 https://github.com/Nezaemmy/Neza74HC595.git|Contributed|Neza74HC595
 https://github.com/gavinlyonsrepo/BMP280_LTSM.git|Contributed|BMP280_LTSM


### PR DESCRIPTION
Companion to https://github.com/arduino/library-registry/pull/7838