### PR TITLE
Add new repository link for ESP-DOOM

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -9848,3 +9848,4 @@ https://github.com/sedislab/arduino-sentil
 https://github.com/HelTecAutomation/RadioCore_Library
 https://github.com/FT-tele/IT7259_Touch_driver
 https://github.com/neoge/stringToSevenSegmentDisplay
+https://github.com/rear16/ESP-DOOM


### PR DESCRIPTION
Adding my library ESP-DOOM (Doom engine port for ESP32-S3).