### PR TITLE
Add Nius ArduinoNRF companion libraries

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -9182,6 +9182,8 @@ https://github.com/ayatec-europe/AyatecSensoraya2.x
 https://github.com/moddoio/moddoMOUSE-Arduino
 https://github.com/adafruit/Adafruit_APDS9999.git
 https://github.com/dunknowcoding/DiFinders
+https://github.com/dunknowcoding/ArduinoNRF-IMU
+https://github.com/dunknowcoding/ArduinoNRF-Zigbee
 https://github.com/dunknowcoding/RoboServo.git
 https://github.com/CostelloTechnical/DN24F08.git
 https://github.com/KovalRM/KRM_libraries_Arduino


### PR DESCRIPTION
This PR adds two ArduinoNRF companion libraries to Library Manager:

- https://github.com/dunknowcoding/ArduinoNRF-IMU
- https://github.com/dunknowcoding/ArduinoNRF-Zigbee

Compliance checks completed before submission:

- `arduino-lint --compliance strict --library-manager submit F:\Arduino\driver\ArduinoNRF-IMU` -> no errors or warnings
- `arduino-lint --compliance strict --library-manager submit F:\Arduino\driver\ArduinoNRF-Zigbee` -> no errors or warnings

Tagged releases are available:

- NiusIMU 0.2.1: https://github.com/dunknowcoding/ArduinoNRF-IMU/releases/tag/v0.2.1
- NiusZigbee 0.1.1: https://github.com/dunknowcoding/ArduinoNRF-Zigbee/releases/tag/v0.1.1

The Library Manager display names intentionally do not start with Arduino:

- `name=NiusIMU`
- `name=NiusZigbee`