### PR TITLE
Add Time64 library

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -9544,3 +9544,4 @@ https://github.com/dmdengineeringllc/DMD_AllocTrace
 https://github.com/dunknowcoding/ArduinoNRF-Thread
 https://github.com/OperatorFoundation/AudioCodec
 https://github.com/m5stack/M5Hat-Mini-JoyC
+https://github.com/pjscruggs/Time64


### PR DESCRIPTION
Adds the Time64 Arduino library to Library Manager.

Repository: https://github.com/pjscruggs/Time64
Release tag: v1.6.2
Library name: Time64

Validation performed locally against a clean tracked-file export:
- `arduino-lint --library-manager submit`: 0 errors, 2 warnings
- Scratch host tests: pass
- Arduino CLI compile smoke tests for Uno and Mega: pass

The lint warnings are for the inherited lack of a root license file and the inherited Processing `.pde` example extension.