### PR TITLE
Add ArduinoPTPIP

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -9095,3 +9095,4 @@ https://github.com/codewitch-honey-crisis/htcw_frame
 https://github.com/ManishKDtm/PHMonitor
 https://github.com/OneDevelopmentPL/UltraSense
 https://github.com/gb88/BLEOTA/
+https://github.com/seemantadutta/ArduinoPTPIP.git


### PR DESCRIPTION
Add ArduinoPTPIP which is a library for WiFi-based remote control of Canon EOS cameras via the PTP/IP protocol. 

This helps set aperture, shutter speed, and ISO; trigger single captures or bracketed exposure sequences; and keep your application in sync with physical dial changes via automatic background polling.

Link to repo: https://github.com/seemantadutta/ArduinoPTPIP