### PR TITLE
Add Arduino_GFX_Graph

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -9775,3 +9775,4 @@ https://github.com/eleboys/LU9685
 https://github.com/bnorth12/LC29H_GNSS-Library
 https://github.com/Xinyuan-LilyGO/LilyGo-display-library
 https://github.com/htlabnet/Pico_USB_Disp
+https://github.com/hazowa/Arduino_GFX_Graph


### PR DESCRIPTION
``markdown
Adds GFX_Graph, a small 2D graphing library for Arduino_GFX: axes, grids, tick
labels and data series on any display Arduino_GFX supports.

- Repository: https://github.com/hazowa/Arduino_GFX_Graph
- Tagged release: v1.0.0
- `arduino-lint --library-manager submit` runs green in CI on every push.
```