### PR TITLE
Add ozobot circuit kit HAL library.

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -9163,3 +9163,4 @@ https://github.com/angeloINTJ/USBSnifferPIO_RP2040.git
 https://github.com/hfdalkarim/Hafid
 https://github.com/IowaScaledEngineering/mss-xcade-lib
 https://github.com/mitutake0422/TeensyXENO
+https://github.com/ozobot/circuit_kit_library


### PR DESCRIPTION
Add Ozobot official circuit kit library to Arduinos library manager.