### PR TITLE
Add VN_VOICE library

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -9592,3 +9592,4 @@ https://github.com/pcbcupid/PCBCUPID-MCP79412
 https://github.com/pcbcupid/PCBCUPID-PLAYER
 https://github.com/dstroy0/DeterministicESPAsyncWebServer
 https://github.com/OneDevelopmentPL/EasyIR
+https://github.com/HuuPhuoc2411/VN_VOICE


### PR DESCRIPTION
This pull request adds the VN_VOICE Arduino library to the Arduino Library Manager registry.

Repository:
https://github.com/HuuPhuoc2411/VN_VOICE