### PR TITLE
Add NickP005/plynx-library

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -9736,3 +9736,4 @@ https://github.com/Alash-electronics/I2C_LiquidCrystal_RUS
 https://github.com/Alash-electronics/AlashSerialTerminal
 https://github.com/styropyr0/MAX7219
 https://github.com/LEKPCSTEAM/SmartFont.git
+https://github.com/NickP005/plynx-library


### PR DESCRIPTION
Adding the Plynx C++ library for Arduino, ESP32 and ESP8266.

- Repo: https://github.com/NickP005/plynx-library
- Release: v1.0.1
- Passes arduino-lint (--library-manager submit --compliance strict): 0 errors, 0 warnings

It lets you control a board from the Plynx app and speaks the classic Blynk Legacy wire protocol. It is a renamed derivative of the Blynk library by Volodymyr Shymanskyy, redistributed under the same MIT License with attribution kept in LICENSE and in the source files.