### PR TITLE
Update repositories.txt

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -9687,3 +9687,4 @@ https://github.com/vic4key/MyButtons
 https://github.com/Protocentral/protocentral_healthypi_5_firmware
 https://github.com/dunknowcoding/NiusWireless
 https://github.com/arduino-libraries/Arduino_UniqueHWId
+https://github.com/HRK-Yas/HM01B0_CPUfree_Camera


### PR DESCRIPTION
Add HM01B0_CPUfree_Camera library to Arduino Library Registry

This library provides zero-CPU-overhead camera streaming for RP2350 using DMA and PIO with dual-buffer architecture.

**Library details:**
- Name: HM01B0_CPUfree_Camera
- Repository: https://github.com/HRK-Yas/HM01B0_CPUfree_Camera
- Supports: RP2350 and RP2040
- Features: CPU-free capture, dual-buffer, 15-120fps

**Repository URL added to list:**
https://github.com/HRK-Yas/HM01B0_CPUfree_Camera