### PR TITLE
Rename midi2_cpp to midi2cpp

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -9380,7 +9380,7 @@ https://github.com/andrey-val-rodin/BleCommands.Arduino
 https://github.com/kritishmohapatra/SingleSevenSeg
 https://github.com/Nocturnailed-Community/NocShield
 https://github.com/sauloverissimo/midi2
-https://github.com/sauloverissimo/midi2_cpp
+https://github.com/sauloverissimo/midi2cpp
 https://github.com/RobotBuzzard/ClearCoreWatchdog
 https://github.com/soosp/SimcomA76xx
 https://github.com/K3vin135/iot-azure-bridge


### PR DESCRIPTION
The library `midi2_cpp` has been renamed to `midi2cpp` (https://github.com/sauloverissimo/midi2cpp) in deference to [`starfishmod/MIDI2_CPP`](https://github.com/starfishmod/MIDI2_CPP), maintained since 2021 by Andrew Mee (MIDI Association TSB Rep) in the same domain. Keeping the names disjoint avoids confusion in the Library Manager and search.

The GitHub repository has been renamed (the old URL redirects), the `library.properties` declares `name=midi2cpp`, and v0.3.0 has been tagged: https://github.com/sauloverissimo/midi2cpp/releases/tag/v0.3.0

Replaces the previous entry merged in #8289.