### PR TITLE
Add FDCxCapSense library

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -9420,3 +9420,4 @@ https://github.com/ulywae/NeuWiFi
 https://github.com/SerhiiLe/microTelegramAPI
 https://github.com/SerhiiLe/DFMiniMp3E
 https://github.com/Unical-A/DashlyClient.git
+https://github.com/Parvaz-Jamei/FDCxCapSense


### PR DESCRIPTION
This PR adds the FDCxCapSense Arduino library to the Library Manager registry.

Library repository:
https://github.com/Parvaz-Jamei/FDCxCapSense

The library provides Arduino capacitive sensing support for TI FDC1004, FDC1004-Q1, FDC2x1x, and FDC2214 devices.