### PR TITLE
Add ExecuTorch

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -9863,3 +9863,4 @@ https://github.com/lovnishverma/NIELIT-ESP32-Practicals
 https://github.com/Stutchbury/ScreenManager
 https://github.com/alloyrobotics/alloy-logger-arduino
 https://github.com/jackjansen/cmArduinoJWT
+https://github.com/meta-pytorch/executorch-arduino


### PR DESCRIPTION
Adds [ExecuTorch](https://github.com/meta-pytorch/executorch-arduino), PyTorch's on-device inference runtime, packaged as an Arduino library.

It runs models exported from PyTorch (`.pte`) directly on the board, using CMSIS-NN accelerated int8 kernels on Cortex-M. The three examples cover a minimal model load, a full inference pass, and a quantized keyword-spotting DS-CNN running on real audio features.

Supported board is the Arduino UNO Q (`arduino:zephyr`). No other cores are claimed — ExecuTorch requires C++17, and the other official ARM cores currently ship a 2017 toolchain that cannot build it.

Before submitting:

- `arduino-lint --project-type library --library-manager submit --compliance strict` → no errors or warnings
- tagged `v0.1.0`; the tagged tree is exactly what passed that check
- all three examples compile and run correctly on hardware
