### PR TITLE
Add MLBScoreboard-Arduino-Library

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -9919,3 +9919,4 @@ https://github.com/PTSolns/I2Connect_KXTJ3-1057
 https://github.com/adafruit/Adafruit_TSL2585
 https://github.com/adafruit/Adafruit_GP8403
 https://github.com/todbot/TS20_Arduino
+https://github.com/5ne/MLBScoreboard-Arduino-Library


### PR DESCRIPTION
Built a MLBScoreboard parser with the unofficial API on mlb.com.  The code is tested on an InkPlate2 (the only hardware I have) but it works well and I'll be testing further in the coming days.  This is the first release of the app.  