### PR TITLE
Add DS18B20_RMT repository link

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -9291,3 +9291,4 @@ https://github.com/Nocturnailed-Community/NocMotion
 https://github.com/SethKinzel/EasyJoystick
 https://github.com/nawawimegahertz/IndustrialSense.git
 https://github.com/specledcomua-creator/SenseAir_S88.git
+https://github.com/Motyl-sk/DS18B20_RMT


### PR DESCRIPTION
DS18B20 temperature sensor library for ESP32 using the RMT peripheral for 1-Wire communication. No bit-banging — all bus timing is handled in hardware.