### PR TITLE
Add mmWaveKit library

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -9387,3 +9387,4 @@ https://github.com/K3vin135/iot-azure-bridge
 https://github.com/ulywae/NeuStorage
 https://github.com/Gigasitron-xcross/XC_SR04
 https://github.com/dm-mamun/DualMotor
+https://github.com/LennartHennigs/mmWaveKit


### PR DESCRIPTION
Arduino library wrapping the Seeed MR60BHA2 mmWave sensor kit with a Button2-style callback API.

- Repository: https://github.com/LennartHennigs/mmWaveKit
- Library page: https://github.com/LennartHennigs/mmWaveKit
- Version: 1.0.0

I have verified that the library complies with the [Arduino Library specification](https://arduino.github.io/arduino-cli/library-specification/).