### PR TITLE
Add AlashLEDMatrix8x8 repository link

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -9729,3 +9729,4 @@ https://github.com/matthias-bs/esp32-shelly-ble-rpc
 https://github.com/dunknowcoding/NobroRTOS-Arduino
 https://github.com/dunknowcoding/NiusAudio
 https://github.com/Alash-electronics/Alash_DS1302
+https://github.com/Alash-electronics/AlashLEDMatrix8x8


### PR DESCRIPTION
Adds a link to the AlashLEDMatrix8x8 library.

- Repository: https://github.com/Alash-electronics/AlashLEDMatrix8x8
- License: MIT
- `library.properties` present at repo root
- Tagged release: https://github.com/Alash-electronics/AlashLEDMatrix8x8/releases/tag/1.0.7

Drives 8x8 LED matrix displays over SPI on Arduino, ESP32, and ESP8266, with text, image, and animation support.