### PR TITLE
Add ESPGithubOTA library

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -9629,3 +9629,4 @@ https://github.com/Protocentral/protocentral_as6221_arduino
 https://github.com/su7eib/Ultrasonic-Sensor-Library
 https://github.com/CodexPad/byte_buffer_arduino_lib
 https://github.com/mahbubul03/MatrixForge
+https://github.com/himanshufanibhare/ESPGithubOTA


### PR DESCRIPTION
Adding ESP32GithubOTA library.

OTA update library for ESP32/ESP8266 using GitHub as firmware host.
Includes built-in web dashboard with login protection, auto-check timer,
progress callbacks, and board auto-detection.

Repository: https://github.com/himanshufanibhare/ESPGithubOTA.git