### PR TITLE
Add PersianDate library by Hamidreza Milaninia

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -9458,3 +9458,4 @@ https://github.com/soosp/RunningStatistics
 https://github.com/Protocentral/protocentral_fdc2214_arduino
 https://github.com/birmanish/PID_5_Sensors
 https://github.com/abinantony01/ViSPE-ADIN1110
+https://github.com/ARDUnia/PersianDate.git


### PR DESCRIPTION
This PR adds the PersianDate library (v1.1.0) for converting Gregorian dates to Persian (Jalali) dates. The library provides formatted date strings, month/weekday names, and is compatible with RTClib. The algorithm is verified and tested for years 2000–2100 CE.

Repository: https://github.com/ARDUnia/PersianDate