### PR TITLE
Add new repository link for xelp

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -9293,3 +9293,4 @@ https://github.com/SethKinzel/EasyJoystick
 https://github.com/nawawimegahertz/IndustrialSense.git
 https://github.com/specledcomua-creator/SenseAir_S88.git
 https://github.com/atsign-foundation/at_client_arduino.git
+https://github.com/deftio/xelp


### PR DESCRIPTION
xelp is a cli lirbary for microcontrollers that allows c functions to be a accessed from serial link (or ble or etc).  it includes built-in help, parsing and doesn't use malloc or std library calls. full docs and examples provided at repo.