### PR TITLE
Add SmartProv library

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -9273,3 +9273,4 @@ https://github.com/joseluu/adc128d818_driver
 https://github.com/mulberry4275/EspNowDev
 https://github.com/SeventyFourProductions/TFTGraph
 https://github.com/blackhack/ES32D26PLC
+https://github.com/Masud744/SmartProv


### PR DESCRIPTION
Add SmartProv library — a captive-portal Wi-Fi provisioning library for ESP32 and ESP8266.

Repository: https://github.com/Masud744/SmartProv