### PR TITLE
Add new repository link for boost-embedded-190

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -9066,3 +9066,4 @@ https://github.com/HijelHub/HijelHID_BLEKeyboard
 https://github.com/franzisco29/RaceDisplay
 https://github.com/AchirawareElectronics/SimpleRGBLed
 https://github.com/andremmfaria/ESP32Wiimote
+https://github.com/sat-mtl/boost-embedded-190


### PR DESCRIPTION
This allows to use a recent version of boost ; many libraries work fine for instance on ESP32, Teensy, etc. as most things are header-only