### PR TITLE
Add RCArmDrive library

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -6,6 +6,7 @@ https://github.com/fun6400/Adafruit_SSD1306_72x40
 https://github.com/fun6400/PipeGIF
 https://github.com/Moaaz-i/MicroTaskX
 https://github.com/CarloCBragagnolo/LSM6DS3
+https://github.com/nthnsdev/RCArmDrive
 https://github.com/tkhoi0821-svg/GrayKazu
 https://github.com/Vean/FansElectronics_DMD8266
 https://github.com/You-010/HCSR04_ESP_Hardware

--- a/repositories.txt
+++ b/repositories.txt
@@ -45,6 +45,7 @@ https://github.com/sSpectrals/RoboticusDebugger
 https://github.com/Otto17/ESP_ChaCha
 https://github.com/ccaprojects/CCARemote-Arduino
 https://github.com/Otto17/LightConnect
+https://github.com/nthnsdev/RCArmDrive
 https://github.com/Circuit-Digest/CircuitDigestCloud
 https://github.com/gavinlyonsrepo/GC9107_LTSM
 https://github.com/rohitmaji004/RohitCore-Config

--- a/repositories.txt
+++ b/repositories.txt
@@ -6,7 +6,6 @@ https://github.com/fun6400/Adafruit_SSD1306_72x40
 https://github.com/fun6400/PipeGIF
 https://github.com/Moaaz-i/MicroTaskX
 https://github.com/CarloCBragagnolo/LSM6DS3
-https://github.com/nthnsdev/RCArmDrive
 https://github.com/tkhoi0821-svg/GrayKazu
 https://github.com/Vean/FansElectronics_DMD8266
 https://github.com/You-010/HCSR04_ESP_Hardware


### PR DESCRIPTION
## New Library Submission

**Library name:** RCArmDrive
**Repository:** https://github.com/nthnsdev/RCArmDrive
**Version:** 1.1.0

### Description
Transport-agnostic Arduino library for controlling an RC car with a servo-driven crane/robotic arm attachment. Supports ESP32 BLE, HC-05/HC-06 Classic Bluetooth, and WiFi with a unified command protocol.

### Checklist
- [x] Library is hosted on GitHub
- [x] `library.properties` is present and valid
- [x] MIT license included
- [x] At least one example sketch included
- [x] Tagged release exists (1.0.0, 1.1.0)
- [x] Library name is unique in the registry