### PR TITLE
Add Blifi library

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -9756,3 +9756,4 @@ https://github.com/mvoss96/bthome-cpp
 https://github.com/mvoss96/SimpleWifiManager
 https://github.com/LZQS1/VQF-for-Arduino
 https://github.com/jwpyle3/DIPSwitch16
+https://github.com/akilaid/esp32-blifi-arduino


### PR DESCRIPTION
Adding https://github.com/akilaid/esp32-blifi-arduino — Blifi, BLE-based Wi-Fi provisioning for ESP32 (Arduino wrapper over an ESP-IDF component). MIT licensed, tagged release v0.1.0.