### PR TITLE
Add AMRFID library

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -9388,3 +9388,4 @@ https://github.com/ulywae/NeuStorage
 https://github.com/Gigasitron-xcross/XC_SR04
 https://github.com/dm-mamun/DualMotor
 https://github.com/LennartHennigs/mmWaveKit
+https://github.com/guicaiala/AMRFID


### PR DESCRIPTION
Adding the AMRFID library to the Arduino Library Manager registry.

- Repository: https://github.com/guicaiala/AMRFID
- Category: Communication
- Version: 1.0.0
- Author: Gui Caiala