### PR TITLE
Add RotaryEncoder library

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -9237,3 +9237,4 @@ https://github.com/ulywae/NeuEEPROM
 https://github.com/LearnPRG-py/Vectorial
 https://github.com/agusevtec/eva-motors
 https://github.com/Adriano-Severino/ASXNanoStreamEncoder
+https://github.com/RPaulT/RotaryEncoder

--- a/repositories.txt
+++ b/repositories.txt
@@ -9237,4 +9237,4 @@ https://github.com/ulywae/NeuEEPROM
 https://github.com/LearnPRG-py/Vectorial
 https://github.com/agusevtec/eva-motors
 https://github.com/Adriano-Severino/ASXNanoStreamEncoder
-https://github.com/RPaulT/RotaryEncoder
+https://github.com/RPaulT/AdvancedRotaryEncoder


### PR DESCRIPTION
Adds the RotaryEncoder library to the Arduino Library Manager.

Repository:
https://github.com/RPaulT/RotaryEncoder