### PR TITLE
rename: Esp32-RTOS-Serial  to  esp-rtosSerial

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -3412,7 +3412,7 @@ https://github.com/HakkanR/DMD2TUR
 https://github.com/HakkanR/slowAES
 https://github.com/HakkanR/SSD1306TUR
 https://github.com/HamzaYslmn/detaBaseESP8266
-https://github.com/HamzaYslmn/Esp32-RTOS-Serial
+https://github.com/HamzaYslmn/esp-rtosSerial
 https://github.com/HamzaYslmn/esp32-tunnel
 https://github.com/HamzaYslmn/espfetch
 https://github.com/handmade0octopus/CursedDoubleLinkedListInterface-library


### PR DESCRIPTION
rename: Esp32-RTOS-Serial  to  esp-rtosSerial

because esp8266 supported now