### PR TITLE
Add Timezone64

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -9546,6 +9546,7 @@ https://github.com/dunknowcoding/ArduinoNRF-Thread
 https://github.com/OperatorFoundation/AudioCodec
 https://github.com/m5stack/M5Hat-Mini-JoyC
 https://github.com/pjscruggs/Time64
+https://github.com/pjscruggs/Timezone64
 https://github.com/pjscruggs/TLC5947_SplitLatch
 https://github.com/bluerobotics/BlueRobotics_TMP119_Library
 https://github.com/jshaw/SJSArray


### PR DESCRIPTION
Adds the public Timezone64 library repository to the Arduino Library Manager registry.\n\nLibrary repository: https://github.com/pjscruggs/Timezone64\nRelease tag: https://github.com/pjscruggs/Timezone64/releases/tag/1.3.0\n\nLocal validation:\n- arduino-lint --project-type library --compliance strict --library-manager submit\n- arduino-cli compile --fqbn arduino:avr:uno --library . --library ..\\Time64 .\\examples\\Greenland\\Greenland.ino\n- arduino-cli compile --fqbn arduino:avr:uno --library . --library ..\\Time64 .\\examples\\tzTest\\tzTest.ino