### PR TITLE
Add SeaPerchDepthSensor

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -9904,3 +9904,4 @@ https://github.com/codewitch-honey-crisis/htcw_multibutton
 https://github.com/m5stack/M5Faces
 https://github.com/davisonaudio/MAX98389
 https://github.com/PedroFnseca/esp32-mcp
+https://github.com/charleszyong/SeaPerchDepthSensor


### PR DESCRIPTION
Adds the SeaPerchDepthSensor Arduino library repository. Version 1.0.0 is released, Arduino Lint passes in strict Library Manager submission mode with no warnings, and all examples compile for Arduino UNO R4 Minima, UNO R4 WiFi, and Nano R4.