### PR TITLE
Add BMx280PIO_RP2040 — BMP280/BME280 driver for RP2040

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -9679,3 +9679,4 @@ https://github.com/soosp/EEPROMPreferences
 https://github.com/habuenav/quickMap
 https://github.com/habuenav/Breath
 https://github.com/gaweueu/KenwoodXS
+https://github.com/angeloINTJ/BMx280PIO_RP2040.git


### PR DESCRIPTION
## BMx280PIO_RP2040

BMP280/BME280 temperature, pressure, and humidity sensor driver for Raspberry Pi Pico (RP2040).

- **PIO+DMA burst reads**: 8 registers in a single I2C transaction via PIO state machine
- **GPIO bit-bang I2C**: works on any pin pair
- Auto-detects BMP280 vs BME280
- Verified on hardware: PIO readings match GPIO exactly
- 4 examples included
- MIT license

Repository: https://github.com/angeloINTJ/BMx280PIO_RP2040
Release: v1.0.0