### PR TITLE
MiCS6814-I2C: Migrate repo URL from Github to Codeberg

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -2843,7 +2843,7 @@ https://github.com/EmotiBit/EmotiBit_MAX30101
 https://github.com/EmotiBit/EmotiBit_MLX90632
 https://github.com/EmotiBit/EmotiBit_NCP5623
 https://github.com/EmotiBit/EmotiBit_XPlat_Utils
-https://github.com/eNBeWe/MiCS6814-I2C-Library
+https://codeberg.org/eNBeWe/MiCS6814-I2C-Library
 https://github.com/end2endzone/AnyRtttl
 https://github.com/end2endzone/BitReader
 https://github.com/end2endzone/NonBlockingRTTTL


### PR DESCRIPTION
In light of the recent changes to GitHub I am migrating all my repositories away.
The Arduino Library is being migrated to Codeberg.org.