### PR TITLE
Add new repository link for qf_math

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -9389,3 +9389,5 @@ https://github.com/Gigasitron-xcross/XC_SR04
 https://github.com/dm-mamun/DualMotor
 https://github.com/LennartHennigs/mmWaveKit
 https://github.com/guicaiala/AMRFID
+http://github.com/deftio/qf_math
+


### PR DESCRIPTION
qf_math is a fast floating point library for trig, log, exp, wave form gen, and related functions. It is the float api equivalent of github/deftio/fr_math (fixed point)