### PR TITLE
Update URL of "TumbleFeeder"

### DIFF
--- a/registry.txt
+++ b/registry.txt
@@ -8941,7 +8941,7 @@ https://github.com/RobTillaart/TGS2620.git|Contributed|TGS2620
 https://github.com/tanakamasayuki/variants_collector.git|Contributed|variants_collector
 https://github.com/Shourov-Paul/TFT_RoboEyes.git|Contributed|TFT_RoboEyes
 https://github.com/Aryan-git-byte/Devatext.git|Contributed|Devatext
-https://github.com/MasBarr/TumbleFeeder.git|Contributed|TumbleFeeder
+https://github.com/KravitzLabDevices/TumbleFeeder.git|Contributed|TumbleFeeder
 https://github.com/Xorlent/ESP32IMDB.git|Contributed|ESP32IMDB
 https://github.com/Ada-Rhodes/MoIRA.git|Contributed|MoIRA
 https://github.com/Ryzobee/Ryzobee_arduino_esp32.git|Contributed|Ryzobee


### PR DESCRIPTION
Companion to https://github.com/arduino/library-registry/pull/7840