### PR TITLE
Added SegLCDLib for segment LCD displays

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -9121,6 +9121,6 @@ https://github.com/agusevtec/eva-core-sk
 https://github.com/derekbreden/PersistentLog.git
 https://github.com/shawrhit/ESP32_AWS_MQTT_Manager
 https://github.com/glebshow23-crypto/SharpSensor
-
 https://github.com/pcabello-kode/kode_bsp_function_ev_board.git
 https://github.com/UDFSmart/UCommandExecutor
+https://github.com/petrkr/SegLCDLib


### PR DESCRIPTION
Library for most known LCD displays which I found on market.
List of supported LCD screens is in documentation (
https://petrkr.github.io/SegLCDLib/)

It follows LCD API 1.0 specification where it was possible as this specification is for dot-matrix alphanumeric LCD screens and not for segments, where lot of things simply does not exists on hardware level ( so for example you can not implement blink cursor on/off as there is no cursor at all)

But I implemented row/col, setPosition, home, clear.. Most of LCD has only 1 row, but there are also some which have 2 or 3 rows, so it follows this setPosition.

Also it uses Print.h, so users can use simple lcd.print() which will automatically increment col and row. 

As Print.h it out of box supports data types like string, integer, float).

Some LCD have colon between digits, so if there is cursor it will light up this colon instead fake it from charset table, that makes time easy like 

```
lcd.print("14:24");
lcd.home();
lcd.print("14:25");
```
