### PR TITLE
Add new repository link for GL55xxSensor

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -9695,3 +9695,4 @@ https://github.com/SUNSETDEVER/AVR_TaskScheduler
 https://github.com/TakamoriRobot/HIRO
 https://github.com/chijesusboy2004-crypto/omiru.h
 https://github.com/chijesusboy2004-crypto/AxonSDK
+https://github.com/KarlEffinger/GL55xxSensor


### PR DESCRIPTION
Library for using the GL55xx Light Dependent Resistor family to get readings in raw values, lux or foot candles