### PR TITLE
Add LionRtosTask

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -9636,3 +9636,4 @@ https://github.com/blah188/LionArray
 https://github.com/hmz06967/ozkled
 https://github.com/fabianodaq/EdulcoWaterSmart
 https://github.com/H-Kurosaki/UARDECS_PICO
+https://github.com/blah188/LionRtosTask


### PR DESCRIPTION
Adds LionRtosTask — a tiny OOP wrapper over FreeRTOS tasks for ESP32 (subclass, override TaskBody(), run pinned to a core). 0BSD licensed. Repo: https://github.com/blah188/LionRtosTask