### PR TITLE
Add NessoLink

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -9742,3 +9742,4 @@ https://github.com/NotPamusa/RoboReach
 https://github.com/RANINDRAM123/TameModbus
 https://github.com/LeviMonte/ArduinoRemoteIO
 https://github.com/vedacool/Arduino-Azure-IoT-Central
+https://github.com/ugursayar/NessoLink


### PR DESCRIPTION
Adding https://github.com/ugursayar/NessoLink — versioned binary control-link protocol (RemoteFrame v1/v2 codec + WiFi UDP/TCP, BLE and LoRa transports) for the Arduino Nesso N1 robot controller. Tagged release: 1.1.0. Passes arduino-lint --library-manager submit --compliance specification with no errors or warnings.