### PR TITLE
Remove "ESP_8_BIT Color Composite Video Library"

### DIFF
--- a/registry.txt
+++ b/registry.txt
@@ -3765,7 +3765,6 @@ https://github.com/lionrocker/better-joystick.git|Contributed|Better Joystick
 https://github.com/kmpelectronics/KMP_MCP23S08.git|Contributed|KMP_MCP23S08
 https://github.com/coderfls/Arduino_MultiFunctionShield.git|Contributed|MultiFunctionShield
 https://github.com/khoih-prog/megaAVR_TimerInterrupt.git|Contributed|megaAVR_TimerInterrupt
-https://github.com/Roger-random/ESP_8_BIT_composite.git|Contributed|ESP_8_BIT Color Composite Video Library
 https://github.com/ponoor/Ponoor_L6470_Library.git|Contributed|Ponoor L6470 Library
 https://github.com/sparkfun/SparkFun_SPI_SerialFlash_Arduino_Library.git|Contributed|SparkFun SPI SerialFlash Arduino Library
 https://github.com/mbratch/TaskJockey.git|Contributed|TaskJockey


### PR DESCRIPTION
Companion to https://github.com/arduino/library-registry/pull/7957