### PR TITLE
Remove "Universal Blink"

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -9418,7 +9418,6 @@ https://github.com/Rafeul1997/NTCTemp
 https://github.com/Rafeul1997/AutoLCD
 https://github.com/NikolaiRadke/TinyRTOS
 https://github.com/AvantMaker/AvantLumi
-https://github.com/Rafeul1997/Universal_Blink
 https://github.com/IdlanZafran/RemoteUpload
 https://github.com/ArtronShop/DuinoClaw
 https://github.com/CodexPad/codex_pad_frame_decoder_arduino_lib


### PR DESCRIPTION
Due to unacceptable behavior (see https://github.com/arduino/library-registry/pull/8337#pullrequestreview-4270053083), this library maintainer's Arduino Library Registry privileges have been permanently revoked.