### PR TITLE
Add Adafruit TMAG5273 library

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -1064,6 +1064,7 @@ https://github.com/adafruit/Adafruit_TLV320_I2S
 https://github.com/adafruit/Adafruit_TMP006
 https://github.com/adafruit/Adafruit_TMP007_Library
 https://github.com/adafruit/Adafruit_TMP117
+https://github.com/adafruit/Adafruit_TMAG5273
 https://github.com/adafruit/Adafruit_TouchScreen
 https://github.com/adafruit/Adafruit_Trellis_Library
 https://github.com/adafruit/Adafruit_TSC2007


### PR DESCRIPTION
Add Adafruit TMAG5273 3-axis Hall-effect sensor library.

- Repository: https://github.com/adafruit/Adafruit_TMAG5273
- Release: https://github.com/adafruit/Adafruit_TMAG5273/releases/tag/1.0.0
- TI TMAG5273 low-power linear 3D Hall-effect sensor with I2C
- Adafruit_Sensor + BusIO based