### PR TITLE
add-xc-gui

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -9655,3 +9655,4 @@ https://github.com/ARAM-USA-Support/ARAM_Metal_Orchestra
 https://github.com/CodexPad/gamepad_codec_arduino_lib
 https://github.com/AERL-Official/AERL-C-Framework
 https://github.com/dunknowcoding/NiusCam
+https://github.com/Gigasitron-xcross/XC_GUI


### PR DESCRIPTION
This PR adds the XC_GUI Arduino library.

Repository:
https://github.com/Gigasitron-xcross/XC_GUI

XC_GUI is a precompiled Arduino graphics library for Gigasitron-designed LCD modules. It supports buffered drawing, text rendering, bitmap drawing, and bundled SSD1306/ST7789 display drivers for supported ARM Cortex and ESP32-family boards.