### PR TITLE
Add EdulcoWaterSmart library

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -9634,3 +9634,4 @@ https://github.com/periashutosh-prog/Smart-Connect
 https://github.com/hapbeat/hapbeat-arduino
 https://github.com/blah188/LionArray
 https://github.com/hmz06967/ozkled
+https://github.com/fabianodaq/EdulcoWaterSmart


### PR DESCRIPTION
Add EdulcoWaterSmart library to the Arduino Library Manager.

Repository:
https://github.com/fabianodaq/EdulcoWaterSmart

Initial public release (v1.0.1).