### PR TITLE
Add AlashDHT repository link

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -9728,3 +9728,4 @@ https://github.com/streef/YetAnotherRotaryEncoder
 https://github.com/matthias-bs/esp32-shelly-ble-rpc
 https://github.com/dunknowcoding/NobroRTOS-Arduino
 https://github.com/dunknowcoding/NiusAudio
+https://github.com/Alash-electronics/AlashDHT


### PR DESCRIPTION
Adds a link to the AlashDHT library.

- Repository: https://github.com/Alash-electronics/AlashDHT
- License: MIT
- `library.properties` present at repo root
- Tagged release: https://github.com/Alash-electronics/AlashDHT/releases/tag/1.0.8

Temperature and humidity reading library for DHT11/DHT22 sensors on Arduino, ESP8266, and ESP32.