### PR TITLE
Add loxdb library

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -9887,3 +9887,4 @@ https://github.com/ramo828/tiny_print_library
 https://github.com/aSharcc/PMW3389-Library-Arduino
 https://github.com/virgilvox/bellows-embedded
 https://github.com/m5stack/M5Unit-8Servos2-I2C
+https://github.com/Vanderhell/loxdb


### PR DESCRIPTION
Adds loxdb to the Arduino Library Manager registry.

Repository:
https://github.com/Vanderhell/loxdb

Latest release: v1.5.4
Architecture: ESP32

The library has been validated with Arduino Library Manager lint and compiled successfully for ESP32-S3.