### PR TITLE
Add ZoneStarIoT

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -9911,3 +9911,4 @@ https://github.com/PedroFnseca/esp32-mcp
 https://github.com/charleszyong/SeaPerchDepthSensor
 https://github.com/dunknowcoding/NiusBus
 https://github.com/Terry-Gould/CANSignalStudioInterface
+https://github.com/sheesourav0/zonestar-iot-arduino


### PR DESCRIPTION
Arduino library for ZoneStar IoT devices -- typed device API over MQTT/TLS (switch, light, fan, thermostat, lock, blinds, garage).

Repository: https://github.com/sheesourav0/zonestar-iot-arduino
Release: https://github.com/sheesourav0/zonestar-iot-arduino/releases/tag/1.0.0