### PR TITLE
Add midi2

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -9376,3 +9376,4 @@ https://github.com/kwlew/PIDEasy-Improved
 https://github.com/andrey-val-rodin/BleCommands.Arduino
 https://github.com/kritishmohapatra/SingleSevenSeg
 https://github.com/Nocturnailed-Community/NocShield
+https://github.com/sauloverissimo/midi2


### PR DESCRIPTION
## Submission Checklist

- [x] My library is fully open source and is provided to the community for free.
- [x] My library has source files at the root of the repository or under a `src` subfolder.
- [x] My library is hosted at GitHub.
- [x] My library has either a [`library.properties`](https://arduino.github.io/arduino-cli/latest/library-specification/#library-metadata) file or a `.h` header file at the root.
- [x] My library has a tagged release with the same version as defined in `library.properties` (`v0.3.1`).
- [x] My library `library.properties` is encoded in UTF-8.

## Library

- Name: **midi2**
- Repo: https://github.com/sauloverissimo/midi2
- Latest release: https://github.com/sauloverissimo/midi2/releases/tag/v0.3.1
- License: MIT
- Architectures: `*` (portable C99)

Portable MIDI 2.0 UMP library written in C99. Provides UMP construction, parsing, dispatch, and MIDI-CI for the Universal MIDI Packet on embedded targets, from AVR to desktop. Header-only public API with stb-style amalgamation available under `dist/`. Also distributed via PlatformIO.

Two example sketches under `examples/` (`BasicUsage` and `CIDiscovery`) appear in the IDE's File > Examples menu after install. Validated with `arduino-cli` on Arduino UNO (AVR) and Teensy 4.1.