### PR TITLE
Add LU9685 library

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -9769,3 +9769,5 @@ https://github.com/juarendra/MR24HPC1-Arduino
 https://github.com/juarendra/ZE40B-TVOC-Arduino
 https://github.com/juarendra/ADPD188BI-Arduino
 https://github.com/juarendra/D6F-W04A1-Arduino
+
+https://github.com/eleboys/LU9685


### PR DESCRIPTION
## Library

- **Name:** LU9685
- **URL:** https://github.com/eleboys/LU9685
- **Latest release:** [1.1.0](https://github.com/eleboys/LU9685/releases/tag/1.1.0)

Arduino library for the LU9685-20CU 20-channel I2C servo controller module.

Compliance notes:
- Library 1.5 format (`src/`, `library.properties`, `includes=LU9685.h`)
- MIT licensed
- Tagged release `1.1.0` matches `version` in `library.properties`
