### PR TITLE
Update name and URL of "esp32-tunnel"

### DIFF
--- a/registry.txt
+++ b/registry.txt
@@ -9164,6 +9164,6 @@ https://github.com/m5stack/M5Unit-KEYBOARD.git|Contributed|M5Unit-KEYBOARD
 https://github.com/kaustavsaloi/VEGA_RV3028.git|Contributed|VEGA_RV3028
 https://github.com/SaleemAkhter/synolinks-arduino.git|Contributed|SynoLinks
 https://github.com/Zo-dri/CharlieDisplay.git|Contributed|CharlieDisplay
-https://github.com/HamzaYslmn/esp32-localtunnel.git|Contributed|esp32-tunnel
+https://github.com/HamzaYslmn/esp32-tunnel.git|Contributed|esp32-tunnel
 https://github.com/HamzaYslmn/espfetch.git|Contributed|espfetch
 https://github.com/simplefoc/SimpleCANio.git|Contributed|SimpleCANio


### PR DESCRIPTION
This PR consists of two changes:

- Change URL from `https://github.com/HamzaYslmn/esp32-localtunnel.git` to `https://github.com/HamzaYslmn/esp32-tunnel.git` (companion to https://github.com/arduino/library-registry/pull/8031)
- Change name from `esp32-localtunnel` to `esp32-tunnel`.

Since the name change operation on the database is actually a removal followed by automated re-indexing on the next job run, the URL update will occur as a matter of course. For this reason, the only operation required from the backend maintainer is a standard name change procedure.