### PR TITLE
Add stringToSevenSegmentDisplay library

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -9846,3 +9846,4 @@ https://github.com/NitrofMtl/BACnet-Arduino
 https://github.com/sedislab/arduino-sentil
 https://github.com/HelTecAutomation/RadioCore_Library
 https://github.com/FT-tele/IT7259_Touch_driver
+https://github.com/neoge/stringToSevenSegmentDisplay


### PR DESCRIPTION
Library: https://github.com/neoge/stringToSevenSegmentDisplay

The library converts strings to segment codes for 7-segment displays.
Shift registers of type 74HC595 drive the display. Three pins are
necessary.

- The repository has a Git tag for release 1.0.0.
- arduino-lint 1.3.0 with --library-manager submit shows no errors and
  no warnings.
- The repository has two example sketches, a README file and an MIT
  license.