### PR TITLE
Add AlashUartMP3 repository link

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -9729,3 +9729,4 @@ https://github.com/matthias-bs/esp32-shelly-ble-rpc
 https://github.com/dunknowcoding/NobroRTOS-Arduino
 https://github.com/dunknowcoding/NiusAudio
 https://github.com/Alash-electronics/Alash_DS1302
+https://github.com/Alash-electronics/AlashUartMP3


### PR DESCRIPTION
Adds a link to the AlashUartMP3 library.

- Repository: https://github.com/Alash-electronics/AlashUartMP3
- License: MIT
- `library.properties` present at repo root
- Tagged release: https://github.com/Alash-electronics/AlashUartMP3/releases/tag/1.0.0

Controls UART-based MP3 player modules (e.g. JQ8400 chip) from Arduino and ESP32.