### PR TITLE
Add AlashSerialTerminal repository link

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -9729,3 +9729,4 @@ https://github.com/matthias-bs/esp32-shelly-ble-rpc
 https://github.com/dunknowcoding/NobroRTOS-Arduino
 https://github.com/dunknowcoding/NiusAudio
 https://github.com/Alash-electronics/Alash_DS1302
+https://github.com/Alash-electronics/AlashSerialTerminal


### PR DESCRIPTION
Adds a link to the AlashSerialTerminal library.

- Repository: https://github.com/Alash-electronics/AlashSerialTerminal
- License: MIT
- `library.properties` present at repo root
- Tagged release: https://github.com/Alash-electronics/AlashSerialTerminal/releases/tag/1.0.8

Simplifies building a serial command terminal for remote control and monitoring of Arduino devices.