### PR TITLE
Add planterm repository link

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -9673,3 +9673,4 @@ https://github.com/VoidLoopers/ViewPoint
 https://github.com/soosp/DigitalOutput
 https://github.com/decoded-cipher/nodrix-sdk
 https://github.com/F1chter/LynkTuyaLocal
+https://github.com/teemow/planterm


### PR DESCRIPTION
https://github.com/teemow/planterm

CAREL pLAN terminal protocol library — header-only C++17, MIT licensed, tagged release v0.1.0, passes `arduino-lint --library-manager submit --compliance strict` with no errors or warnings.

Made with [Cursor](https://cursor.com)