### PR TITLE
Add CANduino library

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -9241,3 +9241,4 @@ https://github.com/Adriano-Severino/ASXNanoStreamEncoder
 https://github.com/RPaulT/AdvancedRotaryEncoder
 https://github.com/IdlanZafran/ThingsSentral
 https://github.com/dunknowcoding/INA_series_sensor
+https://github.com/MassiveButDynamic/CANduino


### PR DESCRIPTION
Add CANduino library.

Beginner-friendly CAN library for CANduino v4 with a simple API.

Features:
- Easy bitrate setup (e.g. CAN.begin(500000))
- Standard and extended CAN frames
- Filters and masks
- Interrupt support
- Loopback, listen-only and sleep modes