### PR TITLE
Add IP5108 library

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -9813,3 +9813,4 @@ https://github.com/jwachlin/open-rc-spotter
 https://github.com/AlfredoSystems/AlfredoDShot
 https://github.com/krulkip/PN532Toolkit
 https://github.com/amitxgit/VL53L5CX-Arduino
+https://github.com/milad-nikpendar/IP5108


### PR DESCRIPTION
Arduino library for the IP5108 power management IC (Li-ion charge/boost/flashlight controller) over I2C.

Repository: https://github.com/milad-nikpendar/IP5108