### PR TITLE
Add APAPHX2_ADS1115

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -1,3 +1,4 @@
+https://github.com/apadevices/APAPHX2_ADS1115
 https://github.com/DIYables/DIYables_4Digit7Segment_TM1637
 https://github.com/You-010/GY33_Arduino
 https://github.com/DIYables/DIYables-DC-Motor


### PR DESCRIPTION
Library repository: https://github.com/apadevices/APAPHX2_ADS1115

Complies with Arduino Library Specification:
- library.properties present and valid
- Source files in root
- examples/ folder present
- Public GitHub repository
- Tagged release 1.1.0
- MIT License