### PR TITLE
chore: update repositories with DevLab_TCAN1051VHD

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -9068,6 +9068,7 @@ https://github.com/UNIT-Electronics-MX/unit_devlab_max30102_library
 https://github.com/UNIT-Electronics-MX/unit_cmsis_dap_ch55x_library
 https://github.com/UNIT-Electronics-MX/unit_devlab_joystickcontroller_library
 https://github.com/UNIT-Electronics-MX/unit_devlab_mpu6005_library
+https://github.com/UNIT-Electronics-MX/unit_devlab_tcan1051hvd_library
 https://github.com/jmwanderer/tlv.arduino
 https://github.com/PaulNTU/MoonMin-Scanner-Arduino-Library
 https://gitlab.com/Vishal1695/mvswifi_esp32


### PR DESCRIPTION
DevLab_TCAN1051HVD — Summary
Arduino library for the Texas Instruments TCAN1051HVD CAN transceiver, built on top of the native ESP32 TWAI controller.

The TCAN1051HVD is a physical-layer-only transceiver (no SPI/I2C control interface) that sits between the MCU's TWAI controller and the CANH/CANL bus. Since this module wires only TXD, RXD, VIO, GND, CANH and CANL (no S/Silent Mode pin), the library focuses on wrapping the ESP-IDF TWAI driver with a clean, object-oriented Arduino API — handling initialization, frame transmission/reception, bus/controller error reporting, and bus-off recovery, without requiring any external CAN controller IC.

Category: Communication
Architecture: esp32 (ESP32, S3, C3, C6, C5, H2, P4)
Version: 1.0.0
License: MIT