### PR TITLE
Add hapbeat/hapbeat-arduino

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -9631,3 +9631,4 @@ https://github.com/CodexPad/byte_buffer_arduino_lib
 https://github.com/mahbubul03/MatrixForge
 https://github.com/himanshufanibhare/ESPGithubOTA
 https://github.com/periashutosh-prog/Smart-Connect
+https://github.com/hapbeat/hapbeat-arduino


### PR DESCRIPTION
Adds the Hapbeat library — drive Hapbeat haptic devices from ESP32 / M5Stack / Arduino over Wi-Fi UDP. Passes `arduino-lint --library-manager submit --compliance strict` with no errors or warnings.