### PR TITLE
Update library repository URL from Universal-Blink to Blink

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -9401,5 +9401,5 @@ https://github.com/Rafeul1997/NTCTemp
 https://github.com/Rafeul1997/AutoLCD
 https://github.com/NikolaiRadke/TinyRTOS
 https://github.com/AvantMaker/AvantLumi
-https://github.com/Rafeul1997/Universal_Blink
+https://github.com/Rafeul1997/Blink
 https://github.com/IdlanZafran/RemoteUpload


### PR DESCRIPTION
Renamed the library repository from "Universal-Blink" to "Blink".

Updated repositories.txt to replace:
https://github.com/Rafeul1997/Universal-Blink

with:
https://github.com/Rafeul1997/Blink

Library version has also been updated and a new release tag has been created.
