### PR TITLE
Add Adafruit WF100DPZ pressure sensor library

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -1086,6 +1086,7 @@ https://github.com/adafruit/Adafruit_VL53L1X
 https://github.com/adafruit/Adafruit_VL6180X
 https://github.com/adafruit/Adafruit_VS1053_Library
 https://github.com/adafruit/Adafruit_WavePlayer
+https://github.com/adafruit/Adafruit_WF100DPZ
 https://github.com/adafruit/Adafruit_Wippersnapper_Arduino
 https://github.com/adafruit/Adafruit_xCA9554
 https://github.com/adafruit/Adafruit_ZeroDMA


### PR DESCRIPTION
Adding the Adafruit WF100DPZ MEMS gauge pressure sensor library.

- **Repository:** https://github.com/adafruit/Adafruit_WF100DPZ
- **Release:** https://github.com/adafruit/Adafruit_WF100DPZ/releases/tag/1.0.0
- **Version:** 1.0.0
- **License:** MIT

I2C driver for the WF100DPZ low-cost MEMS gauge pressure sensor with temperature output.