### PR TITLE
Added repo URL for RedLab_I2CMatrixKeyPad

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -1,3 +1,4 @@
+https://github.com/ZipionLive/RedLab_I2CMatrixKeypad
 https://github.com/houslast3/sistema
 https://github.com/ailagari/JMCMotorControl
 https://github.com/Moaaz-i/FlareDom


### PR DESCRIPTION
This library is designed to drive this I2C matrix keypad module : https://oshwlab.com/zipionlive/project_eljpuaux

The 4x4 version is also about to be released