### PR TITLE
Add Lucarne library

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -9621,3 +9621,4 @@ https://github.com/winglander/PiicoDev_Button
 https://github.com/IsraEB/TEA5767Radio/
 https://github.com/EasyMem/easy_stack
 https://github.com/Nerdsiah/NeoStreaming.git
+https://github.com/Pupariaa/Lucarne


### PR DESCRIPTION
## Summary

Submit **Lucarne** for inclusion in the Arduino Library Manager index.

- Repository: https://github.com/Pupariaa/Lucarne
- Latest release: https://github.com/Pupariaa/Lucarne/releases/tag/v0.1.1
- License: MIT
- Category: Display (ST7789 / ST7735S SPI UI toolkit for Arduino and ESP32)

## Library metadata

- `library.properties` at repository root
- `includes=Lucarne.h` (src layout)
- Examples: HelloLucarne, LucarneDiag, LucarneUI, LucarneMenu, LucarnePreview

## Test plan

- [x] `library.properties` at repo root
- [x] Git tag `v0.1.1` matches `version=0.1.1`
- [x] Arduino Library Manager lint enabled in CI (`arduino-lint --library-manager`)