### PR TITLE
Add AlashKeypadMatrix repository link

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -9729,3 +9729,4 @@ https://github.com/matthias-bs/esp32-shelly-ble-rpc
 https://github.com/dunknowcoding/NobroRTOS-Arduino
 https://github.com/dunknowcoding/NiusAudio
 https://github.com/Alash-electronics/Alash_DS1302
+https://github.com/Alash-electronics/AlashKeypadMatrix


### PR DESCRIPTION
Adds a link to the AlashKeypadMatrix library.

- Repository: https://github.com/Alash-electronics/AlashKeypadMatrix
- License: MIT
- `library.properties` present at repo root
- Tagged release: https://github.com/Alash-electronics/AlashKeypadMatrix/releases/tag/1.0.8

Handles matrix keypad key states and events on Arduino.