### PR TITLE
Add NobroRTOS library

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -9725,3 +9725,4 @@ https://github.com/JoergTiedemann/ESP32-IoT-Framework.git
 https://github.com/NicholasTracy/ANSITerm
 https://github.com/fikrielektro21/MHZ19
 https://github.com/matthias-bs/esp32-shelly-ble-rpc
+https://github.com/dunknowcoding/NobroRTOS-Arduino


### PR DESCRIPTION
Adds the dedicated package-root NobroRTOS Arduino repository. Release 0.3.0 passes Arduino Lint 1.3.0 with strict Library Manager submission compliance and no errors or warnings.