### PR TITLE
Add Fluxgrid

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -9553,3 +9553,4 @@ https://github.com/bluerobotics/BlueRobotics_TMP119_Library
 https://github.com/jshaw/SJSArray
 
 https://github.com/superdmz/SuperDMZ-Arduino
+https://github.com/Lonely-Binary/FluxGrid


### PR DESCRIPTION
Adding the Fluxgrid library — a dead-simple ESP32 client for the Fluxgrid IoT platform.

Repository: https://github.com/Lonely-Binary/FluxGrid

- `library.properties` at repo root, version 0.9.1, tagged `v0.9.1`
- Passes `arduino-lint --library-manager submit --compliance specification` with 0 errors, 0 warnings
- MIT licensed