### PR TITLE
Add ezTime2 library

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -9649,3 +9649,4 @@ https://github.com/kokofixcomputers/ESP32BLECombo
 https://github.com/PLGdevo/CKC_LIB.git
 https://github.com/blah188/LionWifi
 https://github.com/blah188/LionDallas
+https://github.com/Dag0d/ezTime2


### PR DESCRIPTION
Adds `https://github.com/Dag0d/ezTime2` to the Arduino Library Manager registry.

Release/tag prepared for indexing:
- `v1.0.0`

Library metadata lives in the repository root `library.properties`.
