### PR TITLE
Add IoTDataHub library

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -1,4 +1,4 @@
-﻿https://github.com/Vean/FansElectronics_DMD8266
+ttps://github.com/Vean/FansElectronics_DMD8266
 https://github.com/You-010/HCSR04_ESP_Hardware
 https://github.com/gevindug/HW827_PPG
 https://github.com/Vean/FansElectronics_DMD32

--- a/repositories.txt
+++ b/repositories.txt
@@ -1,4 +1,4 @@
-ttps://github.com/Vean/FansElectronics_DMD8266
+https://github.com/Vean/FansElectronics_DMD8266
 https://github.com/You-010/HCSR04_ESP_Hardware
 https://github.com/gevindug/HW827_PPG
 https://github.com/Vean/FansElectronics_DMD32

--- a/repositories.txt
+++ b/repositories.txt
@@ -1,4 +1,4 @@
-https://github.com/Vean/FansElectronics_DMD8266
+﻿https://github.com/Vean/FansElectronics_DMD8266
 https://github.com/You-010/HCSR04_ESP_Hardware
 https://github.com/gevindug/HW827_PPG
 https://github.com/Vean/FansElectronics_DMD32
@@ -9579,3 +9579,6 @@ https://github.com/robiduck/Raphael
 https://github.com/sparkfun/SparkFun_MCP4725_Arduino_Library
 https://github.com/HuuPhuoc2411/VN_LCD
 https://github.com/engeen-nl/Arduino-TLE75080
+https://github.com/iotpioneers/iotdatahub-library
+
+


### PR DESCRIPTION
Add the IoTDataHub Arduino client library to the registry.

- Repository: https://github.com/iotpioneers/iotdatahub-library
- Current version: 1.1.0
- Category: Communication
- Architectures: esp32, esp8266, rp2040, samd, nrf52, avr, stm32
- Depends: PubSubClient
