### PR TITLE
Add Ultrasonic Sensor Library to Arduino Library Manager

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -9624,3 +9624,4 @@ https://github.com/Nerdsiah/NeoStreaming.git
 https://github.com/Pupariaa/Lucarne
 https://github.com/ziyarago/RisalDash
 https://github.com/Protocentral/protocentral_as6221_arduino
+https://github.com/su7eib/Ultrasonic-Sensor-Library


### PR DESCRIPTION
This pull request adds the Ultrasonic Sensor Library to the Arduino Library Manager.

Repository:
https://github.com/su7eib/Ultrasonic-Sensor-Library

Library features:
- Support for Trig/Echo ultrasonic sensors
- Support for single-pin ultrasonic sensors
- Simple API (readCM, readMM, readInch)
- Built-in measurement timing control
- Compatible with Arduino boards and ESP-based boards

Version: 1.0.0