### PR TITLE
Add CriticalTaskScheduler library

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -9391,3 +9391,4 @@ https://github.com/LennartHennigs/mmWaveKit
 https://github.com/guicaiala/AMRFID
 http://github.com/deftio/qf_math
 https://github.com/Rafeul1997/ESPCar.git
+https://github.com/andrenepomuceno/CriticalTaskScheduler


### PR DESCRIPTION
### Add CriticalTaskScheduler

**Repository URL:** https://github.com/andrenepomuceno/CriticalTaskScheduler

**Description:** Lightweight cooperative task scheduler for Arduino (AVR, SAMD, RP2040, ESP8266, ESP32, nRF52). Features background (earliest-due, one task per loop) and critical (all-due, FreeRTOS-driven) task buckets, per-task statistics, and a pluggable time source for unit testing. No heap allocation. MIT licensed.

I have verified that:
- [x] The library compiles without errors for Arduino Uno and ESP32
- [x] library.properties is present and valid (arduino-lint passes with --compliance strict)
- [x] The repository is tagged with semantic versioning (1.0.1)
- [x] The library has a MIT license