### PR TITLE
Add RumiCar-lib repository link

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -9358,3 +9358,4 @@ https://github.com/weenachuangkud/XSegment_lib
 https://github.com/vktrsansara/LedBasic
 https://github.com/Adrien-Legrand/PlaneteSciences85
 https://github.com/ARAM-USA-Support/ARAM_FS_Stepper
+https://github.com/RumiCar-group/RumiCar-lib


### PR DESCRIPTION
Submitting RumiCar-lib for inclusion in the Arduino Library Manager index.

RumiCar is an autonomous driving learning platform. This library provides setup and control APIs (RC_setup / RC_steer / RC_drive) for steering and drive motors, plus initialization of three VL53L0X laser distance sensors. It supports Arduino AVR, ESP32, Sony Spresense, and Raspberry Pi Pico W via preprocessor branches.

Repository: https://github.com/RumiCar-group/RumiCar-lib
Latest tag: v0.1.0

arduino-lint (compliance: specification, library-manager: submit) passes with 0 errors and 0 warnings on the latest commit.
