### PR TITLE
Add MaxMatrix repository link to repositories.txt

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -9477,3 +9477,4 @@ https://github.com/Terry-Gould/ACANFD_SAME
 https://github.com/felixlubenben/XLOT_QuadSwitch
 https://github.com/Terry-Gould/CANMessageSignal
 https://github.com/Fl-project123/Hijri_date
+https://github.com/AndreasBur/MaxMatrix

--- a/repositories.txt
+++ b/repositories.txt
@@ -9477,4 +9477,4 @@ https://github.com/Terry-Gould/ACANFD_SAME
 https://github.com/felixlubenben/XLOT_QuadSwitch
 https://github.com/Terry-Gould/CANMessageSignal
 https://github.com/Fl-project123/Hijri_date
-https://github.com/AndreasBur/MaxMatrix
+https://github.com/superminyon/MaxMatrix


### PR DESCRIPTION
Pull request to add the MaxMatrix library to the Arduino Library Manager.
Original repository: https://github.com/AndreasBur/MaxMatrix