### PR TITLE
Add SJSArray

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -9547,3 +9547,4 @@ https://github.com/OperatorFoundation/AudioCodec
 https://github.com/m5stack/M5Hat-Mini-JoyC
 https://github.com/pjscruggs/Time64
 https://github.com/bluerobotics/BlueRobotics_TMP119_Library
+https://github.com/jshaw/SJSArray


### PR DESCRIPTION
Adding SJSArray — a bounds-safe wrapper for raw C++ arrays with utility functions (min, max, sum, average, contains, indexOf, fill, sorting) and range-based for-loop support.

Repo: https://github.com/jshaw/SJSArray
Latest tag: v1.5.0

Passes `arduino-lint --library-manager submit --compliance strict` with 0 errors, 0 warnings.