### PR TITLE
Add PicoSound library

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -9132,3 +9132,4 @@ https://github.com/UDFSmart/Relay-Controller
 https://github.com/angeloINTJ/BuzzerPIO_RP2040.git
 https://github.com/shawrhit/ESP32_Azure_MQTT_Manager
 https://github.com/vwireiot/vwire-arduino.git
+https://github.com/IWILZ/PicoSound


### PR DESCRIPTION
PicoSound - Dual-core audio library for Raspberry Pi Pico (RP2040)
   
   Repository: https://github.com/IWILZ/PicoSound