### PR TITLE
Add NiusWireless library

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -9685,3 +9685,4 @@ https://github.com/angeloINTJ/BMx280PIO_RP2040.git
 https://github.com/codewitch-honey-crisis/htcw_frame_arq
 https://github.com/vic4key/MyButtons
 https://github.com/Protocentral/protocentral_healthypi_5_firmware
+https://github.com/dunknowcoding/NiusWireless


### PR DESCRIPTION
Adding NiusWireless (https://github.com/dunknowcoding/NiusWireless) to the Arduino Library Manager index.

Unified, cross-platform Arduino driver for RFID-RC522 (MIFARE Classic 1K / 4K / Mini, Ultralight, NTAG213/215/216), LoRa (RFM95/96/98, RA-01/02, SX1261/62/68), NRF24L01(+), HC-12, HC-05/06, and PN532.

Latest release: v0.1.0, compliant with Arduino Library Specification 1.5.