### PR TITLE
Update name and URL of "esp-rtosSerial"

### DIFF
--- a/registry.txt
+++ b/registry.txt
@@ -8151,7 +8151,7 @@ https://github.com/BestModules-Libraries/BMH12M205.git|Contributed|BMH12M205
 https://github.com/BestModules-Libraries/BMS56M206A.git|Contributed|BMS56M206A
 https://github.com/BestModules-Libraries/BMH08101.git|Contributed|BMH08101
 https://github.com/BestModules-Libraries/BMV31M304A.git|Contributed|BMV31M304A
-https://github.com/HamzaYslmn/Esp32-RTOS-Serial.git|Contributed|Esp32-RTOS-Serial
+https://github.com/HamzaYslmn/Esp32-RTOS-Serial.git|Contributed|esp-rtosSerial
 https://github.com/Zakrzewiaczek/pantryclient-esp.git|Contributed|PantryClient
 https://github.com/John-Karatka/MAX6953.git|Contributed|MAX6953
 https://github.com/GyverLibs/GyverMenu.git|Contributed|GyverMenu

--- a/registry.txt
+++ b/registry.txt
@@ -8151,7 +8151,7 @@ https://github.com/BestModules-Libraries/BMH12M205.git|Contributed|BMH12M205
 https://github.com/BestModules-Libraries/BMS56M206A.git|Contributed|BMS56M206A
 https://github.com/BestModules-Libraries/BMH08101.git|Contributed|BMH08101
 https://github.com/BestModules-Libraries/BMV31M304A.git|Contributed|BMV31M304A
-https://github.com/HamzaYslmn/Esp32-RTOS-Serial.git|Contributed|esp-rtosSerial
+https://github.com/HamzaYslmn/esp-rtosSerial.git|Contributed|esp-rtosSerial
 https://github.com/Zakrzewiaczek/pantryclient-esp.git|Contributed|PantryClient
 https://github.com/John-Karatka/MAX6953.git|Contributed|MAX6953
 https://github.com/GyverLibs/GyverMenu.git|Contributed|GyverMenu


### PR DESCRIPTION
This PR consists of two changes:

- Change URL from `https://github.com/HamzaYslmn/Esp32-RTOS-Serial.git` to `https://github.com/HamzaYslmn/esp-rtosSerial.git` (companion to https://github.com/arduino/library-registry/pull/8042)
- Change name from `Esp32-RTOS-Serial` to `esp-rtosSerial`.

Since the name change operation on the database is actually a removal followed by automated re-indexing on the next job run, the URL update will occur as a matter of course. For this reason, the only operation required from the backend maintainer is a standard name change procedure.