### PR TITLE
Add I2C_LiquidCrystal_RUS repository link

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -9729,3 +9729,4 @@ https://github.com/matthias-bs/esp32-shelly-ble-rpc
 https://github.com/dunknowcoding/NobroRTOS-Arduino
 https://github.com/dunknowcoding/NiusAudio
 https://github.com/Alash-electronics/Alash_DS1302
+https://github.com/Alash-electronics/I2C_LiquidCrystal_RUS


### PR DESCRIPTION
Adds a link to the I2C_LiquidCrystal_RUS library, which extends LiquidCrystal_I2C with Cyrillic character support for I2C LCD displays on Arduino, ESP32, and ESP8266.

- Repository: https://github.com/Alash-electronics/I2C_LiquidCrystal_RUS
- License: MIT
- `library.properties` present at repo root
- Tagged release: https://github.com/Alash-electronics/I2C_LiquidCrystal_RUS/releases/tag/1.0.8