### PR TITLE
Remove "Arduino_UniqueHWId"

### DIFF
--- a/registry.txt
+++ b/registry.txt
@@ -9679,7 +9679,6 @@ https://github.com/nthnsdev/RCArmDrive.git|Contributed|RCArmDrive
 https://github.com/Protocentral/protocentral_healthypi_5_firmware.git|Contributed|ProtoCentral HealthyPi 5
 https://github.com/Moaaz-i/Ultra1602Ultimate.git|Contributed|Ultra1602Ultimate
 https://github.com/dunknowcoding/NiusWireless.git|Contributed|NiusWireless
-https://github.com/arduino-libraries/Arduino_UniqueHWId.git|Arduino|Arduino_UniqueHWId
 https://github.com/HRK-Yas/HM01B0_CPUfree_Camera.git|Contributed|HM01B0_CPUfree_Camera
 https://github.com/HRK-Yas/OV7725_CPUfree_Camera.git|Contributed|OV7725_Camera_Library
 https://github.com/TakamoriRobot/HIRO.git|Contributed|HIRO


### PR DESCRIPTION
Companion to https://github.com/arduino/library-registry/pull/8720