### PR TITLE
Add PtpIpCamera

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -9106,3 +9106,4 @@ https://github.com/allwhc/mvsconnect.git
 https://github.com/HavishVivek/ESP32MacroPad
 https://github.com/angeloINTJ/OneWirePIO_RP2040.git
 https://github.com/angeloINTJ/DHT22PIO_RP2040.git
+https://github.com/seemantadutta/PtpIpCamera.git


### PR DESCRIPTION
Add PtpIpCamera which is a library for WiFi-based remote control of Canon EOS cameras via the PTP/IP protocol.

This helps set aperture, shutter speed, and ISO; trigger single captures or bracketed exposure sequences; and keep your application in sync with physical dial changes via automatic background polling.

Link to repo: https://github.com/seemantadutta/PtpIpCamera