### PR TITLE
Register VIA_Arduino library

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -9763,3 +9763,4 @@ https://github.com/jwpyle3/DIPSwitch16
 https://github.com/akilaid/esp32-blifi-arduino
 https://github.com/t0mer/GreenApi-WhatsApp-Library.git
 https://github.com/anvishinc/GlideEdgent
+https://github.com/juarendra/VIA-Arduino


### PR DESCRIPTION
Registers https://github.com/juarendra/VIA-Arduino for installation through Arduino Library Manager.\n\nValidation: VIA_Arduino v0.1.0 is a published stable GitHub release, and the repository CI passed Arduino Lint with Library Manager submission rules.