### PR TITLE
Add Pardalote

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -9874,3 +9874,4 @@ https://github.com/aneesharnavch/microinput
 https://github.com/ahmed-Idrees/QuadratureEncoder
 https://github.com/atvirokodosprendimai/arduino-dali
 https://github.com/m5stack/M5Stamp-UWB
+https://github.com/ScottMit/Pardalote-arduino


### PR DESCRIPTION
Adding **Pardalote** — an Arduino library that lets you control hardware directly from a web browser or p5.js over WiFi or USB serial, using a compact binary protocol. Opt-in extensions for servos, steppers, Feetech bus servos, NeoPixels, ultrasonic sensors, IMUs, rotary encoders, and the ESP32 camera.

- Repository: https://github.com/ScottMit/Pardalote-arduino
- Boards: ESP32, Arduino UNO R4 (WiFi & Minima) — `architectures=esp32,renesas_uno`
- License: GPL-3.0

Submission checklist:
- [x] `library.properties` is in the repository root
- [x] A release/tag (`1.0.0`) matching the `library.properties` version is present
- [x] `arduino-lint --library-manager submit` passes with no errors or warnings
- [x] The `name` value is unique and does not start with "Arduino"
- [x] The repository contains no executables, symlinks, or bundled binaries