### PR TITLE
Add PulseWetProbe library

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -9436,3 +9436,4 @@ https://github.com/Rafeul-1997/OTAxpress
 https://github.com/Rafeul-1997/ESP32_WebGPIO
 https://github.com/Parvaz-Jamei/EcoSensePower-Arduino
 https://github.com/Alexandros-Charitonidis/MiniMessenger
+https://github.com/Parvaz-Jamei/PulseWetProbe-Arduino


### PR DESCRIPTION
Adds the PulseWetProbe Arduino library repository URL for Arduino Library Manager indexing.

Library repository:
https://github.com/Parvaz-Jamei/PulseWetProbe-Arduino

Release:
https://github.com/Parvaz-Jamei/PulseWetProbe-Arduino/releases/tag/v0.3.7