### PR TITLE
Fix inconsistent newline

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -9260,5 +9260,4 @@ https://github.com/SlaydDev/SteadyPing
 https://github.com/m5stack/M5Unit-NFC
 https://github.com/ulywae/NeuNVS
 https://github.com/FBSeletronica/ESPNowProtocol
-
 https://github.com/JorgeGBeltre/MQTTOTAv5


### PR DESCRIPTION
The repositories list uses the LF newline.

A contributor somehow managed to add a single line with a CRLF newline. This is problematic because text editors will automatically convert newlines. That means that seemingly valid submission PRs that come after the introduction of the inconsistent newline will be detected as a "modification" instead of "submission".

For this reason, it is necessary to change the inconsistent CRLF newline to LF.