### PR TITLE
Add ADS112C04 Arduino library

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -9794,6 +9794,7 @@ https://github.com/juarendra/MR24HPC1-Arduino
 https://github.com/juarendra/ZE40B-TVOC-Arduino
 https://github.com/juarendra/ADPD188BI-Arduino
 https://github.com/juarendra/D6F-W04A1-Arduino
+https://github.com/juarendra/ADS112C04-Arduino
 https://github.com/PrimusKirill/BD37033
 https://github.com/eleboys/LU9685
 https://github.com/bnorth12/LC29H_GNSS-Library


### PR DESCRIPTION
Adds https://github.com/juarendra/ADS112C04-Arduino to the Library Manager registry.