### PR TITLE
Remove "OTAxpress"

### DIFF
--- a/registry.txt
+++ b/registry.txt
@@ -9422,7 +9422,6 @@ https://github.com/LaskaKit/laskakit_zivyobraz_client.git|Contributed|LaskakitZi
 https://github.com/emakefun-arduino-library/cq01.git|Contributed|CQ01
 https://github.com/mumanchu/SerialRGBLed.git|Contributed|SerialRGBLed
 https://github.com/apadevices/APADOSE.git|Contributed|APA-Dose
-https://github.com/Rafeul-1997/OTAxpress.git|Contributed|OTAxpress
 https://github.com/Rafeul-1997/ESP32_WebGPIO.git|Contributed|ESP32_WebGPIO
 https://github.com/Parvaz-Jamei/EcoSensePower-Arduino.git|Contributed|EcoSensePower
 https://github.com/mumanchu/W25QxxFlash.git|Contributed|WS25QxxFlash


### PR DESCRIPTION
Due to unacceptable behavior (see https://github.com/arduino/library-registry/pull/8337#pullrequestreview-4270053083), this library maintainer's Arduino Library Registry privileges have been permanently revoked.

Companion to https://github.com/arduino/library-registry/pull/8407