### PR TITLE
Add Lonely Binary Coin Acceptor library

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -9556,3 +9556,4 @@ https://github.com/superdmz/SuperDMZ-Arduino
 https://github.com/Lonely-Binary/FluxGrid
 https://github.com/lasselukkari/ArduinoJsonLogic
 https://github.com/n-car/rpc-arduino-toolkit
+https://github.com/Lonely-Binary/Coin-Acceptor


### PR DESCRIPTION
Adds the Lonely Binary Coin Acceptor Arduino library to Library Manager.

Repository: https://github.com/Lonely-Binary/Coin-Acceptor
Release: https://github.com/Lonely-Binary/Coin-Acceptor/releases/tag/1.0.0