### PR TITLE
Add Alash_DS1302 repository link

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -9728,3 +9728,4 @@ https://github.com/streef/YetAnotherRotaryEncoder
 https://github.com/matthias-bs/esp32-shelly-ble-rpc
 https://github.com/dunknowcoding/NobroRTOS-Arduino
 https://github.com/dunknowcoding/NiusAudio
+https://github.com/Alash-electronics/Alash_DS1302


### PR DESCRIPTION
Adds a link to the Alash_DS1302 library.

- Repository: https://github.com/Alash-electronics/Alash_DS1302
- License: MIT
- `library.properties` present at repo root
- Tagged release: https://github.com/Alash-electronics/Alash_DS1302/releases/tag/1.0.8

Real-time clock library for the DS1302 RTC module on Arduino, ESP8266, and ESP32.