### PR TITLE
Add segDisplay library

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -9609,3 +9609,4 @@ https://github.com/levkovigor/UWB_DW1000_DW3000
 https://github.com/CodexPad/gamepad_input_arduino_lib
 https://github.com/Pooria-nek/BusproCore
 https://github.com/argeorun/BACnetMSTP-ArduinoLib
+https://github.com/Qmaker-programmer/segDisplay


### PR DESCRIPTION
Please add the `segDisplay` library to the official registry. 

- **Repository:** https://github.com
- **Author:** Qmaker
- **Version:** v1.0.0

The library has been structured and tested according to the Arduino Library Manager specifications. Thanks!
