### PR TITLE
Add OV7725_CPUfree_Camera library to registry

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -9687,3 +9687,4 @@ https://github.com/vic4key/MyButtons
 https://github.com/Protocentral/protocentral_healthypi_5_firmware
 https://github.com/dunknowcoding/NiusWireless
 https://github.com/arduino-libraries/Arduino_UniqueHWId
+https://github.com/HRK-Yas/OV7725_CPUfree_Camera

--- a/repositories.txt
+++ b/repositories.txt
@@ -9687,4 +9687,5 @@ https://github.com/vic4key/MyButtons
 https://github.com/Protocentral/protocentral_healthypi_5_firmware
 https://github.com/dunknowcoding/NiusWireless
 https://github.com/arduino-libraries/Arduino_UniqueHWId
+https://github.com/HRK-Yas/HM01B0_CPUfree_Camera
 https://github.com/HRK-Yas/OV7725_CPUfree_Camera


### PR DESCRIPTION
Adds OV7725_CPUfree_Camera - Zero-CPU-overhead camera streaming library for RP2350

- CPU-free image capture using DMA/PIO
- Dual-buffer architecture
- Support for RP2350
- Color (YUV) and monochrome modes at 30fps
- Bilingual documentation (Japanese/English)