### PR TITLE
Add Bellows

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -9884,3 +9884,4 @@ https://github.com/umeiko/PicoCamera
 https://github.com/vishal-95-um/esp32-iot-management
 https://github.com/ramo828/tiny_print_library
 https://github.com/aSharcc/PMW3389-Library-Arduino
+https://github.com/virgilvox/bellows-embedded


### PR DESCRIPTION
Adds https://github.com/virgilvox/bellows-embedded

**Bellows** is header-only C++17 audio synthesis, music theory and sequencing for 32-bit microcontrollers: oscillators, filters, envelopes, drum and physical-modelling voices, effects, plus scales, chords, tunings, euclidean rhythms and a tempo map. Nothing allocates and nothing self-registers, so you include one header and you link one engine.

Checked before submitting:

- `arduino-lint --library-manager submit --compliance strict` passes with no errors or warnings, run against a fresh clone of the 0.1.0 tag.
- 16 of the 17 examples compile with `arduino-cli` on a Teensy 4.1. The seventeenth, `12_DacOut`, declines with a deliberate `#error` because a Teensy 4.x has no DAC.
- Tagged `0.1.0`, matching `version` in `library.properties`.
- Apache-2.0, `LICENSE` included.

The repository is a generated mirror of `packages/bellows-embedded` in https://github.com/virgilvox/bellowsjs, flattened so `library.properties` sits at the root. `MIRROR.md` says so and points contributors at the monorepo.