### PR TITLE
Add Waveshare_TFT_Touch_Arduino

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -9879,3 +9879,4 @@ https://github.com/ScottMit/Pardalote-arduino
 https://github.com/ayresnet/AyresTimer
 https://github.com/alirezashirzadath/soocket
 https://github.com/SUNSETDEVER/3DM_Xrenderer
+https://github.com/teddokano/Waveshare_TFT_Touch_Arduino


### PR DESCRIPTION
Adds https://github.com/teddokano/Waveshare_TFT_Touch_Arduino, an Arduino driver for the Waveshare 2.8inch TFT Touch Shield (SKU 10684; ST7789V LCD + XPT2046 resistive touch).

- Library.properties at repo root, Arduino Library 1.5 format
- Tagged release: [1.0.0](https://github.com/teddokano/Waveshare_TFT_Touch_Arduino/releases/tag/1.0.0)
- CI compiles all examples against 4 boards (arduino:avr, arduino:renesas_uno, nxp:mcx frdm_mcxa153/frdm_mcxn947) on every push
- All examples verified on real hardware on all 4 boards