### PR TITLE
Add m-mcgowan/note-cpp

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -9714,3 +9714,4 @@ https://github.com/supratikd/HW290
 
 https://github.com/srirangaraj-b/UNOQ_STM32_HAL
 https://github.com/sbarabe/SBK_AvrBuzzer.git
+https://github.com/m-mcgowan/note-cpp


### PR DESCRIPTION
Adds [note-cpp](https://github.com/m-mcgowan/note-cpp) — a typed, header-only C++ SDK for the Blues Notecard (Arduino, PlatformIO, and CMake).

Latest release `v0.3.2` is tagged and passes `arduino-lint --library-manager submit` with no errors or warnings.
