### PR TITLE
Add NTCTemp library (v1.0.0)

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -9394,3 +9394,4 @@ http://github.com/deftio/qf_math
 https://github.com/Rafeul1997/ESPCar.git
 https://github.com/andrenepomuceno/CriticalTaskScheduler
 https://github.com/ulywae/NeuKV
+https://github.com/Rafeul1997/NTCTemp


### PR DESCRIPTION
## NTCTemp Library v1.0.0

This is the initial release of the **NTCTemp** library.

### Overview
NTCTemp is a lightweight and universal library for reading temperature from NTC thermistors. It supports multiple microcontroller platforms including Arduino, ESP32, ESP8266, STM32, Raspberry Pi Pico (RP2040), and other Arduino-compatible boards.

### Features
- Read temperature in Celsius
- Read temperature in Fahrenheit
- Configurable NTC resistance value
- Configurable series resistor value
- Adjustable Beta coefficient
- Configurable nominal temperature
- Custom ADC resolution support
- Lightweight and fast execution

### Supported Platforms
- Arduino boards (UNO, Mega, Nano, etc.)
- ESP32
- ESP8266
- STM32
- Raspberry Pi Pico (RP2040)
- Other Arduino-compatible microcontrollers

### Library Structure
- Clean `src` implementation
- Example sketches included:
  - Basic temperature reading (`TempRead`)
  - Advanced configuration (`CustomTemp`)
- Arduino IDE compatible (`library.properties`, `keywords.txt` included)

### Author
Abdul Rafeul Mallick  
GitHub: https://github.com/Rafeul1997

### Version
v1.0.0 - Initial Release