### PR TITLE
Add DS3501 repository link

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -6262,6 +6262,7 @@ https://github.com/RobTillaart/DS2401
 https://github.com/RobTillaart/DS2438
 https://github.com/RobTillaart/DS28CM00
 https://github.com/RobTillaart/DS3232
+https://github.com/RobTillaart/DS3501
 https://github.com/RobTillaart/DS3502
 https://github.com/RobTillaart/ellipse
 https://github.com/RobTillaart/ERCFS


### PR DESCRIPTION
Arduino library for the DS3501, I2C, 7-bit, non-volatile, digital potentiometer. Temperature control.