### PR TITLE
Add TCA6424A_RT repository link

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -6306,6 +6306,7 @@ https://github.com/RobTillaart/SWSerialOut
 https://github.com/RobTillaart/SWSPI
 https://github.com/RobTillaart/TCA6408A_RT
 https://github.com/RobTillaart/TCA6416A_RT
+https://github.com/RobTillaart/TCA6424A_RT
 https://github.com/RobTillaart/TCA9548
 https://github.com/RobTillaart/TCA9554
 https://github.com/RobTillaart/TCA9555


### PR DESCRIPTION
Arduino library for TCA6424A I2C 24 bits IO expander.