### PR TITLE
Add midi2_cpp

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -9379,6 +9379,7 @@ https://github.com/andrey-val-rodin/BleCommands.Arduino
 https://github.com/kritishmohapatra/SingleSevenSeg
 https://github.com/Nocturnailed-Community/NocShield
 https://github.com/sauloverissimo/midi2
+https://github.com/sauloverissimo/midi2_cpp
 https://github.com/RobotBuzzard/ClearCoreWatchdog
 https://github.com/soosp/SimcomA76xx
 https://github.com/K3vin135/iot-azure-bridge


### PR DESCRIPTION
midi2_cpp is the C++17 wrapper around the [midi2](https://github.com/sauloverissimo/midi2) C99 core (already on the Library Manager via PR #8284).

- v0.2.0 release: https://github.com/sauloverissimo/midi2_cpp/releases/tag/v0.2.0
- C++17 callback-first API for MIDI 2.0 (UMP transport, MIDI-CI, Property Exchange, Profile Configuration, Process Inquiry, Flex Data, Bit Scaling)
- depends on midi2 (>=0.3.3) — declared in `library.properties`, auto-resolved by the Library Manager

Tested locally with `arduino-lint` and the project's CI matrix (Ubuntu / macOS host tests, gcc + clang strict warnings, Arduino compile on Raspberry Pi Pico, Pico SDK build).