### PR TITLE
Add WiStalker

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -9659,3 +9659,4 @@ https://github.com/AERL-Official/AERL-C-Framework
 https://github.com/dunknowcoding/NiusCam
 https://github.com/Gigasitron-xcross/XC_GUI
 https://github.com/PTSolns/I2Connect_AHT20
+https://github.com/1e1/arduino-macaddress-detector


### PR DESCRIPTION
Adds the WiStalker library to the Arduino Library Manager index.

- Repository: https://github.com/1e1/arduino-macaddress-detector
- Passive 802.11 presence detection for ESP8266 and ESP32 (promiscuous sniffing)
- Release tag `1.0.0`, MIT license, `library.properties` in the repo root
- `arduino-lint` (submit mode) passing in the repository CI