### PR TITLE
Add EasyLED library

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -9067,3 +9067,4 @@ https://github.com/franzisco29/RaceDisplay
 https://github.com/AchirawareElectronics/SimpleRGBLed
 https://github.com/andremmfaria/ESP32Wiimote
 https://github.com/sat-mtl/boost-embedded-190
+https://github.com/Santi123-debug/EasyLED


### PR DESCRIPTION
I am adding the EasyLED library to the official registry.
- Repository: [https://github.com/Santi123-debug/EasyLED.git](https://github.com/Santi123-debug/EasyLED.git)
- Version: v1.0.0
- Valid library.properties included.
- No blocking delays (millis based).
