### PR TITLE
Update URL of "BlynkNcpDriver"

### DIFF
--- a/registry.txt
+++ b/registry.txt
@@ -5894,7 +5894,7 @@ https://github.com/hexaedron/PostNeoSWSerial.git|Contributed|PostNeoSWSerial
 https://github.com/epsilonrt/modbus-radio.git|Contributed|Modbus-Radio
 https://github.com/alexitoo00/NewEncoder.git|Contributed|NewEncoder
 https://github.com/stm32duino/VL53L8CX.git|Contributed|STM32duino VL53L8CX
-https://github.com/blynkkk/BlynkNcpDriver.git|Contributed|BlynkNcpDriver
+https://github.com/Blynk-Technologies/Blynk-NCP-Driver.git|Contributed|BlynkNcpDriver
 https://github.com/AsproCompany/GeneralShield.git|Contributed|GeneralShield
 https://github.com/sunfounder/SunFounder_Ai_Camera.git|Contributed|SunFounder AI Camera
 https://github.com/DFRobot/DFRobot_GP8XXX.git|Contributed|DFRobot_GP8XXX


### PR DESCRIPTION
Companion to https://github.com/arduino/library-registry/pull/7944