### PR TITLE
Add plexus-c

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -9367,3 +9367,4 @@ https://github.com/ARAM-USA-Support/ARAM_FS_Stepper
 https://github.com/RumiCar-group/RumiCar-lib
 https://github.com/PratulDeshpande/PQCMicro
 https://github.com/ulywae/NeuButton
+https://github.com/plexus-oss/plexus-c


### PR DESCRIPTION
Adds plexus-c, a telemetry SDK for sending sensor data from microcontrollers to the Plexus HardwareOps platform. Targets ESP32, ESP8266, and STM32 boards.

Latest release: v0.1.1
Project URL: https://github.com/plexus-oss/plexus-c