### PR TITLE
Add ZorozOLED library

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -1,3 +1,4 @@
+https://github.com/Engrzoroz/ZOROZ_OLED
 https://github.com/David-Vandensteen/dv-average-accumulator8
 https://github.com/David-Vandensteen/dv-every-interval
 https://github.com/David-Vandensteen/dv-iir-filter8


### PR DESCRIPTION
This pull request submits the ZorozOLED library for inclusion in the Arduino Library Manager.

Library repository:
https://github.com/Engrzoroz/ZOROZ_OLED

Initial version:
1.0.0