### PR TITLE
Add Vira Matrix library

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -9705,3 +9705,4 @@ https://github.com/sauloverissimo/midi2duino.git
 https://github.com/Cymeria/LittleFSExplorer
 https://github.com/rowanzhang123/IF97duino-public
 https://github.com/m5stack/M5Hat-18650C
+https://github.com/admin3314/Vira_Matrix.git


### PR DESCRIPTION
Please add my library to the Arduino Library Manager.

Library name:
Vira Matrix

Repository:
https://github.com/admin3314/Vira_Matrix

Author:
Mostafa MirMousavi