### PR TITLE
Update name and URL of "midi2cpp"

### DIFF
--- a/registry.txt
+++ b/registry.txt
@@ -9375,7 +9375,7 @@ https://github.com/RobTillaart/A02YYUW.git|Contributed|A02YYUW
 https://github.com/RobotBuzzard/ClearCoreWatchdog.git|Contributed|ClearCoreWatchdog
 https://github.com/soosp/SimcomA76xx.git|Contributed|SimcomA76xx
 https://github.com/K3vin135/iot-azure-bridge.git|Contributed|EasyAzureIoT
-https://github.com/sauloverissimo/midi2_cpp.git|Contributed|midi2cpp
+https://github.com/sauloverissimo/midi2cpp.git|Contributed|midi2cpp
 https://github.com/ulywae/NeuStorage.git|Contributed|NeuStorage
 https://github.com/ccaprojects/CCARemote-Arduino.git|Contributed|CCARemote
 https://github.com/Gigasitron-xcross/XC_SR04.git|Contributed|XC_SR04

--- a/registry.txt
+++ b/registry.txt
@@ -9375,7 +9375,7 @@ https://github.com/RobTillaart/A02YYUW.git|Contributed|A02YYUW
 https://github.com/RobotBuzzard/ClearCoreWatchdog.git|Contributed|ClearCoreWatchdog
 https://github.com/soosp/SimcomA76xx.git|Contributed|SimcomA76xx
 https://github.com/K3vin135/iot-azure-bridge.git|Contributed|EasyAzureIoT
-https://github.com/sauloverissimo/midi2_cpp.git|Contributed|midi2_cpp
+https://github.com/sauloverissimo/midi2_cpp.git|Contributed|midi2cpp
 https://github.com/ulywae/NeuStorage.git|Contributed|NeuStorage
 https://github.com/ccaprojects/CCARemote-Arduino.git|Contributed|CCARemote
 https://github.com/Gigasitron-xcross/XC_SR04.git|Contributed|XC_SR04


### PR DESCRIPTION
This PR consists of two changes:

- Change URL from `https://github.com/sauloverissimo/midi2_cpp.git` to `https://github.com/sauloverissimo/midi2cpp.git` (companion to https://github.com/arduino/library-registry/pull/8293).
- Change name from `midi2_cpp` to `midi2cpp` (resolves https://github.com/arduino/library-registry/issues/8294)

Since the name change operation on the database is actually a removal followed by automated re-indexing on the next job run, the URL update will occur as a matter of course. For this reason, the only operation required from the backend maintainer is a standard name change procedure.