### PR TITLE
Add 7Semi OPT3004 Arduino Library

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -9077,3 +9077,4 @@ https://github.com/roboticist-blip/LoRa32T
 https://github.com/dhruvkotian/em2m-esp32-modbus
 https://github.com/stm32duino/LSM6DSO32
 https://github.com/7semi-solutions/7Semi-NAU7802-24bit-ADC-for-Weight-Scale
+https://github.com/7semi-solutions/7Semi-OPT3004-Digital-Ambient-Light-Sensor-Arduino-Library


### PR DESCRIPTION
This PR adds the 7Semi OPT3004 Arduino Library to the Arduino Library Manager index.

Repository URL:
https://github.com/7semi-solutions/7Semi-OPT3004-Digital-Ambient-Light-Sensor-Arduino-Library

The library provides APIs to read ambient light intensity in lux from the OPT3004 digital ambient light sensor using I2C, including example sketches for easy integration with Arduino, ESP32, and STM32 boards.