### PR TITLE
Add LionStreams

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -9640,3 +9640,4 @@ https://github.com/blah188/LionRtosTask
 https://github.com/blah188/LionLogger
 https://github.com/pcbcupid/PCBCUPID-QMC6309
 https://github.com/blah188/LionTask
+https://github.com/blah188/LionStreams


### PR DESCRIPTION
Adding LionStreams: tiny header-only Arduino Stream adapters (StringStream over a String, ServerStream chunk-flushing to ESP8266/ESP32 web servers). 0BSD, no dependencies.