### PR TITLE
Add SingleSevenSeg library

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -9374,3 +9374,4 @@ https://github.com/plexus-oss/plexus-c
 https://github.com/arduino-libraries/Arduino_HardwareServo
 https://github.com/kwlew/PIDEasy-Improved
 https://github.com/andrey-val-rodin/BleCommands.Arduino
+https://github.com/kritishmohapatra/SingleSevenSeg


### PR DESCRIPTION
Added SingleSevenSeg - An Arduino library for controlling a single-digit 7-segment display. Supports Common Anode and Common Cathode displays with optional decimal point control.