### PR TITLE
Remove "TAD2144"

### DIFF
--- a/registry.txt
+++ b/registry.txt
@@ -8646,7 +8646,6 @@ https://github.com/askinkeles/DWIN_UNI_HMI.git|Contributed|DWIN_UNI_HMI
 https://github.com/Herobrine-pixel/GestureAirDrawPro.git|Contributed|GestureAirDrawPro
 https://github.com/JorgeGBeltre/MQTTOTA.git|Contributed|MQTTOTA
 https://github.com/bhadreshmewada/UniversalDebugLib.git|Contributed|Universal Debug Library
-https://github.com/tdk-invn-oss/motion.arduino.TAD2144.git|Contributed|TAD2144
 https://github.com/sparkfun/SparkFun_FPC2534_Arduino_Library.git|Contributed|SparkFun FPC2534 Arduino Library
 https://github.com/elevoi/ESteme.git|Contributed|ESteme
 https://github.com/ErlingSigurdson/Drv7Seg2x595.git|Contributed|Drv7Seg2x595


### PR DESCRIPTION
Companion to https://github.com/arduino/library-registry/pull/7981