### PR TITLE
Add Nodrix

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -9668,3 +9668,4 @@ https://github.com/maker-wesley/SensorRoxoOBR.git
 https://github.com/VoidLoopers/SignalCore
 https://github.com/VoidLoopers/ViewPoint
 https://github.com/soosp/DigitalOutput
+https://github.com/decoded-cipher/nodrix-sdk


### PR DESCRIPTION
Adds https://github.com/decoded-cipher/nodrix-sdk — an Arduino library for connecting ESP32/ESP8266 hardware to Nodrix (WiFi, TLS, WebSocket/HTTP transport, JSON, and the control/telemetry protocol behind a small API).

`arduino-lint --library-manager submit --compliance strict` passes with no errors or warnings across the library and all five examples.