### PR TITLE
Add RadioCore_Kit library

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -9840,3 +9840,4 @@ https://github.com/forgevolt/SoundEngine
 https://github.com/forgevolt/ESPNowUtilities
 https://github.com/gsgaurav0/ESP32-HID-Keyboard
 https://github.com/xXMarifFXx/N-R_ESP32.git
+https://github.com/HelTecAutomation/RadioCore_Library


### PR DESCRIPTION
Submit https://github.com/HelTecAutomation/RadioCore_Library for inclusion in the Arduino Library Manager index.