### PR TITLE
Add VEGA_RV3028 library

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -9168,3 +9168,4 @@ https://github.com/IowaScaledEngineering/mss-xcade-lib
 https://github.com/mitutake0422/TeensyXENO
 https://github.com/ozobot/circuit_kit_library
 https://github.com/m5stack/M5Unit-KEYBOARD
+https://github.com/kaustavsaloi/VEGA_RV3028


### PR DESCRIPTION
Adding VEGA_RV3028 RTC library for VEGA Thejas32 platform.