### PR TITLE
Remove nonpawite/bcc-esp-dev

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -8993,7 +8993,6 @@ https://github.com/valeriofantozzi/TraccarClient.git
 https://github.com/SofaPirate/PqLEDStrip
 https://github.com/SofaPirate/PqOsc
 https://github.com/dac1e/RcSwitchTransmitter
-https://github.com/nonpawite/bcc-esp-dev
 https://github.com/ennio64/StepperHAL_STM32F4x1-Library
 https://github.com/AymenTurki0/Aerobotix_Arduino_navigation
 https://github.com/Chanatip112/HanumanMini


### PR DESCRIPTION
This pull request **intentionally removes** the URL `https://github.com/nonpawite/bcc-esp-dev` from `repositories.txt`.

I am the maintainer of that library and I am requesting its removal from the Arduino Library Registry, per the "Remove library" procedure in [maintenance-requests.md](https://github.com/arduino/library-registry/blob/main/maintenance-requests.md#remove-library).

The only change is the deletion of that single line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)