### PR TITLE
Update repositories.txt

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -1,4 +1,5 @@
 https://github.com/David-Vandensteen/dv-iir-filter8
+https://github.com/X-croot/MPU6050Auto
 https://github.com/SolderedElectronics/Soldered-ADSB-Receiver-Arduino-Library
 https://github.com/ZipionLive/RedLab_I2CMatrixKeypad
 https://github.com/houslast3/sistema


### PR DESCRIPTION
# MPU6050Auto

![MPU6050Auto Banner](assets/banner.png)

**The zero-config MPU6050 library: one line to start, auto-calibrated, quaternion-ready.**

[![Arduino Library](https://img.shields.io/badge/Arduino-Library-00979D?logo=arduino&logoColor=white)](https://www.arduino.cc/reference/en/libraries/)
[![PlatformIO](https://img.shields.io/badge/PlatformIO-Registry-orange?logo=platformio&logoColor=white)](https://registry.platformio.org/)
[![GitHub stars](https://img.shields.io/github/stars/X-croot/MPU6050Auto?style=social)](https://github.com/X-croot/MPU6050Auto)
[![License](https://img.shields.io/badge/license-User--Defined-blue.svg)](LICENSE)

---

## Why MPU6050Auto?

Most MPU6050 libraries out there are either barebones register wrappers or bloated do-everything monsters. MPU6050Auto sits in the sweet spot:

- **One-line setup** — `imu.begin()` handles I2C init, WHO_AM_I check, wake, DLPF, and range configuration.
- **Automatic calibration** — On first boot, the library detects if the sensor is stationary and computes gyroscope bias and accelerometer offsets automatically. Data is stored to EEPROM (AVR) or Preferences (ESP32) and reused on every subsequent boot.
- **Motion rejection** — If the sensor moves during calibration, it is retried up to 5 times. No garbage biases are ever saved.
- **Built-in sensor fusion** — Madgwick and Mahony filters are integrated. `imu.getQuaternion()`, `imu.getEuler()`, and `imu.getYawPitchRoll()` just work.
- **Adaptive sample rate** — The sample rate divider auto-tunes to the MCU clock speed (AVR, ESP32, ESP8266, SAMD).
- **Bus abstraction** — Pass any `TwoWire` reference. Works with ESP32 `Wire1`, SoftWire, etc.
- **Low power** — `sleep()`, `wake()`, and hardware motion interrupt support out of the box.
- **Debug mode** — Enable Serial diagnostics with a single build flag (`-DMPU6050AUTO_DEBUG=1`).
- **Zero external dependencies** — Only `Wire.h` and `EEPROM.h`/`Preferences.h` from the core.

---

## Installation

### Arduino IDE (Library Manager)

1. Open **Sketch → Include Library → Manage Libraries...**
2. Search for `MPU6050Auto`
3. Click **Install**

### Arduino IDE (Manual ZIP)

1. Download this repository as a ZIP
2. **Sketch → Include Library → Add .ZIP Library...**
3. Select the downloaded ZIP

### PlatformIO

Add to your `platformio.ini`:

```ini
lib_deps =
    https://github.com/X-croot/MPU6050Auto.git
```

---

## Quick Start

```cpp
#include <MPU6050Auto.h>

MPU6050Auto imu;

void setup() {
    Serial.begin(115200);
    imu.begin();
}

void loop() {
    imu.update();
    Euler e = imu.getEuler();
    Serial.print(e.roll); Serial.print(' ');
    Serial.print(e.pitch); Serial.print(' ');
    Serial.println(e.yaw);
    delay(20);
}
```

That's it. First boot auto-calibrates. Subsequent boots use stored calibration. No manual offset tuning, ever.

---

## API Reference

### Construction

```cpp
MPU6050Auto imu;                          // default: Wire, 0x68
MPU6050Auto imu(Wire1, 0x69);             // custom bus and address
```

### Lifecycle

| Method | Description |
| ------ | ----------- |
| `bool begin()` | Full init with defaults (`ACCEL_2G`, `GYRO_250`, Madgwick). Returns `false` if WHO_AM_I fails. |
| `bool begin(AccelRange, GyroRange, FusionType)` | Init with explicit config. |
| `void update()` | Reads sensors, applies calibration, runs fusion. Call every loop. |
| `bool isConnected()` | Verifies WHO_AM_I response. |
| `void sleep()` / `void wake()` | Power management. |

### Data Access

| Method | Returns |
| ------ | ------- |
| `Vec3 getAccel()` | Acceleration in `g` (bias-corrected) |
| `Vec3 getGyro()` | Angular velocity in `°/s` (bias-corrected) |
| `float getTemperature()` | Die temperature in `°C` |
| `Quat getQuaternion()` | Fusion quaternion `{w, x, y, z}` |
| `Euler getEuler()` | Roll, pitch, yaw in degrees |
| `Euler getYawPitchRoll()` | Yaw-first ordering |

### Calibration

| Method | Description |
| ------ | ----------- |
| `void calibrate(uint16_t samples = 2000)` | Force a fresh calibration and persist it |
| `void resetCalibration()` | Wipe stored offsets from EEPROM/Preferences |

### Fusion

| Method | Description |
| ------ | ----------- |
| `void setFusion(FusionType)` | Switch between `FUSION_MADGWICK`, `FUSION_MAHONY`, `FUSION_NONE` |
| `void setMadgwickBeta(float)` | Madgwick beta (default 0.1) |
| `void setMahonyGains(float kp, float ki)` | Mahony gains (default 2.0, 0.005) |

### Motion Interrupt

| Method | Description |
| ------ | ----------- |
| `void enableMotionInterrupt(uint8_t threshold)` | Threshold in `mg` units (2-255) |
| `void disableMotionInterrupt()` | Turn off motion detection |
| `bool motionDetected()` | Poll motion status |

---

## Sensor Fusion: Madgwick vs Mahony

| Filter | Best For | CPU Cost | Notes |
| ------ | -------- | -------- | ----- |
| **Madgwick** | Higher accuracy, smoother output | Higher | Default. Great for AHRS, drones, VR. |
| **Mahony** | Low-power MCUs, faster convergence | Lower | Better for 8-bit AVR at high rates. |
| **None** | Raw data pipelines | Zero | You supply your own filter downstream. |

Switch at runtime:

```cpp
imu.setFusion(FUSION_MAHONY);
imu.setMahonyGains(5.0f, 0.02f);
```

---

## How Auto-Calibration Works

```
begin() called
      │
      ▼
Read EEPROM/Preferences
      │
      ├─── Magic byte 0xA5 present? ──── yes ──▶ Load offsets, done
      │
      no
      │
      ▼
Collect 2000 samples over ~2s
      │
      ▼
Compute per-axis min/max range
      │
      ├─── Range > 5 °/s on any axis? ─── yes ──▶ Motion detected, retry (up to 5×)
      │
      no
      │
      ▼
Average samples → gyro bias
Average accel → offsets (Z subtracts 1g)
      │
      ▼
Write magic byte + offsets to EEPROM/Preferences
```

Keep the sensor still for the first 2 seconds after power-on. That's it. Every future boot loads instantly.

---

## Wiring

| Board | SDA | SCL | VCC | GND | INT (optional) |
| ----- | --- | --- | --- | --- | -------------- |
| Arduino Uno / Nano | A4 | A5 | 3.3V/5V | GND | D2 |
| Arduino Mega | 20 | 21 | 3.3V/5V | GND | D2 |
| ESP32 (default) | GPIO21 | GPIO22 | 3.3V | GND | any GPIO |
| ESP32 (Wire1) | GPIO25 | GPIO26 | 3.3V | GND | any GPIO |
| ESP8266 (NodeMCU) | D2 (GPIO4) | D1 (GPIO5) | 3.3V | GND | D5 |
| SAMD (Zero/M0) | SDA | SCL | 3.3V | GND | any digital pin |

> ⚠️ MPU6050 breakout boards typically include a 3.3V regulator and level shifters, so 5V VCC is fine on most modules — but always check your specific board.

---

## Troubleshooting

**`begin()` returns `false`**
- Check wiring (SDA/SCL not swapped, pull-ups present)
- Try alternate I2C address: `MPU6050Auto imu(Wire, 0x69);`
- Run an I2C scanner sketch to confirm the device shows up

**Yaw drifts continuously**
- MPU6050 has no magnetometer; yaw drift is expected without a mag. Consider a 9-DOF board (MPU9250) if drift matters.
- Try Mahony with higher `kp` for faster attitude correction on roll/pitch.

**Calibration keeps failing (`autoCalibrate` retries)**
- Sensor is moving. Place it on a flat, stable surface during power-on.
- Vibration from a nearby motor/fan can trigger motion rejection — isolate the board.

**Values look scaled wrong**
- Wrong range enum passed to `begin()`. The library sets the register **and** the scale factor together — don't manually poke `ACCEL_CONFIG`.

**Different I2C bus (ESP32 Wire1)**

```cpp
#include <Wire.h>
#include <MPU6050Auto.h>

MPU6050Auto imu(Wire1);

void setup() {
    Wire1.begin(25, 26);
    imu.begin();
}
```

---

## Examples

- **BasicRead** — Raw accel/gyro streaming
- **OrientationEuler** — Roll/pitch/yaw over Serial
- **QuaternionOutput** — CSV quaternion stream for Processing/Unity visualisation
- **MotionInterrupt** — LED wake on motion detection

---

## Contributing

Issues and pull requests welcome. Please target the `main` branch and follow the existing style (no inline comments — the code is documented by naming).

---

## Author

**Can Ünüvar** — [github.com/X-croot](https://github.com/X-croot)

---

## License

Add your preferred `LICENSE` file to the repository root. MIT is recommended for maximum reach.
