### PR TITLE
Add DiFinders library

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -9168,6 +9168,7 @@ https://github.com/BOTCLibs/BrgOfTheCyber_SCD4x
 https://github.com/ayatec-europe/AyatecSensoraya2.x
 https://github.com/moddoio/moddoMOUSE-Arduino
 https://github.com/adafruit/Adafruit_APDS9999.git
+https://github.com/dunknowcoding/DiFinders
 https://github.com/dunknowcoding/RoboServo.git
 https://github.com/CostelloTechnical/DN24F08.git
 https://github.com/KovalRM/KRM_libraries_Arduino


### PR DESCRIPTION
## Summary

Submit [DiFinders](https://github.com/dunknowcoding/DiFinders) for inclusion in the Arduino Library Manager index.

- **Repository:** https://github.com/dunknowcoding/DiFinders
- **Release tag:** v0.1.0 (matches `version=0.1.0` in library.properties)
- **Category:** Sensors — distance, ToF, IR, mmWave, PIR, Modbus, CAN modules for Arduino-compatible boards

## Library structure

- `library.properties` at repository root
- `src/DiFinders.h` umbrella include
- `examples/` — English sketches using `read()` + `SensorStatus`
- MIT license

## Maintainer

@dunknowcoding — will follow up on any @ArduinoBot feedback promptly.
