### PR TITLE
Remove "NTCTemp"

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -9414,7 +9414,6 @@ http://github.com/deftio/qf_math
 https://github.com/Rafeul1997/ESPCar.git
 https://github.com/andrenepomuceno/CriticalTaskScheduler
 https://github.com/ulywae/NeuKV
-https://github.com/Rafeul1997/NTCTemp
 https://github.com/Rafeul1997/AutoLCD
 https://github.com/NikolaiRadke/TinyRTOS
 https://github.com/AvantMaker/AvantLumi


### PR DESCRIPTION
Due to unacceptable behavior (see https://github.com/arduino/library-registry/pull/8337#pullrequestreview-4270053083), this library maintainer's Arduino Library Registry privileges have been permanently revoked.