### PR TITLE
add XPoint base URL to repositories.txt

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -9583,4 +9583,5 @@ https://github.com/engeen-nl/Arduino-TLE75080
 https://github.com/iotpioneers/iotdatahub-library
 https://github.com/figamore/EspNowLink
 https://github.com/Sakuhano/JoystickProtocol
+https://github.com/dstroy0/XPoint
 


### PR DESCRIPTION
XPoint is a hardware agnostic unified crosspoint driver. Includes unit tests and reports.