### PR TITLE
Add AzDeck library

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -9895,3 +9895,4 @@ https://github.com/Awulokune/ESP32_ST7789_Fast
 https://github.com/FMazz97/CS123x
 https://github.com/iskakfatoni/IskakINO
 https://github.com/agusevtec/eva-boxy
+https://github.com/aztechell/azdeck-lib


### PR DESCRIPTION
Add AzDeck to the Arduino Library Manager registry.

Repository: https://github.com/aztechell/azdeck-lib

Latest release: v0.1.0

Made with [Cursor](https://cursor.com)