### PR TITLE
This PR adds the OhStemRobotics library to Arduino Library Manager.  …

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -9307,3 +9307,4 @@ https://github.com/juslam/IoTera_Arduino
 https://github.com/mattykakes/SerialCommandCoordinator
 https://github.com/foodini/arduino_ms5611_spi
 https://github.com/deftio/fr_math
+https://github.com/truongphat230799/ohstem-orc-hub-robotics.git


### PR DESCRIPTION
This PR adds the OhStemRobotics library to Arduino Library Manager.

Repository:
https://github.com/truongphat230799/ohstem-orc-hub-robotics

Library name:
OhStemRobotics

Release:
0.2.0

The repository follows the standard Arduino library structure and includes:
- src/
- examples/
- library.properties
- keywords.txt

Thank you.
