### PR TITLE
feat: add repository link for esp32-mcp

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -9902,3 +9902,4 @@ https://github.com/adafruit/Adafruit_TMF8801
 https://github.com/codewitch-honey-crisis/htcw_multibutton
 https://github.com/m5stack/M5Faces
 https://github.com/davisonaudio/MAX98389
+https://github.com/PedroFnseca/esp32-mcp


### PR DESCRIPTION
This PR adds the repository:

[https://github.com/PedroFonseca/esp32-mcp](https://github.com/PedroFonseca/esp32-mcp)

**Library:** ESP32-MCP
**Category:** Communication
**Architectures:** esp32
**License:** MIT

The library follows the Arduino Library Specification, includes semantic versioning, and passes `arduino-lint` with `--library-manager submit --compliance strict`.

Ready for inclusion in the Arduino Library Manager.