### PR TITLE
Add GreenApi WhatsApp Library

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -9761,3 +9761,4 @@ https://github.com/mvoss96/SimpleWifiManager
 https://github.com/LZQS1/VQF-for-Arduino
 https://github.com/jwpyle3/DIPSwitch16
 https://github.com/akilaid/esp32-blifi-arduino
+https://github.com/t0mer/GreenApi-WhatsApp-Library.git


### PR DESCRIPTION
### Add library to Library Manager index

Adding the **GreenApi** library to the registry.

- **Repository:** https://github.com/t0mer/GreenApi-WhatsApp-Library
- **Author/Maintainer:** Tomer Klein <tomer.klein@gmail.com>
- **Latest release tag:** `1.1.0`
- **Category:** Communication
- **Architectures:** esp32, esp8266

**What it does:** A small Arduino library for sending WhatsApp messages via the
Green-API service. It wraps the required HTTPS request and JSON formatting into a
simple `GreenApi` class, so a message can be sent in a couple of lines. Works on
both ESP32 and ESP8266.

### Checklist
- [x] The repository is public.
- [x] `library.properties` is present in the repository root and valid.
- [x] The library has at least one release tag using semantic versioning (`1.1.0`).
- [x] The library name (`GreenApi`) is unique in the index.
- [x] The code is licensed (see `LICENSE`).