### PR TITLE
Add HW290 library repository

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -9708,3 +9708,4 @@ https://github.com/Cymeria/LittleFSExplorer
 https://github.com/rowanzhang123/IF97duino-public
 https://github.com/m5stack/M5Hat-18650C
 https://github.com/admin3314/Vira_Matrix.git
+https://github.com/supratikd/HW290


### PR DESCRIPTION
Add the HW290-10DOF library repository URL to repositories.txt for inclusion in the Arduino Library Manager.

The library provides support for the HW290 10-DOF sensor module, including:
- MPU6050 (Accelerometer & Gyroscope)
- BMP180 (Barometric Pressure & Temperature)
- HP5883 (Magnetometer)

The repository includes documentation, examples, and is released under the MIT License.