### PR TITLE
Add RobotechPixel library

### DIFF
--- a/repositories/BigWings2020/robo-tech.txt
+++ b/repositories/BigWings2020/robo-tech.txt
@@ -1,0 +1,1 @@
+https://github.com/BigWings2020/robo-tech.git


### PR DESCRIPTION
Adds the **RobotechPixel** library for Robotech NeoRing and QuadPixel LED boards.

- **Repository**: https://github.com/BigWings2020/robo-tech
- **Category**: Display
- **Dependency**: Adafruit NeoPixel
- **Architectures**: All (`*`)
- **License**: MIT