### PR TITLE
Add ClearCoreWatchdog

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -9379,3 +9379,4 @@ https://github.com/andrey-val-rodin/BleCommands.Arduino
 https://github.com/kritishmohapatra/SingleSevenSeg
 https://github.com/Nocturnailed-Community/NocShield
 https://github.com/sauloverissimo/midi2
+https://github.com/RobotBuzzard/ClearCoreWatchdog


### PR DESCRIPTION
Hardware watchdog timer for the [Teknic ClearCore](https://www.teknic.com/products/io-motion-controller-clearcore/) (Microchip SAME53N19A).

Fills a real gap: Teknic's ClearCore Arduino library (`ClearCore:sam`) exposes no watchdog API at all (`SysManager` has only `ConnectorByIndex` and `ResetBoard`, verified at https://teknic-inc.github.io/ClearCore-library/). This library wraps the SAMD51/SAME53 WDT block via direct CMSIS register access.

* Repo: https://github.com/RobotBuzzard/ClearCoreWatchdog
* Tagged release: https://github.com/RobotBuzzard/ClearCoreWatchdog/releases/tag/v1.0.0
* MIT licensed.
* Three example sketches (Basic, HangDetect, BracketLongOperation) — all compile clean.
* `arduino-lint --library-manager submit --compliance permissive` passes with zero errors and zero warnings on library + examples.
* Bench-validated: deliberate-hang test produces automatic reset within the configured timeout.