### PR TITLE
Remove libraries: Virtuino, virtuinoESP, virtuino_stm32

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -3682,10 +3682,7 @@ https://github.com/igvina/ArdVoice
 https://github.com/IharYakimush/arduino-temperature-control-events
 https://github.com/ihormelnyk/opentherm_library
 https://github.com/iitaka1142/NullSerial
-https://github.com/iliaslamprou/virtuino
-https://github.com/iliaslamprou/virtuino_stm32
 https://github.com/iliaslamprou/virtuinoCM
-https://github.com/iliaslamprou/virtuinoESP
 https://github.com/ILoveMemes/SoftwareTimer
 https://github.com/iMakeOfficial/iMakeBeta
 https://github.com/imax9000/Arduino-PID-Library


### PR DESCRIPTION
Removing this library as it is no longer maintained.

Repository: https://github.com/iliaslamprou/virtuino
Repository: https://github.com/iliaslamprou/virtuinoESP
Repository: https://github.com/iliaslamprou/virtuino_stm32