### PR TITLE
Add WCB_Client

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -9444,3 +9444,4 @@ https://github.com/Alexandros-Charitonidis/MiniMessenger
 https://github.com/Parvaz-Jamei/PulseWetProbe-Arduino
 https://github.com/Dim-aka/AY8912_ESP32.git
 https://github.com/sajidrahii/ESP32S3_n8r16_CameraStream
+https://github.com/greghulette/WCBClient.git


### PR DESCRIPTION
Adding the WCB_Client library (https://github.com/greghulette/WCBClient).

ESP32 ESP-NOW client library for joining a Wireless Communication Board (WCB) network. Passes `arduino-lint --library-manager submit` with 0 errors / 0 warnings. Tagged release 1.0.0.