### PR TITLE
MPU6050 Library Renamed

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -9071,7 +9071,7 @@ https://github.com/UNIT-Electronics-MX/unit_devlab_veml3328_library
 https://github.com/UNIT-Electronics-MX/unit_devlab_max30102_library
 https://github.com/UNIT-Electronics-MX/unit_cmsis_dap_ch55x_library
 https://github.com/UNIT-Electronics-MX/unit_devlab_joystickcontroller_library
-https://github.com/UNIT-Electronics-MX/unit_devlab_mpu6005_library
+https://github.com/UNIT-Electronics-MX/unit_devlab_mpu6050_library
 https://github.com/UNIT-Electronics-MX/unit_devlab_tcan1051hvd_library
 https://github.com/jmwanderer/tlv.arduino
 https://github.com/PaulNTU/MoonMin-Scanner-Arduino-Library

--- a/repositories.txt
+++ b/repositories.txt
@@ -9068,6 +9068,7 @@ https://github.com/UNIT-Electronics-MX/unit_devlab_max30102_library
 https://github.com/UNIT-Electronics-MX/unit_cmsis_dap_ch55x_library
 https://github.com/UNIT-Electronics-MX/unit_devlab_joystickcontroller_library
 https://github.com/UNIT-Electronics-MX/unit_devlab_mpu6005_library
+https://github.com/UNIT-Electronics-MX/unit_devlab_tcan1051hvd_library
 https://github.com/jmwanderer/tlv.arduino
 https://github.com/PaulNTU/MoonMin-Scanner-Arduino-Library
 https://gitlab.com/Vishal1695/mvswifi_esp32


### PR DESCRIPTION
The repository unit_devlab_mpu6005_library was renamed to unit_devlab_mpu6050_library
(typo fix: 6005 → 6050). This PR updates the registry entry to point to the new URL
so the Library Manager doesn't lose track of the existing library.