### PR TITLE
Add I2C_HC4067 repository link

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -6112,6 +6112,7 @@ https://github.com/RobTillaart/I2C_24LC1025
 https://github.com/RobTillaart/I2C_ASDX
 https://github.com/RobTillaart/I2C_CAT24M01
 https://github.com/RobTillaart/I2C_EEPROM
+https://github.com/RobTillaart/I2C_HC4067
 https://github.com/RobTillaart/I2C_LCD
 https://github.com/RobTillaart/I2C_SCANNER
 https://github.com/RobTillaart/I2C_SOFTRESET


### PR DESCRIPTION
Arduino library for HC4067 over I2C with a PCF8574.