### PR TITLE
Add NiusThread repository link

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -9539,3 +9539,4 @@ https://github.com/Protocentral/protocentral_tmf8829_arduino
 https://github.com/Gershy13/dtc-lookup
 https://github.com/ardunia/TTP223Row
 https://github.com/devjune-apiota/apiota-esp32
+https://github.com/dunknowcoding/ArduinoNRF-Thread


### PR DESCRIPTION
Adding the NiusThread library: Thread (OpenThread) IPv6 mesh networking on the nRF52840's native 2.4 GHz radio, for the ArduinoNRF board package.

- Repository: https://github.com/dunknowcoding/ArduinoNRF-Thread
- Published name: NiusThread (release tag 0.1.0)
- Companion library to the already-indexed NiusIMU / NiusZigbee (same maintainer)

I have read the [FAQ](https://github.com/arduino/library-registry/blob/main/FAQ.md#readme) and the requirements listed there are met.