### PR TITLE
Remove "Virtuino library for all ESP8266 and ESP32 boards"

### DIFF
--- a/registry.txt
+++ b/registry.txt
@@ -2249,7 +2249,6 @@ https://github.com/smaffer/espvgax.git|Contributed|ESPVGAX
 https://github.com/neosarchizo/cm1106_i2c.git|Contributed|CM1106 I2C
 https://github.com/GiorgosXou/NeuralNetworks.git|Contributed|NeuralNetwork
 https://github.com/boxtec/Witty.git|Contributed|Witty
-https://github.com/iliaslamprou/virtuinoESP.git|Contributed|Virtuino library for all ESP8266 and ESP32 boards
 https://github.com/iliaslamprou/virtuino_stm32.git|Contributed|Virtuino library for STM32 boards
 https://github.com/guru-florida/PWMFreak.git|Contributed|PWMFreak
 https://github.com/H-Kurosaki/UARDECS.git|Contributed|UARDECS Library


### PR DESCRIPTION
Companion to https://github.com/arduino/library-registry/pull/8542