### PR TITLE
Add new repository link for synapse

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -9817,7 +9817,7 @@ https://github.com/jwachlin/open-rc-spotter
 https://github.com/AlfredoSystems/AlfredoDShot
 https://github.com/krulkip/PN532Toolkit
 https://github.com/amitxgit/VL53L5CX-Arduino
-https://github.com/Kkmit13/synapse
+https://github.com/Kkmit13/synapse-arduino
 https://github.com/nawawimegahertz/FarmSense
 https://github.com/bozont/millisRTC
 https://github.com/GroeiAcademie/GroeiAcademie

--- a/repositories.txt
+++ b/repositories.txt
@@ -9788,3 +9788,4 @@ https://github.com/jwachlin/open-rc-spotter
 https://github.com/AlfredoSystems/AlfredoDShot
 https://github.com/krulkip/PN532Toolkit
 https://github.com/amitxgit/VL53L5CX-Arduino
+https://github.com/Kkmit13/synapse


### PR DESCRIPTION
Client for the Synapse embedded systems debugger.

Supports:
- WiFi mode: ESP32, ESP8266, Arduino Nano 33 IoT (direct HTTP POST)
- Serial bridge mode: Arduino Uno, Nano, Mega (USB serial → Python bridge)

Repository: https://github.com/Kkmit13/synapse-arduino