### PR TITLE
Add new repository link for BACnet-Arduino

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -9840,3 +9840,4 @@ https://github.com/forgevolt/SoundEngine
 https://github.com/forgevolt/ESPNowUtilities
 https://github.com/gsgaurav0/ESP32-HID-Keyboard
 https://github.com/xXMarifFXx/N-R_ESP32.git
+https://github.com/NitrofMtl/BACnet-Arduino


### PR DESCRIPTION
Arduino BACnet library based on bacnet-stack, with BACnet/IP, objects, scheduling, and Arduino platform integration.