### PR TITLE
Add VirtuinoCloud library

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -9561,3 +9561,4 @@ https://github.com/n-car/rpc-arduino-toolkit
 https://github.com/Lonely-Binary/Coin-Acceptor
 https://github.com/zenopcb/zenopcb-iot-platform.git
 https://github.com/HiTECH-Corporation/R4-WifiManager.git
+https://github.com/iliaslamprou/VirtuinoCloud


### PR DESCRIPTION
Library for the Virtuino Cloud IoT platform.

- Repository: https://github.com/iliaslamprou/VirtuinoCloud
- Supports: ESP32, ESP8266, Uno WiFi Rev2, MKR WiFi 1010, Nano 33 IoT, Nano RP2040 Connect
- Arduino Library Manager compliant (library.properties included)