### PR TITLE
Add ModbusRTU library

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -9738,3 +9738,4 @@ https://github.com/styropyr0/MAX7219
 https://github.com/LEKPCSTEAM/SmartFont.git
 https://github.com/NickP005/plynx-library
 https://github.com/NotPamusa/RoboReach
+https://github.com/RANINDRAM123/ModbusRTU


### PR DESCRIPTION
## Summary

This pull request adds the ModbusRTU Arduino library to the Arduino Library Manager.

Repository:
https://github.com/RANINDRAM123/ModbusRTU

The library implements a Modbus RTU Master with configurable timeouts and retries, CRC validation, Modbus exception decoding, RS-485 half-duplex support, multiple data-type readers, example sketches, and native unit tests.

The repository includes:
- Valid `library.properties`
- MIT License
- Examples
- Semantic version tags
- GitHub release (`v0.4.0`)