### PR TITLE
Remove "ESPCar"

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -9411,7 +9411,6 @@ https://github.com/LennartHennigs/mmWaveKit
 https://github.com/guicaiala/AMRFID
 https://github.com/m5stack/M5Unit-RFID
 http://github.com/deftio/qf_math
-https://github.com/Rafeul1997/ESPCar.git
 https://github.com/andrenepomuceno/CriticalTaskScheduler
 https://github.com/ulywae/NeuKV
 https://github.com/Rafeul1997/NTCTemp


### PR DESCRIPTION
Due to unacceptable behavior (see https://github.com/arduino/library-registry/pull/8337#pullrequestreview-4270053083), this library maintainer's Arduino Library Registry privileges have been permanently revoked.