### PR TITLE
Add LionDallas

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -9647,3 +9647,4 @@ https://github.com/outlookhazy/SyntropicOS.git
 https://github.com/kokofixcomputers/ESP32BLECombo
 https://github.com/PLGdevo/CKC_LIB.git
 https://github.com/blah188/LionWifi
+https://github.com/blah188/LionDallas


### PR DESCRIPTION
Adds LionDallas — a compact DS18B20 driver over OneWire for the Lion* stack (ESP8266). Repository: https://github.com/blah188/LionDallas (tagged v1.0.0, library.properties present, MIT).