### PR TITLE
Retire ESP32 composite video out by roger-random

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -6300,7 +6300,6 @@ https://github.com/RodolfoPrieto/MCP3208
 https://github.com/rodrigodornelles/3bc-lang
 https://github.com/rodrigodornelles/arduino-tone-pitch
 https://github.com/roelandkluit/Free-ESPatHome
-https://github.com/Roger-random/ESP_8_BIT_composite
 https://github.com/rogerjames99/json2asw-arduino
 https://github.com/RogueRobotics/RogueMP3
 https://github.com/RogueRobotics/RogueSD


### PR DESCRIPTION
ESP32 Arduino Core v3 removed functionality critical to this library. There is no direct migration path from the lost v2 API to any v3 counterparts and after two years I have to concede I'll never find the time to perform the major rewrite required for the migration. I have decided to retire it, so to stop disappointing people who install a library that is stuck in the past.

Retiring my repository should also free up the library name in Arduino Library Manager. My repository remains MIT licensed and open to someone else picking up the challenge. If so, perhaps they will resubmit to Arduino Library Manager.