### PR TITLE
Add winglander/PiicoDev_Buzzer

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -9616,3 +9616,4 @@ https://github.com/Qmaker-programmer/segDisplay
 https://github.com/zeevje/ESPNowHub
 https://github.com/HimC29/AsyncBitMatrix
 https://github.com/PTSolns/I2Connect_EEPROM
+https://github.com/winglander/PiicoDev_Buzzer


### PR DESCRIPTION
Add the PiicoDev_Buzzer Arduino library to the Library Manager index.

- Repo: https://github.com/winglander/PiicoDev_Buzzer
- An Arduino library for the PiicoDev Buzzer Module over I2C (tone, volume, presence detection).
- Tagged release 1.0.0 with a valid library.properties.
- Verified compiling on Arduino AVR (Uno) and ESP32.