### PR TITLE
Add NeoGPS-GarminClock library

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -9547,6 +9547,7 @@ https://github.com/OperatorFoundation/AudioCodec
 https://github.com/m5stack/M5Hat-Mini-JoyC
 https://github.com/pjscruggs/Time64
 https://github.com/pjscruggs/Timezone64
+https://github.com/pjscruggs/NeoGPS-GarminClock
 https://github.com/pjscruggs/TLC5947_SplitLatch
 https://github.com/bluerobotics/BlueRobotics_TMP119_Library
 https://github.com/jshaw/SJSArray


### PR DESCRIPTION
Adds https://github.com/pjscruggs/NeoGPS-GarminClock to the Arduino Library Manager registry.\n\nThe library is a GPL-3.0-or-later fork of NeoGPS configured for Garmin GPS 18x LVC clock projects, with PGRMF leap-second parsing and Timezone64 compatibility.