### PR TITLE
Add ESP32_WebGPIO library

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -9414,3 +9414,4 @@ https://github.com/Parvaz-Jamei/CrashHive32
 https://github.com/zjp007/PulseAnalyzer
 https://github.com/Protocentral/protocentral_st1vafe3bx_arduino
 https://github.com/CITROMOSEPER/XYdraw
+https://github.com/Rafeul1997/ESP32_WebGPIO


### PR DESCRIPTION
### Library Name
ESP32_WebGPIO

### Repository
https://github.com/YOUR_USERNAME/ESP32_WebGPIO

### Description
ESP32 Web GPIO control with dynamic buttons and static IP support.

### Checklist
- [x] Library follows Arduino structure
- [x] Contains examples
- [x] Has LICENSE file
- [x] Has library.properties