### PR TITLE
Add SimpleRGBLed repository link

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -9063,3 +9063,4 @@ https://github.com/Gypsy-Server/Gypsyv1
 https://github.com/ltavasilva/WiFiController.git
 https://github.com/HijelHub/HijelHID_BLEKeyboard
 https://github.com/franzisco29/RaceDisplay
+https://github.com/AchirawareElectronics/SimpleRGBLed


### PR DESCRIPTION
Add SimpleRGBLed library - a standalone RGB LED driver for ESP32 using the RMT peripheral.
Supports WS2812-compatible LEDs with named colors, brightness control, blinking, and FreeRTOS thread safety.

Repository: https://github.com/AchirawareElectronics/SimpleRGBLed