### PR TITLE
Add PersistentLog library

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -9116,3 +9116,4 @@ http://github.com/Axxel-otl/Sonic
 https://github.com/ThanabordeeN/MCP-U_Arduino
 https://github.com/matthias-bs/SX1276_Radio_Lite
 https://github.com/agusevtec/eva-core-sk
+https://github.com/derekbreden/PersistentLog.git


### PR DESCRIPTION
Ring buffer logger for Arduino that persists to LittleFS/SPIFFS. Fixed storage budget with automatic rotation. Printf-style API. Survives power cycles.

Repository: https://github.com/derekbreden/PersistentLog

Tested on ESP32 and ESP32-S3 hardware.