### PR TITLE
Add NiusAudio

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -9727,3 +9727,4 @@ https://github.com/fikrielektro21/MHZ19
 https://github.com/streef/YetAnotherRotaryEncoder
 https://github.com/matthias-bs/esp32-shelly-ble-rpc
 https://github.com/dunknowcoding/NobroRTOS-Arduino
+https://github.com/dunknowcoding/NiusAudio


### PR DESCRIPTION
Adds the NiusAudio Arduino audio-module library. The v0.3.1 release is Apache-2.0 licensed and passes strict Arduino Library Manager submission lint plus pinned AVR and ESP32-S3 compile checks.