### PR TITLE
Add Forgetfulino subdirectory URL

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -9049,3 +9049,4 @@ https://github.com/cubicleguy/xv7021_arduino_spi
 https://github.com/Kiwistron/KiwisIoT
 https://github.com/EdwinKestler/SIM800_MQTT.git
 https://github.com/IamTheVector/Forgetfulino
+https://github.com/IamTheVector/Forgetfulino/tree/main/Forgetfulino-main


### PR DESCRIPTION
This PR adds the URL below to repositories.txt as requested:

- https://github.com/IamTheVector/Forgetfulino/tree/main/Forgetfulino-main

Note: This is a repository subdirectory URL (tree).

Made with [Cursor](https://cursor.com)