### PR TITLE
Add ASXNanoStreamEncoder to Library Manager list

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -9236,3 +9236,4 @@ https://github.com/IlVin/QMan
 https://github.com/ulywae/NeuEEPROM
 https://github.com/LearnPRG-py/Vectorial
 https://github.com/agusevtec/eva-motors
+https://github.com/Adriano-Severino/ASXNanoStreamEncoder


### PR DESCRIPTION
Adds the ASXNanoStream library repository URL to the Library Manager registry list.\n\nRepository: https://github.com/Adriano-Severino/ASXNanoStreamEncoder\nLatest compliant tag prepared: 1.0.1