### PR TITLE
Add HW827_PPG library

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -1,3 +1,4 @@
+https://github.com/gevindug/HW827_PPG
 https://github.com/Vean/FansElectronics_DMD32
 https://github.com/MaratDevT/SimpleCode
 https://github.com/GavinnnTann/HLK-ZW-Fingerprint-Sensor


### PR DESCRIPTION
This pull request adds the HW827_PPG Arduino library to the Library Manager registry.

HW827_PPG provides signal processing and heart-rate detection for the HW-827 PPG/pulse sensor module. The library outputs the raw ADC signal, baseline-corrected filtered PPG signal, differentiated signal, pulse markers, and filtered BPM. It uses baseline correction, smoothing, differentiation-based pulse detection, and abnormal BPM rejection.

Repository:
https://github.com/YOUR_USERNAME/HW827_PPG