### PR TITLE
Add WirePIO — TwoWire-compatible I2C using PIO+DMA for RP2040

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -9371,6 +9371,7 @@ https://github.com/0ldev/Politician
 https://github.com/electronicstree/blendixserial-arduino
 https://github.com/HijelHub/HijelHID_BLEMouse
 https://github.com/rleusden/LTC2944_BMS
+https://github.com/angeloINTJ/TwoWirePIO_RP2040.git
 https://github.com/angeloINTJ/USBSnifferPIO_RP2040.git
 https://github.com/hfdalkarim/Hafid
 https://github.com/IowaScaledEngineering/mss-xcade-lib


### PR DESCRIPTION
## Library Submission

**Name:** WirePIO
**Repository:** https://github.com/angeloINTJ/TwoWirePIO_RP2040
**Version:** 1.3.2
**Category:** Communication

### Description

TwoWire-compatible I2C implementation using PIO+DMA on the RP2040. Create unlimited I2C buses on any GPIO pin pair — no multiplexers needed. Drop-in replacement for Wire.h.

### Features

- Unlimited I2C buses on any GPIO pins
- Full TwoWire API compatibility (Wire.h drop-in replacement)
- PIO + DMA burst transfers with zero CPU overhead
- GPIO bit-bang fallback
- Master + Slave modes
- Async DMA transfers with callback
- Timeout + NACK detection
- Compatible with Adafruit_BME280, SSD1306, U8g2, RTClib, etc.

### Compliance

`arduino-lint --compliance=strict --library-manager=submit` passes with **0 errors, 0 warnings**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)