### PR TITLE
Add LionWifi

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -9646,3 +9646,4 @@ https://github.com/blah188/LionStreams
 https://github.com/outlookhazy/SyntropicOS.git
 https://github.com/kokofixcomputers/ESP32BLECombo
 https://github.com/PLGdevo/CKC_LIB.git
+https://github.com/blah188/LionWifi


### PR DESCRIPTION
Add LionWifi — a WiFi connection manager with ArduinoOTA, a web filesystem browser (SPIFFS/LittleFS/SD) and a status page, for ESP8266 and ESP32. Repo: https://github.com/blah188/LionWifi