### PR TITLE
Remove "hxtp-micro"

### DIFF
--- a/registry.txt
+++ b/registry.txt
@@ -9060,7 +9060,6 @@ https://github.com/DIYables/DIYables_OLED_SSD1309.git|Contributed|DIYables_OLED_
 https://github.com/ASNProject/Panzer_Robotics_Library.git|Contributed|Panzer_Robotics_Library
 https://github.com/roboticist-blip/LoRa32T.git|Contributed|LoRa32T
 https://github.com/dhruvkotian/em2m-esp32-modbus.git|Contributed|EM2M-ESP32-Driver
-https://github.com/hestia1abs/hxtp-micro.git|Contributed|hxtp-micro
 https://github.com/GyverLibs/GyverMotor2.git|Contributed|GyverMotor2
 https://github.com/GyverLibs/GyverKey.git|Contributed|GyverKey
 https://github.com/stm32duino/LSM6DSO32.git|Contributed|STM32duino LSM6DSO32


### PR DESCRIPTION
Companion to https://github.com/arduino/library-registry/pull/8192