### PR TITLE
Add XLOT_QuadSwitch library

### DIFF
--- a/libraries/XLOT_QuadSwitch.txt
+++ b/libraries/XLOT_QuadSwitch.txt
@@ -1,1 +1,0 @@
-https://github.com/felixlubenben/XLOT_QuadSwitch

--- a/libraries/XLOT_QuadSwitch.txt
+++ b/libraries/XLOT_QuadSwitch.txt
@@ -1,0 +1,1 @@
+https://github.com/felixlubenben/XLOT_QuadSwitch

--- a/repositories.txt
+++ b/repositories.txt
@@ -9474,3 +9474,4 @@ https://github.com/haukex/arduino-ascon128
 https://github.com/hmackowski/N64Controller-ESP32.git
 https://github.com/han-sunghyun/Arduino_Linker_Library
 https://github.com/Terry-Gould/ACANFD_SAME
+https://github.com/felixlubenben/XLOT_QuadSwitch


### PR DESCRIPTION
## Library Submission

**Library name:** XLOT_QuadSwitch
**Repository:** https://github.com/felixlubenben/XLOT_QuadSwitch

This is an Arduino library for the XLOT QuadSwitch module - a 4-channel switch module with RGB LED effects support.

### Library structure
- `src/XLOT_QuadSwitch.h` and `src/XLOT_QuadSwitch.cpp` - Library source
- `examples/` - Example sketches
- `library.properties` - Metadata
- `keywords.txt` - Syntax highlighting

Please add this library to the Arduino Library Manager. Thank you!