### PR TITLE
Add D6F-W04A1 Arduino library

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -9768,3 +9768,4 @@ https://github.com/juarendra/RN8209D-Arduino
 https://github.com/juarendra/MR24HPC1-Arduino
 https://github.com/juarendra/ZE40B-TVOC-Arduino
 https://github.com/juarendra/ADPD188BI-Arduino
+https://github.com/juarendra/D6F-W04A1-Arduino


### PR DESCRIPTION
Adds the D6F-W04A1 Arduino library for the Omron analog air-flow sensor. The repository includes a tagged v0.1.0 release, MIT license, Library Manager metadata, and passing Arduino Lint/ESP32 example CI.