### PR TITLE
Add Adafruit TMF8801

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -9897,3 +9897,4 @@ https://github.com/iskakfatoni/IskakINO
 https://github.com/agusevtec/eva-boxy
 https://github.com/aztechell/azdeck-lib
 https://github.com/ToasterForSale/RideLinkBLE
+https://github.com/adafruit/Adafruit_TMF8801


### PR DESCRIPTION
Adds the Adafruit TMF8801 Arduino library to Library Manager.

Repository: https://github.com/adafruit/Adafruit_TMF8801
Release: https://github.com/adafruit/Adafruit_TMF8801/releases/tag/1.0.0