### PR TITLE
Add LiquidCrystal_I2C repository link

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -9728,3 +9728,4 @@ https://github.com/streef/YetAnotherRotaryEncoder
 https://github.com/matthias-bs/esp32-shelly-ble-rpc
 https://github.com/dunknowcoding/NobroRTOS-Arduino
 https://github.com/dunknowcoding/NiusAudio
+https://github.com/Alash-electronics/LiquidCrystal_I2C


### PR DESCRIPTION
Adds a link to the LiquidCrystal_I2C library.

- Repository: https://github.com/Alash-electronics/LiquidCrystal_I2C
- License: MIT
- `library.properties` present at repo root
- Tagged release: https://github.com/Alash-electronics/LiquidCrystal_I2C/releases/tag/1.0.8

Provides I2C control of character LCDs for Arduino, ESP32, and ESP8266.