### PR TITLE
Add BetterMenu library

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -5970,6 +5970,7 @@ https://github.com/ricmoo/QRCode
 https://github.com/ridencww/cww_MorseTx
 https://github.com/rileyjshaw/Seg16
 https://github.com/ripred/Bang
+https://github.com/ripred/BetterMenu
 https://github.com/ripred/ButtonGestures
 https://github.com/ripred/CompileTime
 https://github.com/ripred/CPUTemp


### PR DESCRIPTION
Adds the BetterMenu library repository to the Arduino Library Manager registry.

Library repository: https://github.com/ripred/BetterMenu
Tagged release: https://github.com/ripred/BetterMenu/releases/tag/0.5.0

Pre-submission checks run locally:
- arduino-lint --project-type library --compliance strict --library-manager submit /Users/trent/Documents/BetterMenu
- arduino-cli compile --warnings all --fqbn arduino:avr:uno --library . examples/SerialMenu
- arduino-cli compile --warnings all --fqbn arduino:avr:uno --library . examples/DirectButtonsSerial
- arduino-cli compile --warnings all --fqbn arduino:avr:uno --library . examples/MultiLevelSingleDeclaration
- arduino-cli compile --warnings all --fqbn arduino:avr:uno --library . examples/HD44780Buttons