### PR TITLE
Add ElectinsIoT library

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -9338,3 +9338,4 @@ https://github.com/CDonalO/Embedded-GUI-Framework
 https://github.com/ArtronShop/ATD3.5-S3-HandySense-Arduino-Library
 https://github.com/prj-electins/ElctinsIoTClient
 https://github.com/danielthu167/TMT_SmartConnect
+https://github.com/prj-electins/ElectinsIoT


### PR DESCRIPTION
Submitting ElectinsIoT - a lightweight MQTT 3.1.1 client for ESP8266 and ESP32 with optional ArduinoJson integration.