### PR TITLE
Remove "ESPCar"

### DIFF
--- a/registry.txt
+++ b/registry.txt
@@ -9383,7 +9383,6 @@ https://github.com/dm-mamun/DualMotor.git|Contributed|DualMotor
 https://github.com/LennartHennigs/mmWaveKit.git|Contributed|mmWaveKit
 https://github.com/guicaiala/AMRFID.git|Contributed|AMRFID
 https://github.com/deftio/qf_math.git|Contributed|qf_math
-https://github.com/Rafeul1997/ESPCar.git|Contributed|ESPCar
 https://github.com/andrenepomuceno/CriticalTaskScheduler.git|Contributed|CriticalTaskScheduler
 https://github.com/ulywae/NeuKV.git|Contributed|NeuKV
 https://github.com/tobozo/LGFX_Fonts.git|Contributed|LGFX_Fonts


### PR DESCRIPTION
Due to unacceptable behavior (see https://github.com/arduino/library-registry/pull/8337#pullrequestreview-4270053083), this library maintainer's Arduino Library Registry privileges have been permanently revoked.

Companion to https://github.com/arduino/library-registry/pull/8399