### PR TITLE
Add StreamCipher repository link

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -730,6 +730,7 @@ https://github.com/tdk-invn-oss/pressure.arduino.ICP201XX
 https://github.com/DigitalCodesign/MentorBit-Library
 https://github.com/tabahi/StatefulGSMLib/
 https://github.com/tabahi/ESP-Wifi-Config
+https://github.com/tabahi/StreamCipher
 https://github.com/karolis1115/FTPduino
 https://github.com/RajasundaramM/ReadFilter
 https://github.com/SylvainMontagny/LoRaE5


### PR DESCRIPTION
StreamCipher is a lightweight encryption library intended for low-RAM-budget TCP connections