### PR TITLE
Add midi2duino

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -9701,4 +9701,5 @@ https://github.com/vic4key/MyDisplayLogging
 https://github.com/habuenav/easyMenu
 https://github.com/admin3314/Vira_WiFi_Connector.git
 https://github.com/bhvym-sudo/PT6964
+https://github.com/sauloverissimo/midi2duino.git
 


### PR DESCRIPTION
USB MIDI 2.0 device transport for classic Arduino cores on the stock core (PluggableUSB), for AVR (ATmega32U4) and classic SAMD (SAMD21). Passes arduino-lint --library-manager submit --compliance strict with no errors or warnings.