### PR TITLE
Remove "Universal Blink"

### DIFF
--- a/registry.txt
+++ b/registry.txt
@@ -9394,7 +9394,6 @@ https://github.com/NikolaiRadke/TinyRTOS.git|Contributed|TinyRTOS
 https://github.com/alkonosst/Statechart.git|Contributed|Statechart
 https://github.com/Jueff/AddressLearnMLX.git|Contributed|AddressLearnMLX
 https://github.com/AvantMaker/AvantLumi.git|Contributed|AvantLumi
-https://github.com/Rafeul1997/Universal_Blink.git|Contributed|Universal Blink
 https://github.com/IdlanZafran/RemoteUpload.git|Contributed|RemoteUpload
 https://github.com/ArtronShop/DuinoClaw.git|Contributed|DuinoClaw
 https://github.com/CodexPad/codex_pad_frame_decoder_arduino_lib.git|Contributed|CodexPadFrameDecoder


### PR DESCRIPTION
Due to unacceptable behavior (see https://github.com/arduino/library-registry/pull/8337#pullrequestreview-4270053083), this library maintainer's Arduino Library Registry privileges have been permanently revoked.

Companion to https://github.com/arduino/library-registry/pull/8405