### PR TITLE
Add AlloyLogger

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -9859,3 +9859,4 @@ https://github.com/FltSimTech/ISRdelay
 https://github.com/lovnishverma/NIELIT-Arduino-UNO-Practicals
 https://github.com/lovnishverma/NIELIT-ESP32-Practicals
 https://github.com/Stutchbury/ScreenManager
+https://github.com/alloyrobotics/alloy-logger-arduino


### PR DESCRIPTION
Add the AlloyLogger Arduino library:

https://github.com/alloyrobotics/alloy-logger-arduino

The current `0.5.0` tag passes Arduino Lint 1.3.0 with strict Library Manager submission compliance: 0 errors, 0 warnings.
