### PR TITLE
Add ESP32 BLE Keyboard libraryUpdate repositories.txt

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -9838,3 +9838,5 @@ https://github.com/italo-coelho/UpdateOTW.git
 https://github.com/Carbonara-Individuals/Carbonara_DRV8874
 https://github.com/forgevolt/SoundEngine
 https://github.com/forgevolt/ESPNowUtilities
+https://github.com/gsgaurav0/ESP32-BLE-Keyboard
+


### PR DESCRIPTION
## Add ESP32 HID Keyboard Library

Repository:
https://github.com/gsgaurav0/ESP32-HID-Keyboard

Library Name:
ESP32 HID Keyboard

Description:
ESP32 HID Keyboard is a Bluetooth HID keyboard library for ESP32 boards. It allows ESP32 devices to emulate a Bluetooth keyboard and send text, key presses, and multimedia keys to paired devices.

Version:
v1.0.0

Author:
Gaurav Sharma

Maintainer:
Gaurav Sharma <ss3573509@gmail.com>

License:
MIT