### PR TITLE
Add NTC_Temp library

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -9246,3 +9246,4 @@ https://github.com/Nocturnailed-Community/NocML
 https://github.com/Nocturnailed-Community/NocKinematics
 https://github.com/Nocturnailed-Community/NocLLM
 https://github.com/ulywae/ButtonPoll
+https://github.com/Japs35/NTC_Temp


### PR DESCRIPTION
Add NTC_Temp library to Arduino Library Manager.

Repository:
https://github.com/Japs35/NTC_Temp

The library provides temperature measurement using NTC thermistors with automatic Beta calculation based on two calibration points.

A release (v1.0.0) has been created and the library follows the required structure.

Thank you.