### PR TITLE
Add Forgetfulino library

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -9048,3 +9048,4 @@ https://github.com/snowfoxlab/SyncItIOT
 https://github.com/cubicleguy/xv7021_arduino_spi
 https://github.com/Kiwistron/KiwisIoT
 https://github.com/EdwinKestler/SIM800_MQTT.git
+https://github.com/IamTheVector/Forgetfulino 


### PR DESCRIPTION
This PR adds the Forgetfulino library by IamTheVector to the Arduino Library Manager registry.