### PR TITLE
Add CriticalTaskScheduler library

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -9391,3 +9391,4 @@ https://github.com/LennartHennigs/mmWaveKit
 https://github.com/guicaiala/AMRFID
 http://github.com/deftio/qf_math
 https://github.com/Rafeul1997/ESPCar.git
+https://github.com/andrenepomuceno/CriticalTaskScheduler


### PR DESCRIPTION
## Submitting CriticalTaskScheduler to Library Manager

**Library name:** CriticalTaskScheduler  
**Repository URL:** https://github.com/andrenepomuceno/CriticalTaskScheduler  
**Version:** 1.0.0  
**License:** MIT  

### Description

Lightweight cooperative task scheduler for Arduino and ESP32 with a **dual-bucket model**:
- **Background bucket** — runs one earliest-due task per `execute()` call (loop-friendly, anti-starvation)
- **Critical bucket** — runs all due tasks per `executeCritical()` call, with an optional FreeRTOS dedicated thread on ESP32

### Compliance checklist

- [x] `library.properties` present at root, Arduino Library 1.5 format
- [x] Name `CriticalTaskScheduler` is unique in the registry
- [x] No `.development` file, no `.exe` files, no symlinks
- [x] Git tag `v1.0.0` exists and library was compliant at that tag
- [x] `arduino-lint` passes (strict mode, CI badge in README)
- [x] MIT licensed
- [x] Hosted on GitHub