### PR TITLE
Add YuaMQTT library

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -9043,3 +9043,4 @@ https://github.com/pisco-de-luz/Pisco-Code-Arduino.git
 https://github.com/snowfoxlab/SyncItIOT
 https://github.com/cubicleguy/xv7021_arduino_spi
 https://github.com/Kiwistron/KiwisIoT
+https://github.com/EdwinKestler/SIM800_MQTT.git


### PR DESCRIPTION
Add [YuaMQTT](https://github.com/EdwinKestler/SIM800_MQTT) to the Arduino Library Registry.

**YuaMQTT** is a lightweight MQTT 5.0 library for Arduino, designed for constrained devices (Arduino Uno, 2KB RAM) communicating via SIM800/SIM900 GPRS modules.

- MQTT V5.0 spec-compliant (Variable Byte Integer encoding, type-aware properties)
- Transport-agnostic core + optional SIM800/SIM900 AT command helpers
- 6 examples, 115 unit tests, GitHub Actions CI
- Tagged release: v1.1.0
- License: MIT