### PR TITLE
Add new repository link for I2Connect_EEPROM

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -9613,3 +9613,4 @@ https://github.com/argeorun/BACnetMSTP-ArduinoLib
 https://github.com/Qmaker-programmer/segDisplay
 https://github.com/zeevje/ESPNowHub
 https://github.com/HimC29/AsyncBitMatrix
+https://github.com/PTSolns/I2Connect_EEPROM


### PR DESCRIPTION
Submitting the PTSolns I2Connect_EEPROM library for inclusion.