### PR TITLE
Add NobroRTOSCore

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -9776,6 +9776,7 @@ https://github.com/fikrielektro21/MHZ19
 https://github.com/streef/YetAnotherRotaryEncoder
 https://github.com/matthias-bs/esp32-shelly-ble-rpc
 https://github.com/dunknowcoding/NobroRTOS-Arduino
+https://github.com/dunknowcoding/NobroRTOS
 https://github.com/dunknowcoding/NiusAudio
 https://github.com/Alash-electronics/Alash_DS1302
 https://github.com/Alash-electronics/AlashKeypadMatrix


### PR DESCRIPTION
Adds the GPL-3.0-only NobroRTOSCore Arduino library.

Repository: https://github.com/dunknowcoding/NobroRTOS
Release: https://github.com/dunknowcoding/NobroRTOS/releases/tag/v1.0.0

The v1.0.0 tag passes strict Arduino library lint and AVR compilation in the public release workflow.