### PR TITLE
Add RPCToolkit library

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -9555,3 +9555,4 @@ https://github.com/jshaw/SJSArray
 https://github.com/superdmz/SuperDMZ-Arduino
 https://github.com/Lonely-Binary/FluxGrid
 https://github.com/lasselukkari/ArduinoJsonLogic
+https://github.com/n-car/rpc-arduino-toolkit


### PR DESCRIPTION
Adds RPCToolkit to Arduino Library Manager.\n\nLibrary repository: https://github.com/n-car/rpc-arduino-toolkit\nRelease tag: https://github.com/n-car/rpc-arduino-toolkit/releases/tag/v1.0.0