### PR TITLE
Add XC_SR04 library

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -9385,3 +9385,4 @@ https://github.com/RobotBuzzard/ClearCoreWatchdog
 https://github.com/soosp/SimcomA76xx
 https://github.com/K3vin135/iot-azure-bridge
 https://github.com/ulywae/NeuStorage
+https://github.com/Gigasitron-xcross/XC_SR04


### PR DESCRIPTION
This pull request adds the XC_SR04 Arduino library.

Repository:
https://github.com/Gigasitron-xcross/XC_SR04

XC_SR04 is an object-oriented, non-blocking HC-SR04/SR04 ultrasonic sensor driver for STM32duino. It avoids pulseIn(), uses interrupt-driven echo measurement, HardwareTimer-based timeout handling, and callback result notification.

Initial release: v0.1.0
Tested on: NUCLEO-G474RE