### PR TITLE
Add SensorRoxoOBR library

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -9665,3 +9665,4 @@ https://github.com/PTSolns/I2Connect_AHT20
 https://github.com/1e1/arduino-macaddress-detector
 https://github.com/blah188/LionFastLcd
 https://github.com/lildev1979/AFS01Sensor
+https://github.com/maker-wesley/SensorRoxoOBR.git


### PR DESCRIPTION
Hello! Please add the `SensorRoxoOBR` library to the Arduino Library Registry.

- **Repository URL:**https://github.com/maker-wesley/SensorRoxoOBR.git
- **Description:** A library to simplify the use of the TCS34725 color sensor via an I2C multiplexer, specifically tailored for OBR (Brazilian Robotics Olympiad) line-following robots.

Thank you!