### PR TITLE
Add RN8209D Arduino library

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -9764,3 +9764,4 @@ https://github.com/akilaid/esp32-blifi-arduino
 https://github.com/t0mer/GreenApi-WhatsApp-Library.git
 https://github.com/anvishinc/GlideEdgent
 https://github.com/juarendra/VIA-Arduino
+https://github.com/juarendra/RN8209D-Arduino


### PR DESCRIPTION
Registers https://github.com/juarendra/RN8209D-Arduino for Arduino Library Manager. Release v0.1.0 is tagged, Arduino Lint passes, and UART and SPI examples compile for ESP32.