### PR TITLE
Add RoboS3 library

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -8438,6 +8438,7 @@ https://github.com/DerWaldi/Tiny-I2C-Drivers
 https://github.com/bayeggex/Arduino-AI-Chat-Library
 https://github.com/GRMrGecko/cmd
 https://github.com/joaoaugustocz/LidarArray
+https://github.com/joaoaugustocz/RoboS3
 https://github.com/a3510377/arduino-uno-car
 https://github.com/ayushsharma82/NetWizard
 https://github.com/Zhentao-Lin/WS2812_Lib_for_Air001


### PR DESCRIPTION
Adds the RoboS3 educational robotics library for the ESP32-S3-based RoboS3 board. Release v0.1.0 is available at https://github.com/joaoaugustocz/RoboS3/releases/tag/v0.1.0.