### PR TITLE
Update URL of "SerialWeb"

### DIFF
--- a/registry.txt
+++ b/registry.txt
@@ -8631,7 +8631,7 @@ https://github.com/xreef/RYUW122.git|Contributed|RYUW122
 https://github.com/sciosense/ufm02-arduino.git|Contributed|ScioSense_UFM02
 https://github.com/liviobellini/AmiraEncoder.git|Contributed|AmiraEncoder
 https://github.com/dac1e/Somo1ELV.git|Contributed|Somo1ELV
-https://github.com/TORICA-Org/SerialWeb.git|Contributed|SerialWeb
+https://github.com/00kenno/SerialWeb.git|Contributed|SerialWeb
 https://github.com/basicmicro/basicmicro_arduino.git|Contributed|Basicmicro
 https://github.com/DFRobot/DFRobot_AI10.git|Contributed|DFRobot_AI10
 https://github.com/DFRobot/DFRobot_RTK_4G.git|Contributed|DFRobot_RTK_4G


### PR DESCRIPTION
Companion to https://github.com/arduino/library-registry/pull/8255