### PR TITLE
Add EcoSensePower

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -9431,3 +9431,4 @@ https://github.com/LaskaKit/laskakit_zivyobraz_client
 https://github.com/emakefun-arduino-library/cq01
 https://github.com/Rafeul-1997/OTAxpress
 https://github.com/Rafeul-1997/ESP32_WebGPIO
+https://github.com/Parvaz-Jamei/EcoSensePower-Arduino


### PR DESCRIPTION
This pull request adds the EcoSensePower Arduino library to the Arduino Library Manager registry.

Library repository:
https://github.com/Parvaz-Jamei/EcoSensePower-Arduino

Release:
https://github.com/Parvaz-Jamei/EcoSensePower-Arduino/releases/tag/v0.9.10

EcoSensePower is an energy-aware power management and battery-life estimation library for Arduino and IoT sensor projects. It provides adaptive sampling, sleep orchestration, energy accounting, board/battery/sensor/radio/BLE/GPS/GNSS/WiFi/harvester profile foundations, diagnostics, and dependency-free default builds.

The library includes:
- library.properties at the repository root
- Arduino-compatible src/ and examples/ structure
- MIT license
- Public v0.9.10 release/tag
- GitHub Actions workflows for Arduino lint, compile checks, and host logic tests