### PR TITLE
Added Libraries for: PCA9848 and generic EEPROMs 24xx025

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -9174,3 +9174,5 @@ https://github.com/m5stack/M5Unit-KEYBOARD
 https://github.com/SaleemAkhter/synolinks-arduino.git
 https://github.com/kaustavsaloi/VEGA_RV3028
 https://github.com/Zo-dri/CharlieDisplay
+https://github.com/RBEGamer/Arduino-PCA9848
+https://github.com/RBEGamer/EEPROM_24xx025


### PR DESCRIPTION
Added two libraries for the PCA9848 fast mode + capable i2c port expander and generic 24xx025 eeproms with unique id build in


https://github.com/RBEGamer/Arduino-PCA9848
https://github.com/RBEGamer/EEPROM_24xx025