### PR TITLE
Add ZE40B-TVOC Arduino library

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -9766,3 +9766,4 @@ https://github.com/anvishinc/GlideEdgent
 https://github.com/juarendra/VIA-Arduino
 https://github.com/juarendra/RN8209D-Arduino
 https://github.com/juarendra/MR24HPC1-Arduino
+https://github.com/juarendra/ZE40B-TVOC-Arduino


### PR DESCRIPTION
Adds the ZE40B-TVOC Arduino library for the Winsen ZE40B-TVOC UART sensor. The repository contains a tagged v0.1.0 release, library.properties, MIT license, and passing Arduino Lint/ESP32 example CI.