### PR TITLE
Add EspNowLink library

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -9581,5 +9581,6 @@ https://github.com/sparkfun/SparkFun_MCP4725_Arduino_Library
 https://github.com/HuuPhuoc2411/VN_LCD
 https://github.com/engeen-nl/Arduino-TLE75080
 https://github.com/iotpioneers/iotdatahub-library
+https://github.com/figamore/EspNowLink
 
 


### PR DESCRIPTION
Adds EspNowLink to the Arduino Library Manager registry.

EspNowLink is an ESP32 library for paired, encrypted ESP-NOW client/server links with NVS profile storage, reconnect handling, multi-client server support, and Arduino/PlatformIO-compatible examples.

Repository: https://github.com/figamore/EspNowLink
License: Apache-2.0