### PR TITLE
Add new repository link for CrashHive32

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -9405,3 +9405,4 @@ https://github.com/Rafeul1997/Universal_Blink
 https://github.com/IdlanZafran/RemoteUpload
 https://github.com/ArtronShop/DuinoClaw
 https://github.com/CodexPad/codex_pad_frame_decoder_arduino_lib
+https://github.com/Parvaz-Jamei/CrashHive32


### PR DESCRIPTION
Adds CrashHive32 to the Arduino Library Manager registry.

Library repository:
https://github.com/Parvaz-Jamei/CrashHive32