### PR TITLE
Add Politician WiFi auditing library

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -9147,3 +9147,4 @@ https://github.com/nikki-build/nikki.unoR4
 https://github.com/nikki-build/nikki.esp8266
 https://github.com/shrawankhambekar/ESP32_CPWIFI
 https://github.com/piglet0/haier2supla
+https://github.com/0ldev/Politician


### PR DESCRIPTION
Adding Politician - Modern WiFi auditing library for ESP32
 
 - Repository: https://github.com/0ldev/Politician
 - Author: 0ldev
 - Category: Communication
 - Architectures: ESP32, ESP32-S2, ESP32-S3, ESP32-C3, ESP32-C6
 
 Library captures WPA/WPA2/WPA3 handshakes using PMKID extraction and CSA injection. Supports dual-band ESP32-C6 
(2.4GHz + 5GHz). Includes 9 examples and full documentation.