### PR TITLE
Add ElctinsIoTClient

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -9335,3 +9335,4 @@ https://github.com/meerzafarnoohani/KISS_FFT
 https://github.com/meerzafarnoohani/ETL_Arduino
 https://github.com/CDonalO/Embedded-GUI-Framework
 https://github.com/ArtronShop/ATD3.5-S3-HandySense-Arduino-Library
+https://github.com/prj-electins/ElctinsIoTClient


### PR DESCRIPTION
Adding ElctinsIoTClient - Lightweight MQTT 3.1.1 client for ESP8266 and ESP32 with auto-reconnect, QoS 0/1/2, TLS support, and per-topic callbacks.