### PR TITLE
Add SuperOTA library

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -9125,3 +9125,4 @@ https://github.com/pcabello-kode/kode_bsp_function_ev_board.git
 https://github.com/UDFSmart/UCommandExecutor
 https://github.com/petrkr/SegLCDLib
 https://github.com/AchirawareElectronics/AchiraWareMotor_DRV8830
+https://github.com/joaoaugustocz/SuperOTA


### PR DESCRIPTION
Please add SuperOTA to the Arduino Library Manager index.

Repository: https://github.com/joaoaugustocz/SuperOTA
Latest release/tag: v1.2.1