### PR TITLE
Remove duplicate registry entry for "ESP32MultiWiFiProvision"

### DIFF
--- a/registry.txt
+++ b/registry.txt
@@ -9040,7 +9040,6 @@ https://github.com/EdwinKestler/SIM800_MQTT.git|Contributed|YuaMQTT
 https://github.com/accabog/MedianFilter.git|Contributed|MedianFilter
 https://github.com/sstaub/NextionX3.git|Contributed|NextionX3
 https://github.com/nainaiurk/ESP32MultiWiFiProvision.git|Contributed|ESP32MultiWiFiProvision
-https://github.com/nainaiurk/ESP32MultiWiFiProvision.git|Contributed|ESP32MultiWiFiProvision
 https://github.com/adafruit/Adafruit_TMAG5273.git|Recommended|Adafruit TMAG5273
 https://github.com/IamTheVector/Forgetfulino.git|Contributed|Forgetfulino
 https://github.com/tabahi/StreamCipher.git|Contributed|StreamCipher


### PR DESCRIPTION
Previously, there were two registry entries for this library. The completely redundant second entry is hereby removed.