### PR TITLE
Add Adafruit TSL2585

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -9915,3 +9915,4 @@ https://github.com/Terry-Gould/CANSignalStudioInterface
 https://github.com/sheesourav0/zonestar-iot-arduino
 https://github.com/PTSolns/I2Connect_ICP-20100
 https://github.com/PTSolns/I2Connect_KXTJ3-1057
+https://github.com/adafruit/Adafruit_TSL2585


### PR DESCRIPTION
Adds the Adafruit TSL2585 sensor library. Release 1.0.0 passes the Arduino Library Manager submission lint with zero errors.