### PR TITLE
Add DadosCorp + DadosCorpCore

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -9496,3 +9496,6 @@ https://github.com/ulywae/NeuDB
 https://github.com/soosp/HttpDigestAuth
 https://github.com/aynka/DdsOscillator
 https://github.com/BindThings/bindthings-arduino
+
+https://github.com/edilsonmaia/DadosCorpCore
+https://github.com/edilsonmaia/DadosCorp


### PR DESCRIPTION
Add two official Arduino libraries for the DadosCorp IoT platform:

- **DadosCorpCore** — Universal HMAC-SHA256 + JSON helpers, zero network deps. 100+ devices, 22+ architectures.
- **DadosCorp** — ESP32/ESP8266 plug-and-play. WiFi, TLS, HMAC, telemetry, commands — all in 1 include.

Both follow Arduino 1.5 library spec (rev 2.2). MIT license. Tags v1.0.0 published.