### PR TITLE
Add LionLogger

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -9637,3 +9637,4 @@ https://github.com/hmz06967/ozkled
 https://github.com/fabianodaq/EdulcoWaterSmart
 https://github.com/H-Kurosaki/UARDECS_PICO
 https://github.com/blah188/LionRtosTask
+https://github.com/blah188/LionLogger


### PR DESCRIPTION
Adds LionLogger — a small leveled logger for ESP8266/ESP32 (Serial + SPIFFS/LittleFS, rotation, optional async logging). 0BSD. Repo: https://github.com/blah188/LionLogger