### PR TITLE
Add NocML library

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -9242,3 +9242,4 @@ https://github.com/RPaulT/AdvancedRotaryEncoder
 https://github.com/IdlanZafran/ThingsSentral
 https://github.com/dunknowcoding/INA_series_sensor
 https://github.com/MassiveButDynamic/CANduino
+https://github.com/Nocturnailed-Community/NocML


### PR DESCRIPTION
Registering NocML library for the Arduino Library Manager.

NocML is a modular, lightweight Machine Learning library designed for microcontrollers (ESP32-S3, AVR, etc.). It provides simple implementations for:
- Linear Regression (Prediction)
- KNN (Classification)
- K-Means (Clustering)

Repository: https://github.com/Nocturnailed-Community/NocML