### PR TITLE
Add MR24HPC1 Arduino library

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -9765,3 +9765,4 @@ https://github.com/t0mer/GreenApi-WhatsApp-Library.git
 https://github.com/anvishinc/GlideEdgent
 https://github.com/juarendra/VIA-Arduino
 https://github.com/juarendra/RN8209D-Arduino
+https://github.com/juarendra/MR24HPC1-Arduino


### PR DESCRIPTION
Registers https://github.com/juarendra/MR24HPC1-Arduino for Arduino Library Manager. Release v0.1.0 is tagged, Arduino Lint passes, and the UART and I2C examples compile for ESP32.