### PR TITLE
Add MatrixForge library

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -9628,3 +9628,4 @@ https://github.com/ziyarago/RisalDash
 https://github.com/Protocentral/protocentral_as6221_arduino
 https://github.com/su7eib/Ultrasonic-Sensor-Library
 https://github.com/CodexPad/byte_buffer_arduino_lib
+https://github.com/mahbubul03/MatrixForge


### PR DESCRIPTION
Submitting MatrixForge — a zero-dependency WS2812B LED matrix display library for Arduino/ESP32.
  
  https://github.com/mahbubul03/MatrixForge