### PR TITLE
Update name and URL of "firmngin"

### DIFF
--- a/registry.txt
+++ b/registry.txt
@@ -7765,7 +7765,7 @@ https://github.com/francescop75/LCD_TeleType.git|Contributed|LCD_TeleType
 https://github.com/ArduLite/ArduLite.git|Contributed|ArduLite
 https://github.com/electrocoder/MBModbusRTUSlave.git|Contributed|MBModbusRTUSlave
 https://github.com/Rupakpoddar/ConsumerKeyboard.git|Contributed|ConsumerKeyboard
-https://github.com/firmngin/firmnginKit.git|Contributed|firmngin
+https://github.com/firmngin/Firmngin-Arduino.git|Contributed|firmngin
 https://github.com/DigitalFuturesOCADU/YouveBeenNotified.git|Contributed|YouveBeenNotified
 https://github.com/styropyr0/SensorHub.git|Contributed|SensorHub
 https://github.com/Khuuxuanngoc/Makerlabvn_I2C_Line_Follower_Sensor.git|Contributed|Makerlabvn_I2C_Line_Follower_Sensor

--- a/registry.txt
+++ b/registry.txt
@@ -7765,7 +7765,7 @@ https://github.com/francescop75/LCD_TeleType.git|Contributed|LCD_TeleType
 https://github.com/ArduLite/ArduLite.git|Contributed|ArduLite
 https://github.com/electrocoder/MBModbusRTUSlave.git|Contributed|MBModbusRTUSlave
 https://github.com/Rupakpoddar/ConsumerKeyboard.git|Contributed|ConsumerKeyboard
-https://github.com/firmngin/firmnginKit.git|Contributed|firmnginKit
+https://github.com/firmngin/firmnginKit.git|Contributed|firmngin
 https://github.com/DigitalFuturesOCADU/YouveBeenNotified.git|Contributed|YouveBeenNotified
 https://github.com/styropyr0/SensorHub.git|Contributed|SensorHub
 https://github.com/Khuuxuanngoc/Makerlabvn_I2C_Line_Follower_Sensor.git|Contributed|Makerlabvn_I2C_Line_Follower_Sensor


### PR DESCRIPTION
This PR consists of two changes:

- Change URL from `https://github.com/firmngin/firmnginKit.git` to `https://github.com/firmngin/Firmngin-Arduino.git` (companion to https://github.com/arduino/library-registry/pull/8530).
- Change name from `firmnginKit` to `firmngin` (resolves https://github.com/arduino/library-registry/issues/8531)

Since the name change operation on the database is actually a removal followed by automated re-indexing on the next job run, the URL update will occur as a matter of course. For this reason, the only operation required from the backend maintainer is a standard name change procedure.