### PR TITLE
Add NIELIT Arduino UNO and ESP32 Practicals libraries

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -9855,3 +9855,5 @@ https://github.com/dkaukov/esp32-afsk
 https://github.com/nemo4598/AutonomniOTA
 https://github.com/Studio-Poetics/ST77916_QSPI
 https://github.com/FltSimTech/ISRdelay
+https://github.com/lovnishverma/NIELIT-Arduino-UNO-Practicals
+https://github.com/lovnishverma/NIELIT-ESP32-Practicals


### PR DESCRIPTION
## Libraries submitted

- https://github.com/lovnishverma/NIELIT-Arduino-UNO-Practicals
- https://github.com/lovnishverma/NIELIT-ESP32-Practicals

Both libraries are intended for educational Arduino UNO and ESP32 practical training.

Both repositories contain:
- `library.properties`
- `README.md`
- `src/`
- `examples/`
- Version `1.0.0` release/tag