### PR TITLE
Add AERL C Framework

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -9653,3 +9653,4 @@ https://github.com/blah188/LionDallas
 https://github.com/Dag0d/ezTime2
 https://github.com/ARAM-USA-Support/ARAM_Metal_Orchestra
 https://github.com/CodexPad/gamepad_codec_arduino_lib
+https://github.com/AERL-Official/AERL-C-Framework


### PR DESCRIPTION
Registering the AERL C Framework — a beginner-friendly Arduino/ESP32 HAL library by AERL (Applied Electronics and Robotics Laboratory LLP). Repository: https://github.com/AERL-Official/AERL-C-Framework