### PR TITLE
Update URL of "circuit_kit_library"

### DIFF
--- a/registry.txt
+++ b/registry.txt
@@ -9155,7 +9155,7 @@ https://github.com/RobTillaart/I2C_HC4067.git|Contributed|I2C_HC4067
 https://github.com/Sensirion/arduino-i2c-sen62.git|Contributed|Sensirion I2C SEN62
 https://github.com/JesRex700/HDrive.git|Contributed|HDrive
 https://github.com/DFRobot/DFRobot_STCC4.git|Contributed|DFRobot_STCC4
-https://github.com/ozobot/circuit_kit_library.git|Contributed|circuit_kit_library
+https://github.com/ozobot/drvkit_library.git|Contributed|circuit_kit_library
 https://github.com/RobTillaart/HX712.git|Contributed|HX712
 https://github.com/SolderedElectronics/Inkplate-LVGL-Library.git|Contributed|Inkplate LVGL Library
 https://github.com/kbmkrishnamali1992-hub/SIM800_GSM_GPRS_LIBRARY.git|Contributed|SIM800_GSM_GPRS


### PR DESCRIPTION
Companion to https://github.com/arduino/library-registry/pull/8276