### PR TITLE
Add LionFastLcd

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -9660,3 +9660,4 @@ https://github.com/dunknowcoding/NiusCam
 https://github.com/Gigasitron-xcross/XC_GUI
 https://github.com/PTSolns/I2Connect_AHT20
 https://github.com/1e1/arduino-macaddress-detector
+https://github.com/blah188/LionFastLcd


### PR DESCRIPTION
Adds https://github.com/blah188/LionFastLcd — a change-tracked, buffered character-LCD layer over LiquidCrystal_I2C for ESP8266 + AVR.