### PR TITLE
Update name of "Adafruit DACX578 Library"

### DIFF
--- a/registry.txt
+++ b/registry.txt
@@ -7695,7 +7695,7 @@ https://github.com/PervasiveDisplays/Pervasive_Wide_Large.git|Contributed|Pervas
 https://github.com/PervasiveDisplays/Pervasive_Touch_Small.git|Contributed|Pervasive_Touch_Small
 https://github.com/m5stack/M5Unit-ASR.git|Contributed|M5UnitASR
 https://github.com/Stutchbury/TouchScreenAdapter.git|Contributed|TouchScreenAdapter
-https://github.com/adafruit/Adafruit_DACX578.git|Recommended|Adafruit DAC7578 Library
+https://github.com/adafruit/Adafruit_DACX578.git|Recommended|Adafruit DACX578 Library
 https://github.com/4project-co-il/EBF.git|Contributed|EventBasedFramework
 https://github.com/RobTillaart/AMT25.git|Contributed|AMT25
 https://github.com/pk17r/TouchscreenResistive.git|Contributed|TouchscreenResistive


### PR DESCRIPTION
Resolves https://github.com/arduino/library-registry/issues/8224