### PR TITLE
Add italo-coelho/UpdateOTW

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -9834,3 +9834,4 @@ https://github.com/m5stack/M5Unit-LIGHT
 https://github.com/m5stack/M5Unit-FLASHLIGHT
 https://github.com/AlenKrishna2012/EEPROM24CXX
 https://github.com/Kinshuk-2005/ADRF6655
+https://github.com/italo-coelho/UpdateOTW.git


### PR DESCRIPTION
Firmware update over the wire: a Modbus RTU master streams a firmware image to a slave over half-duplex RS485, and the slave reboots into it without stopping what it was doing.

https://github.com/italo-coelho/UpdateOTW

- Tagged `v1.0.0`
- `arduino-lint --library-manager submit --compliance strict` passes with no errors or warnings
- ESP32, Arduino framework, no external dependencies