### PR TITLE
Add Adafruit VCNL4030 library

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -1070,6 +1070,7 @@ https://github.com/adafruit/Adafruit_TSL2591_Library
 https://github.com/adafruit/Adafruit_UNTZtrument
 https://github.com/adafruit/Adafruit_VCNL4010
 https://github.com/adafruit/Adafruit_VCNL4020
+https://github.com/adafruit/Adafruit_VCNL4030
 https://github.com/adafruit/Adafruit_VCNL4040
 https://github.com/adafruit/Adafruit_VCNL4200
 https://github.com/adafruit/Adafruit_VEML6046


### PR DESCRIPTION
Add the Adafruit VCNL4030X01 proximity and ambient light sensor library.

- Release: https://github.com/adafruit/Adafruit_VCNL4030/releases/tag/1.0.0
- Proximity + ALS + white channel with I2C (BusIO)
- MIT license