### PR TITLE
Remove "BCC_ESP32S3"

### DIFF
--- a/registry.txt
+++ b/registry.txt
@@ -8410,7 +8410,6 @@ https://github.com/RobTillaart/DCT532.git|Contributed|DCT532
 https://github.com/SofaPirate/PqLEDStrip.git|Contributed|PqLEDStrip
 https://github.com/RobTillaart/SHT4x.git|Contributed|SHT4x
 https://github.com/dougp2/Multi_Timer_V2.git|Contributed|Multi_Timer_V2
-https://github.com/nonpawite/bcc-esp-dev.git|Contributed|BCC_ESP32S3
 https://github.com/dac1e/RcSwitchTransmitter.git|Contributed|RcSwitchTransmitter
 https://github.com/ennio64/StepperHAL_STM32F4x1-Library.git|Contributed|StepperHAL_STM32F4x1
 https://github.com/ababdelo/ESPDiscordClient.git|Contributed|ESP Discord Client


### PR DESCRIPTION
Companion to https://github.com/arduino/library-registry/pull/8804