### PR TITLE
Add WcbCmd

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -9715,3 +9715,4 @@ https://github.com/supratikd/HW290
 https://github.com/srirangaraj-b/UNOQ_STM32_HAL
 https://github.com/sbarabe/SBK_AvrBuzzer.git
 https://github.com/m-mcgowan/note-cpp
+https://github.com/greghulette/WcbCmd.git


### PR DESCRIPTION
Adds **WcbCmd** — shared WCB (Wireless Communication Board) command translators: one command vocabulary that emits identical device wire bytes over ESP-NOW or local serial, for the Pololu Maestro (`;M`), SparkFun MP3 Trigger (`;A`), WLED (`;L`), and Human-Cyborg-Relations vocalizer (`;H`).

- Repository: https://github.com/greghulette/WcbCmd
- Latest release/tag: `0.4.0`
- `arduino-lint --library-manager submit --compliance strict` → **0 errors, 0 warnings**
- MIT licensed; `library.properties` at repo root; recursive `src/` layout; `keywords.txt` and examples included.