### PR TITLE
Add PCBCUPID-NAU8325 repository link

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -9585,4 +9585,4 @@ https://github.com/iotpioneers/iotdatahub-library
 https://github.com/figamore/EspNowLink
 https://github.com/Sakuhano/JoystickProtocol
 https://github.com/dstroy0/XPoint
-
+https://github.com/pcbcupid/PCBCUPID-NAU8325


### PR DESCRIPTION
name=PCBCUPID-NAU8325
version=1.0.0
author=Karthik Elumalai <codingkarthik2@gmail.com>
maintainer=PCBCUPID <hello@pcbcupid.com>
sentence=Arduino library for the PCBCUPID NAU8325 audio amplifier + AMP.
paragraph= Library to run the PCBCUPID NAU8325 audio amplifier + AMP. It provides functions to control the amplifier, adjust volume, and manage audio playback.
category=Audio
url=https://github.com/pcbcupid/PCBCUPID-NAU8325
architectures=esp32