### PR TITLE
Add AlfredoDShot

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -9785,3 +9785,4 @@ https://github.com/PiezoSonic/PSI
 https://github.com/Stutchbury/ResistiveTouchScreen
 https://github.com/noureddine-akouchah/nourgrid-arduino.git
 https://github.com/jwachlin/open-rc-spotter
+https://github.com/AlfredoSystems/AlfredoDShot


### PR DESCRIPTION
https://github.com/AlfredoSystems/AlfredoDShot

Bidirectional DShot for the ESP32 over the RMT peripheral, aimed at AM32 ESCs. One GPIO per ESC, with GCR eRPM telemetry and Extended DShot Telemetry.