### PR TITLE
Add Sensirion SEN62 Driver Library

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -6545,6 +6545,7 @@ https://github.com/Sensirion/arduino-i2c-sen66
 https://github.com/Sensirion/arduino-i2c-sen63c
 https://github.com/Sensirion/arduino-i2c-sen65
 https://github.com/Sensirion/arduino-i2c-sen68
+https://github.com/Sensirion/arduino-i2c-sen62
 https://github.com/Sensirion/arduino-i2c-sf06-lf
 https://github.com/Sensirion/arduino-i2c-sfa3x
 https://github.com/Sensirion/arduino-i2c-sfm3000


### PR DESCRIPTION
Add Sensirion's official SEN62 driver library to Arduinos library manager.