### PR TITLE
Add TecnovaIoT

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -9923,3 +9923,4 @@ https://github.com/todbot/TS20_Arduino
 https://github.com/5ne/MLBScoreboard-Arduino-Library
 https://github.com/Protocentral/protocentral_tinygsr_arduino
 https://github.com/cyfney/cyfney-cpp-arduino
+https://github.com/pipe1391/TecnovaIoT


### PR DESCRIPTION
## Descripcion

Agrega TecnovaIoT: conecta un ESP32 a la plataforma IoT Tecnova (panel.ceetecnova.com) por MQTT sobre WebSocket seguro -- maneja WiFi, credenciales del webhook del dispositivo, validacion TLS del broker y reconexion automatica, direccionando variables por nombre en vez de indice fijo.

Repositorio: https://github.com/pipe1391/TecnovaIoT