### PR TITLE
Revoke registry privileges for `github.com/Rafeul1997`

### DIFF
--- a/.github/workflows/assets/accesslist.yml
+++ b/.github/workflows/assets/accesslist.yml
@@ -42,6 +42,10 @@
   access: deny
   reference: https://github.com/arduino/library-registry/pull/5706#issuecomment-2588923290
 - host: github.com
+  name: Rafeul1997
+  access: deny
+  reference: https://github.com/arduino/library-registry/pull/8337#pullrequestreview-4270053083
+- host: github.com
   name: Subodh-roy2
   access: deny
   reference: https://github.com/arduino/library-registry/pull/4422#issuecomment-2589051618


### PR DESCRIPTION
This user has established a pattern of irresponsible behavior in the Arduino Library Manager Registry repository (see https://github.com/arduino/library-registry/pull/8337#pullrequestreview-4270053083). They continued this behavior even after the bot and human maintainer made significant efforts to guide them to responsible
use.