### PR TITLE
Remove "OTAxpress"

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -9437,7 +9437,6 @@ https://github.com/cyfney/easy_i2c
 https://github.com/CITROMOSEPER/MIDIplayer
 https://github.com/LaskaKit/laskakit_zivyobraz_client
 https://github.com/emakefun-arduino-library/cq01
-https://github.com/Rafeul-1997/OTAxpress
 https://github.com/Rafeul-1997/ESP32_WebGPIO
 https://github.com/Parvaz-Jamei/EcoSensePower-Arduino
 https://github.com/Alexandros-Charitonidis/MiniMessenger


### PR DESCRIPTION
Due to unacceptable behavior (see https://github.com/arduino/library-registry/pull/8337#pullrequestreview-4270053083), this library maintainer's Arduino Library Registry privileges have been permanently revoked.