### PR TITLE
chore: add unit_devlab_mpu6005_library to registry

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -9067,6 +9067,7 @@ https://github.com/UNIT-Electronics-MX/unit_devlab_veml3328_library
 https://github.com/UNIT-Electronics-MX/unit_devlab_max30102_library
 https://github.com/UNIT-Electronics-MX/unit_cmsis_dap_ch55x_library
 https://github.com/UNIT-Electronics-MX/unit_devlab_joystickcontroller_library
+https://github.com/UNIT-Electronics-MX/unit_devlab_mpu6005_library
 https://github.com/jmwanderer/tlv.arduino
 https://github.com/PaulNTU/MoonMin-Scanner-Arduino-Library
 https://gitlab.com/Vishal1695/mvswifi_esp32


### PR DESCRIPTION
## Summary

DevLab_MPU6050 is a lightweight Arduino library for controlling the MPU6050 6-axis IMU through direct I²C register communication.

The library provides an object-oriented interface for:

- Reading raw three-axis accelerometer data
- Reading raw three-axis gyroscope data
- Measuring temperature in degrees Celsius
- Selecting accelerometer and gyroscope ranges
- Configuring custom I²C pins and clock speed
- Using either the `0x68` or `0x69` I²C address
- Verifying the sensor through the `WHO_AM_I` register

It includes basic reading and `DATA_RDY` interrupt examples. The library is intended for ESP32 and Arduino-compatible platforms and is distributed under the MIT License.

## Version

`1.0.0`

## Communication Interface

I²C

## License

MIT License