### PR TITLE
Update name and URL of "JoystickButton"

### DIFF
--- a/registry.txt
+++ b/registry.txt
@@ -9575,7 +9575,7 @@ https://github.com/UNIT-Electronics-MX/unit_devlab_veml7700_library.git|Contribu
 https://github.com/iotpioneers/iotdatahub-library.git|Contributed|IoTDataHub
 https://github.com/tkhoi0821-svg/GrayKazu.git|Contributed|GrayKazu
 https://github.com/figamore/EspNowLink.git|Contributed|EspNowLink
-https://github.com/Sakuhano/JoystickProtocol.git|Contributed|JoystickButton
+https://github.com/Sakuhano/JoystickButton.git|Contributed|JoystickButton
 https://github.com/dstroy0/XPoint.git|Contributed|XPoint
 https://github.com/tanakamasayuki/PCMFlowDevice.git|Contributed|PCMFlowDevice
 https://github.com/pcbcupid/PCBCUPID-NAU8325.git|Contributed|PCBCUPID-NAU8325

--- a/registry.txt
+++ b/registry.txt
@@ -9575,7 +9575,7 @@ https://github.com/UNIT-Electronics-MX/unit_devlab_veml7700_library.git|Contribu
 https://github.com/iotpioneers/iotdatahub-library.git|Contributed|IoTDataHub
 https://github.com/tkhoi0821-svg/GrayKazu.git|Contributed|GrayKazu
 https://github.com/figamore/EspNowLink.git|Contributed|EspNowLink
-https://github.com/Sakuhano/JoystickProtocol.git|Contributed|JoystickProtocol
+https://github.com/Sakuhano/JoystickProtocol.git|Contributed|JoystickButton
 https://github.com/dstroy0/XPoint.git|Contributed|XPoint
 https://github.com/tanakamasayuki/PCMFlowDevice.git|Contributed|PCMFlowDevice
 https://github.com/pcbcupid/PCBCUPID-NAU8325.git|Contributed|PCBCUPID-NAU8325


### PR DESCRIPTION
This PR consists of two changes:

- Change URL from `https://github.com/Sakuhano/JoystickProtocol.git` to `https://github.com/Sakuhano/JoystickButton.git` (companion to https://github.com/arduino/library-registry/pull/8577).
- Change name from `JoystickProtocol` to `JoystickButton` (resolves https://github.com/arduino/library-registry/issues/8578)

Since the name change operation on the database is actually a removal followed by automated re-indexing on the next job run, the URL update will occur as a matter of course. For this reason, the only operation required from the backend maintainer is a standard name change procedure.