### PR TITLE
Add NocLLM library

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -9244,3 +9244,4 @@ https://github.com/dunknowcoding/INA_series_sensor
 https://github.com/MassiveButDynamic/CANduino
 https://github.com/Nocturnailed-Community/NocML
 https://github.com/Nocturnailed-Community/NocKinematics
+https://github.com/Nocturnailed-Community/NocLLM

--- a/repositories.txt
+++ b/repositories.txt
@@ -9242,3 +9242,4 @@ https://github.com/RPaulT/AdvancedRotaryEncoder
 https://github.com/IdlanZafran/ThingsSentral
 https://github.com/dunknowcoding/INA_series_sensor
 https://github.com/MassiveButDynamic/CANduino
+https://github.com/Nocturnailed-Community/NocML


### PR DESCRIPTION
Registering NocLLM library for the Arduino Library Manager.

NocLLM is a provider-agnostic, high-performance LLM (Large Language Model) connector for microcontrollers (ESP32-S3, ESP8266, etc.). It is designed to bridge hardware with AI intelligence through:

- **Universal API Support:** Works with any OpenAI-compatible endpoint (Sumopod, Gemini, OpenAI, Groq, or Local LLMs like Ollama/LM Studio).
- **Real-Time Streaming:** Native support for Server-Sent Events (SSE) to handle streaming responses word-by-word.
- **Memory Optimization:** Specifically tuned to work with NocJSON for zero-allocation parsing of streaming chunks.
- **Dynamic Configuration:** Easily switch models and base URLs at runtime.

This library is a core component of the Nocturnailed ecosystem, enabling responsive AI-driven robotics and IoT agents.

Repository: https://github.com/Nocturnailed-Community/NocLLM