### PR TITLE
Remove "SparkFun Authentication Coprocessor Arduino Library"

### DIFF
--- a/registry.txt
+++ b/registry.txt
@@ -8213,7 +8213,6 @@ https://github.com/sstaub/ST7565DOG.git|Contributed|ST7565DOG
 https://github.com/Nezaemmy/NezaButton.git|Contributed|NezaButton
 https://github.com/wisec/tinysleeper.git|Contributed|TinySleeper
 https://github.com/piruetasxyz/FrecuenciasMIDI.git|Contributed|FrecuenciasMIDI
-https://github.com/sparkfun/SparkFun_Authentication_Coprocessor_Arduino_Library.git|Contributed|SparkFun Authentication Coprocessor Arduino Library
 https://github.com/TheProgrammerFundation/EasyArduino.git|Contributed|EasyArduino
 https://github.com/sparkfun/SparkFun_Apple_Accessory_Arduino_Library.git|Contributed|SparkFun Apple Accessory Arduino Library
 https://github.com/RobTillaart/I2C_CAT24M01.git|Contributed|I2C_CAT24M01


### PR DESCRIPTION
Companion to https://github.com/arduino/library-registry/pull/7838