### PR TITLE
Add NiusCam

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -9654,3 +9654,4 @@ https://github.com/Dag0d/ezTime2
 https://github.com/ARAM-USA-Support/ARAM_Metal_Orchestra
 https://github.com/CodexPad/gamepad_codec_arduino_lib
 https://github.com/AERL-Official/AERL-C-Framework
+https://github.com/dunknowcoding/NiusCam


### PR DESCRIPTION
Adds the NiusCam Arduino library: https://github.com/dunknowcoding/NiusCam. Initial tagged release: v0.1.0. The tagged source passes strict Arduino Library Manager submission lint.