### PR TITLE
fixed url of neopixel commander library

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -8260,7 +8260,7 @@ https://github.com/arastaskiran/RustyKeypad
 https://github.com/Freenove/Freenove_RFID_Lib_for_Pico
 https://github.com/thomasgeissl/Parameter
 https://github.com/grantler-instruments/ESP-NOW-MIDI
-https://github.com/thomasgeissl/NeopixelCommander
+https://github.com/threeeeight/NeopixelCommander
 https://github.com/adbancroft/avr-fast-map
 https://github.com/soynaldo/Labvee
 https://github.com/JensDMadsen/Multitasker


### PR DESCRIPTION
Hey, 
i have changed ownership for my neopixel commander library.
updated the url.

https://github.com/thomasgeissl/NeopixelCommander
now available here: https://github.com/threeeeight/NeopixelCommander

best thomas