### PR TITLE
Add WILLOW library

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -1,3 +1,4 @@
+https://github.com/nruimveld7/WILLOW
 https://github.com/DIYables/DIYables_TFT_Shield_Mega
 https://github.com/rohitmaji004/RohitCore-Timer
 https://github.com/rohitmaji004/RohitCore-Base


### PR DESCRIPTION
Adds WILLOW to the Arduino Library Manager index.

Repository:
https://github.com/nruimveld7/WILLOW

Latest release:
v1.0.0