### PR TITLE
Add ATGenXIOT library to Arduino Library Manager

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -1,3 +1,4 @@
+https://github.com/ARDUTECH0/ATGenXIOT
 https://github.com/veersingh671/LuminOx
 https://github.com/lska-dev/microLCD.git
 https://github.com/ARDUTECH0/ATGENXlib-0.0.1


### PR DESCRIPTION
Submitting ATGenXIOT Arduino library (v1.0.0) for inclusion in the Arduino Library Manager.
- MIT License
- Includes example sketch
- Ready for Library Manager