### PR TITLE
Add fr_math repository link to repositories.txt

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -9302,3 +9302,4 @@ https://github.com/deftio/xelp
 https://github.com/juslam/IoTera_Arduino
 https://github.com/mattykakes/SerialCommandCoordinator
 https://github.com/foodini/arduino_ms5611_spi
+https://github.com/deftio/fr_math


### PR DESCRIPTION
Fixed-point math library (integer / no FPU) for embedded C — trig, log/exp, sqrt, 2D transforms, wave generators, ADSR in 4 KB, along with helper fns for printout out fixed point numbers to serial connections (Serial, uart, etc).