### PR TITLE
Update name and URL of "MicroTaskX"

### DIFF
--- a/registry.txt
+++ b/registry.txt
@@ -9587,7 +9587,7 @@ https://github.com/OneDevelopmentPL/EasyIR.git|Contributed|EasyIR
 https://github.com/nananauno/M5GuruguruAvatar.git|Contributed|M5GuruguruAvatar
 https://github.com/HuuPhuoc2411/VN_VOICE.git|Contributed|VN_VOICE
 https://github.com/vic4key/MyOTA.git|Contributed|MyOTA
-https://github.com/Moaaz-i/UMOZ.git|Contributed|UMOZ
+https://github.com/Moaaz-i/UMOZ.git|Contributed|MicroTaskX
 https://github.com/NodeWave-EA/FOTA-Client-ESP32.git|Contributed|FOTA-Client-ESP32
 https://github.com/fun6400/Adafruit_SSD1306_72x40.git|Contributed|Adafruit_SSD1306_72x40
 https://github.com/fun6400/PipeGIF.git|Contributed|PipeGIF

--- a/registry.txt
+++ b/registry.txt
@@ -9587,7 +9587,7 @@ https://github.com/OneDevelopmentPL/EasyIR.git|Contributed|EasyIR
 https://github.com/nananauno/M5GuruguruAvatar.git|Contributed|M5GuruguruAvatar
 https://github.com/HuuPhuoc2411/VN_VOICE.git|Contributed|VN_VOICE
 https://github.com/vic4key/MyOTA.git|Contributed|MyOTA
-https://github.com/Moaaz-i/UMOZ.git|Contributed|MicroTaskX
+https://github.com/Moaaz-i/MicroTaskX.git|Contributed|MicroTaskX
 https://github.com/NodeWave-EA/FOTA-Client-ESP32.git|Contributed|FOTA-Client-ESP32
 https://github.com/fun6400/Adafruit_SSD1306_72x40.git|Contributed|Adafruit_SSD1306_72x40
 https://github.com/fun6400/PipeGIF.git|Contributed|PipeGIF


### PR DESCRIPTION
This PR consists of two changes:

- Change URL from `https://github.com/Moaaz-i/UMOZ.git` to `https://github.com/Moaaz-i/MicroTaskX.git` (companion to https://github.com/arduino/library-registry/pull/8599).
- Change name from `UMOZ` to `MicroTaskX`

Since the name change operation on the database is actually a removal followed by automated re-indexing on the next job run, the URL update will occur as a matter of course. For this reason, the only operation required from the backend maintainer is a standard name change procedure.