### PR TITLE
Add PiicoDev_Button

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -9617,3 +9617,4 @@ https://github.com/zeevje/ESPNowHub
 https://github.com/HimC29/AsyncBitMatrix
 https://github.com/PTSolns/I2Connect_EEPROM
 https://github.com/winglander/PiicoDev_Buzzer
+https://github.com/winglander/PiicoDev_Button


### PR DESCRIPTION
Adding my Arduino library for the Core Electronics PiicoDev Button (I2C):

https://github.com/winglander/PiicoDev_Button

- Standard Arduino library layout (`src/`, `examples/`, `library.properties`, `keywords.txt`)
- MIT licensed, tagged release `1.0.0`
- Tested on hardware (Arduino UNO R4)