### PR TITLE
Add TLC5947_SplitLatch

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -9546,5 +9546,6 @@ https://github.com/dunknowcoding/ArduinoNRF-Thread
 https://github.com/OperatorFoundation/AudioCodec
 https://github.com/m5stack/M5Hat-Mini-JoyC
 https://github.com/pjscruggs/Time64
+https://github.com/pjscruggs/TLC5947_SplitLatch
 https://github.com/bluerobotics/BlueRobotics_TMP119_Library
 https://github.com/jshaw/SJSArray


### PR DESCRIPTION
Adds the public repository for TLC5947_SplitLatch to the Arduino Library Manager registry.\n\nLibrary repository: https://github.com/pjscruggs/TLC5947_SplitLatch\nRelease tag: https://github.com/pjscruggs/TLC5947_SplitLatch/releases/tag/1.3.0\n\nLocal validation:\n- arduino-lint --project-type library --compliance strict --library-manager submit\n- arduino-cli compile --fqbn arduino:avr:uno --library . .\\examples\\tlc5947test\\tlc5947test.ino