### PR TITLE
Update URL for Blynk libraries

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -1934,8 +1934,8 @@ https://github.com/blues/note-arduino
 https://github.com/blues/notecard-aux-wifi
 https://github.com/blues/notecard-env-var-manager
 https://github.com/blues/notecard-pseudo-sensor
-https://github.com/blynkkk/blynk-library
-https://github.com/blynkkk/BlynkNcpDriver
+https://github.com/Blynk-Technologies/blynk-library
+https://github.com/Blynk-Technologies/Blynk-NCP-Driver
 https://github.com/bmellink/IBusBM
 https://github.com/bmellink/VNH3SP30
 https://github.com/bmts/FMDataClient


### PR DESCRIPTION
Changing Blynk libraries since the company officially moved from `https://github.com/blynkkk` to `https://github.com/Blynk-Technologies`.