### PR TITLE
Added Makeability Lab lib to repo list

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -1,3 +1,4 @@
+https://github.com/makeabilitylab/makelab-arduino-lib
 https://github.com/vmykhalchuk/LongLiveThEEPROM
 https://github.com/tdk-invn-oss/motion.arduino.TAD2144
 https://github.com/topquark22/CharlieLED


### PR DESCRIPTION
Added the Makeability Lab library that goes along with the interactive textbook (https://makeabilitylab.github.io/physcomp/) to the official Arduino library repo list.