### PR TITLE
Add VN_LCD library

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -9574,3 +9574,4 @@ https://github.com/levkovigor/AODV
 https://github.com/emakefun-arduino-library/aq01
 https://github.com/robiduck/Raphael
 https://github.com/sparkfun/SparkFun_MCP4725_Arduino_Library
+https://github.com/HuuPhuoc2411/VN_LCD


### PR DESCRIPTION
This pull request adds the VN_LCD Arduino library to the Arduino Library Manager registry.

Repository:
https://github.com/HuuPhuoc2411/VN_LCD