### PR TITLE
Remove "NTCTemp"

### DIFF
--- a/registry.txt
+++ b/registry.txt
@@ -9387,7 +9387,6 @@ https://github.com/Rafeul1997/ESPCar.git|Contributed|ESPCar
 https://github.com/andrenepomuceno/CriticalTaskScheduler.git|Contributed|CriticalTaskScheduler
 https://github.com/ulywae/NeuKV.git|Contributed|NeuKV
 https://github.com/tobozo/LGFX_Fonts.git|Contributed|LGFX_Fonts
-https://github.com/Rafeul1997/NTCTemp.git|Contributed|NTCTemp
 https://github.com/Rafeul1997/AutoLCD.git|Contributed|AutoLCD
 https://github.com/Otto17/ESP_ChaCha.git|Contributed|ESP_ChaCha
 https://github.com/NikolaiRadke/TinyRTOS.git|Contributed|TinyRTOS


### PR DESCRIPTION
Due to unacceptable behavior (see https://github.com/arduino/library-registry/pull/8337#pullrequestreview-4270053083), this library maintainer's Arduino Library Registry privileges have been permanently revoked.

Companion to https://github.com/arduino/library-registry/pull/8401