### PR TITLE
Add 7Semi NAU7802 Arduino Library

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -9076,3 +9076,4 @@ https://github.com/ASNProject/Panzer_Robotics_Library
 https://github.com/roboticist-blip/LoRa32T
 https://github.com/dhruvkotian/em2m-esp32-modbus
 https://github.com/stm32duino/LSM6DSO32
+https://github.com/7semi-solutions/7Semi-NAU7802-24bit-ADC-for-Weight-Scale


### PR DESCRIPTION
This PR adds the 7Semi NAU7802 Arduino Library to the Arduino Library Manager index.

Repository URL:
https://github.com/7semi-solutions/7Semi-NAU7802-24bit-ADC-for-Weight-Scale

The library provides APIs to read weight data from the NAU7802 24-bit ADC load cell amplifier using I2C, including calibration and example sketches.