### PR TITLE
Add new repository link for ESP32_AWS_MQTT_Manager

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -9118,3 +9118,4 @@ https://github.com/ThanabordeeN/MCP-U_Arduino
 https://github.com/matthias-bs/SX1276_Radio_Lite
 https://github.com/agusevtec/eva-core-sk
 https://github.com/derekbreden/PersistentLog.git
+https://github.com/shawrhit/ESP32_AWS_MQTT_Manager


### PR DESCRIPTION
This pull request adds the **ESP32 AWS MQTT Manager** library to the Arduino Library Manager registry.

**Repository:** https://github.com/shawrhit/ESP32_AWS_MQTT_Manager

**Description:** A minimal, asynchronous wrapper around the native ESP-IDF `esp-mqtt` component. It allows ESP32 microcontrollers to connect to AWS IoT Core using mutual TLS (mTLS) without blocking the main Arduino loop. It abstracts the complex event loops and TLS handshakes, exposing a simple API for initialization, subscribing, and publishing.

**Pre-Submission Checklist:**
- [x] The repository contains a valid `library.properties` file in the root directory.
- [x] The `library.properties` file strictly defines `architectures=esp32`.
- [x] The source code is correctly structured within the `src` and `examples` folders.
- [x] A valid version tag (`1.0.0`) matching the properties file has been created and published as a GitHub Release.
- [x] The library has been tested and compiles successfully on ESP32 hardware (Xtensa and RISC-V).

Please let me know if any further changes are required to the repository structure. Thank you!