### PR TITLE
Add new repository links for sim racing UDP libraries

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -9521,3 +9521,10 @@ https://github.com/takkaO/OpenFontRender.git
 https://github.com/ARAM-USA-Support/ARAM_Toggle_Actuator
 https://github.com/wk1093/CrossScheduler
 https://github.com/soosp/Host
+https://github.com/MacManley/f1-23-udp
+https://github.com/MacManley/f1-24-udp
+https://github.com/MacManley/f1-25-udp
+https://github.com/MacManley/f1-26-udp
+https://github.com/MacManley/gt7-udp
+https://github.com/MacManley/assetto-corsa-udp
+https://github.com/MacManley/project-cars-2-udp


### PR DESCRIPTION
The added libraries provide packaged libraries for ESP32 and ESP8266 compatible boards to receive telemetry data from various simulation games such as Gran Turismo 7, Assetto Corsa, and the F1 series. The data can be used to create custom dashboards or DIY motion rigs.