### PR TITLE
Revoke registry privileges for github.com/Rafeul-1997

### DIFF
--- a/.github/workflows/assets/accesslist.yml
+++ b/.github/workflows/assets/accesslist.yml
@@ -41,6 +41,11 @@
   name: kelasrobot
   access: deny
   reference: https://github.com/arduino/library-registry/pull/5706#issuecomment-2588923290
+# This account was created to circumvent the access revocation on their original github.com/Rafeul1997 account.
+- host: github.com
+  name: Rafeul-1997
+  access: deny
+  reference: https://github.com/arduino/library-registry/pull/8337#pullrequestreview-4270053083
 - host: github.com
   name: Rafeul1997
   access: deny


### PR DESCRIPTION
This account was created to circumvent the access revocation on their original github.com/Rafeul1997 account (https://github.com/arduino/library-registry/pull/8343). For details, see https://github.com/arduino/library-registry/pull/8337#pullrequestreview-4270053083.