### PR TITLE
Add NiusBus

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -9906,3 +9906,4 @@ https://github.com/m5stack/M5Faces
 https://github.com/davisonaudio/MAX98389
 https://github.com/PedroFnseca/esp32-mcp
 https://github.com/charleszyong/SeaPerchDepthSensor
+https://github.com/dunknowcoding/NiusBus


### PR DESCRIPTION
Adding NiusBus, an Arduino library of drivers for the CAN, CAN FD, RS-485 and Ethernet modules commonly sold on AliExpress and Amazon.

- Repository: https://github.com/dunknowcoding/NiusBus
- Release: v0.1.0
- Licence: MIT

Covers MCP2515 and MCP2518FD CAN, the MAX485 family with Modbus RTU, W5500 sockets and DHCP, ENC28J60 raw frames, and the WIZnet/USR serial bridges. No dynamic allocation; builds for AVR, megaAVR, SAMD, ESP32 and Renesas RA4.