### PR TITLE
Add M5Stamp-UWB library

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -9872,3 +9872,4 @@ https://github.com/meta-pytorch/executorch-arduino
 https://github.com/aneesharnavch/microinput
 https://github.com/ahmed-Idrees/QuadratureEncoder
 https://github.com/atvirokodosprendimai/arduino-dali
+https://github.com/m5stack/M5Stamp-UWB


### PR DESCRIPTION
Add the M5Stack Stamp UWB Arduino library to the Arduino Library Manager registry.

Repository: https://github.com/m5stack/M5Stamp-UWB