### PR TITLE
Remove shrike_flash library

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -8792,7 +8792,6 @@ https://github.com/PaulNTU/MoonMin-Scanner-Arduino-Library
 https://gitlab.com/Vishal1695/mvswifi_esp32
 https://gitlab.com/Vishal1695/mvswifi_esp8266
 https://github.com/jaikulk14/Advanced-Oximeter
-https://github.com/vicharak-in/shrike_flash
 https://github.com/microbotsio/ProtoBot
 https://github.com/4project-co-il/PlugAndPlay
 https://github.com/geekfactory/GFLED


### PR DESCRIPTION
This library is requested to be removed as the same feature are now merged with the [Shrike](https://github.com/vicharak-in/shrike_arduino) Library. 

Thus this is obsolete and redundant. 
Thank You 
Dpk