### PR TITLE
Add NiusCrypto (ArduinoNRF-Crypto)

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -9185,6 +9185,7 @@ https://github.com/ayatec-europe/AyatecSensoraya2.x
 https://github.com/moddoio/moddoMOUSE-Arduino
 https://github.com/adafruit/Adafruit_APDS9999.git
 https://github.com/dunknowcoding/DiFinders
+https://github.com/dunknowcoding/ArduinoNRF-Crypto
 https://github.com/dunknowcoding/ArduinoNRF-IMU
 https://github.com/dunknowcoding/ArduinoNRF-Zigbee
 https://github.com/dunknowcoding/RoboServo.git


### PR DESCRIPTION
## Library submission: NiusCrypto

**Repository:** https://github.com/dunknowcoding/ArduinoNRF-Crypto

**Library name (library.properties):** `NiusCrypto`

**Latest release tag:** [v0.3.1](https://github.com/dunknowcoding/ArduinoNRF-Crypto/releases/tag/v0.3.1)

### Description

Hardware-accelerated cryptography for the **ArduinoNRF** nRF52840 board package (CryptoCell 310 / CC310). Provides SHA-256/512, HMAC, AES-CBC/CTR/GCM, ECDSA/ECDH P-256, and TRNG via a unified `Crypto` API with automatic on-chip fallback when Nordic binaries are not vendored locally.

Requires the [ArduinoNRF](https://github.com/dunknowcoding/ArduinoNRF) core (`architectures=nrf52`). Related in-package shim: `libraries/CC310/` on ArduinoNRF forwards `#include <NrfCC310.h>` to this library.

### Compliance notes

- Apache-2.0 licensed; no `.exe`, symlinks, or `.development` file
- `library.properties` in repository root
- Compiles on CI without vendored Nordic blobs (on-chip fallback); `precompiled=true` is optional when users import CRYS/Oberon locally
- Other libraries from the same maintainer already indexed: NiusIMU, NiusThread, ArduinoNRF-Zigbee

### Checklist

- [x] GitHub release tag present (v0.3.1)
- [x] Library specification compliant
- [x] Name does not start with `Arduino`
- [x] Potential value to Arduino community (nRF52840 crypto)

Thank you!