### PR TITLE
Add LTC2944_BMS library

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -9151,3 +9151,4 @@ https://github.com/piglet0/haier2supla
 https://github.com/0ldev/Politician
 https://github.com/electronicstree/blendixserial-arduino
 https://github.com/HijelHub/HijelHID_BLEMouse
+https://github.com/rleusden/LTC2944_BMS


### PR DESCRIPTION
# LTC2944_BMS

An Arduino library for the **LTC2944 battery gas gauge IC**, supporting Li-ion,
LiFePO4, AGM, and GEL battery packs across a wide range of series-cell configurations.

Designed for **ATmega328P** boards (Arduino Pro Mini, Nano, Uno).

---

## Features

- State-of-charge (SOC) estimation using a piecewise voltage curve
- IR (internal-resistance) compensation so SOC is accurate under load
- Adaptive coulomb counting once the battery has been calibrated
- Automatic internal-resistance learning — improves accuracy over time without user intervention
- EEPROM persistence for calibration data and the learned resistance model (wear-levelled, CRC-verified)
- Battery-disconnect detection with EEPROM flag (survives power loss)
- Calibration state machine: zero offset → discharge to empty → charge to full
- Alarm bitfield for over/under voltage, temperature, over-current, and profile mismatch
- All battery profiles stored in flash (PROGMEM) to conserve RAM

---
