### PR TITLE
Add SBK_AvrBuzzer to repositories.txt

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -9713,3 +9713,4 @@ https://github.com/admin3314/Vira_Matrix.git
 https://github.com/supratikd/HW290
 
 https://github.com/srirangaraj-b/UNOQ_STM32_HAL
+https://github.com/sbarabe/SBK_AvrBuzzer.git


### PR DESCRIPTION
## Summary

Add SBK_AvrBuzzer to the Arduino Library Manager registry.

Repository:
https://github.com/sbarabe/SBK_AvrBuzzer

Thank you!