### PR TITLE
Add repository link for PCBCUPID-MCP79412

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -9587,3 +9587,4 @@ https://github.com/figamore/EspNowLink
 https://github.com/Sakuhano/JoystickProtocol
 https://github.com/dstroy0/XPoint
 https://github.com/pcbcupid/PCBCUPID-NAU8325
+https://github.com/pcbcupid/PCBCUPID-MCP79412

--- a/repositories.txt
+++ b/repositories.txt
@@ -9585,4 +9585,4 @@ https://github.com/iotpioneers/iotdatahub-library
 https://github.com/figamore/EspNowLink
 https://github.com/Sakuhano/JoystickProtocol
 https://github.com/dstroy0/XPoint
-
+https://github.com/pcbcupid/PCBCUPID-NAU8325


### PR DESCRIPTION
name=PCBCUPID_MCP79412RTC
version=1.0.0
author=Karthik Elumalai <codingkarthik2@gmail.com>
maintainer=PCBCUPID <hello@pcbcupid.com>
sentence=Arduino library for the Microchip MCP79411/12 Real-Time Clock/Calendar.
paragraph=Requires PJRC's improved Arduino Time Library, https://github.com/PaulStoffregen/Time
category=Timing
url=https://github.com/pcbcupid/PCBCUPID-MCP79412
architectures=esp32
depends=Time