### PR TITLE
Update URL of DevLab_MPU6050

### DIFF
--- a/registry.txt
+++ b/registry.txt
@@ -9809,7 +9809,7 @@ https://github.com/EnviroDIY/EpochTime.git|Contributed|EpochTime
 https://github.com/nawawimegahertz/FarmSense.git|Contributed|FarmSense
 https://github.com/tanakamasayuki/EspBle.git|Contributed|EspBle
 https://github.com/bozont/millisRTC.git|Contributed|millisRTC
-https://github.com/UNIT-Electronics-MX/unit_devlab_mpu6005_library.git|Contributed|DevLab_MPU6050
+https://github.com/UNIT-Electronics-MX/unit_devlab_mpu6050_library.git|Contributed|DevLab_MPU6050
 https://github.com/UNIT-Electronics-MX/unit_devlab_tcan1051hvd_library.git|Contributed|DevLab_TCAN1051HVD
 https://github.com/GroeiAcademie/GroeiAcademie.git|Contributed|GroeiAcademie
 https://github.com/David-Vandensteen/dv-dual-hold-state.git|Contributed|dv_dual_hold_state


### PR DESCRIPTION
Companion to https://github.com/arduino/library-registry/pull/8888