### PR TITLE
Add Vira WiFi Connector library

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -9699,3 +9699,4 @@ https://github.com/razkar-studio/stimeration
 https://github.com/KarlEffinger/GL55xxSensor
 https://github.com/vic4key/MyDisplayLogging
 https://github.com/habuenav/easyMenu
+https://github.com/admin3314/Vira_WiFi_Connector.git


### PR DESCRIPTION
## Vira WiFi Connector (ViraWC)

Add Vira WiFi Connector library to Arduino Library Registry.

ViraWC is a lightweight ESP8266 WiFi management library featuring:

- Automatic WiFi connection
- Configuration Access Point
- Web based WiFi setup portal
- DHCP and Static IP support
- EEPROM configuration storage
- WiFi scanning
- Factory Reset API
- ESPAsyncWebServer integration

Repository:
https://github.com/admin3314/Vira_WiFi_Connector

Arduino Lint:
✅ Passed with strict compliance

Version:
v1.2.0