### PR TITLE
Add ADPD188BI Arduino library

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -9767,3 +9767,4 @@ https://github.com/juarendra/VIA-Arduino
 https://github.com/juarendra/RN8209D-Arduino
 https://github.com/juarendra/MR24HPC1-Arduino
 https://github.com/juarendra/ZE40B-TVOC-Arduino
+https://github.com/juarendra/ADPD188BI-Arduino


### PR DESCRIPTION
Adds the ADPD188BI Arduino library for the Analog Devices optical smoke detector. The repository has a tagged v0.1.0 release, an MIT license, Arduino Library Manager metadata, and passing Arduino Lint/ESP32 example CI.