### PR TITLE
Add DiscretePID library

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -9105,3 +9105,4 @@ https://github.com/HavishVivek/ESP32MacroPad
 https://github.com/angeloINTJ/OneWirePIO_RP2040.git
 https://github.com/angeloINTJ/DHT22PIO_RP2040.git
 https://github.com/seemantadutta/PtpIpCamera.git
+https://github.com/Hastu004/DiscretePID.git


### PR DESCRIPTION
Library name: DiscretePID
Repository: https://github.com/Hastu004/DiscretePID.git
Release tag: 1.0.1