### PR TITLE
Add new repository link for SPD_Arduino

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -9484,3 +9484,4 @@ https://github.com/felixlubenben/XLOT_QuadSwitch
 https://github.com/Terry-Gould/CANMessageSignal
 https://github.com/Fl-project123/Hijri_date
 https://github.com/mahdi-misk/EasyWiFiMDNS
+https://github.com/spdrw/SPD_Arduino


### PR DESCRIPTION
SPD_Arduino is an Arduino library for reading/writing EEPROM / Serial Presence Detect (SPD) chips, lightly wrapped for the ESP32 / Arduino platform. The library communicates with SPD devices over I2C and provides simple initialization, read and write interfaces, making it easy to retrieve memory module information or operate small I2C EEPROMs in firmware,Currently, only DDR4 and lower are supported.