### PR TITLE
Add kode_bsp_function_ev_board library

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -9122,3 +9122,4 @@ https://github.com/derekbreden/PersistentLog.git
 https://github.com/shawrhit/ESP32_AWS_MQTT_Manager
 https://github.com/glebshow23-crypto/SharpSensor
 
+https://github.com/pcabello-kode/kode_bsp_function_ev_board.git


### PR DESCRIPTION
Add Kode OS BSP wrapper for ESP32-P4 Function EV Board.

Provides `kode_*` API functions that wrap the Espressif BSP for unified Kode OS development.

Repository: https://github.com/pcabello-kode/kode_bsp_function_ev_board