### PR TITLE
Add VL53L5CX library

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -9787,3 +9787,4 @@ https://github.com/noureddine-akouchah/nourgrid-arduino.git
 https://github.com/jwachlin/open-rc-spotter
 https://github.com/AlfredoSystems/AlfredoDShot
 https://github.com/krulkip/PN532Toolkit
+https://github.com/amitxgit/VL53L5CX-Arduino


### PR DESCRIPTION
Adds https://github.com/amitxgit/VL53L5CX-Arduino to the Arduino Library Manager registry. The v0.1.0 release is tagged, passes strict Arduino Library Manager lint, and its ESP32 example compiles in CI. Hardware validation is pending.