### PR TITLE
feat: update repositories.txt with the ddp library

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -9096,6 +9096,7 @@ https://github.com/UNIT-Electronics-MX/unit_cmsis_dap_ch55x_library
 https://github.com/UNIT-Electronics-MX/unit_devlab_joystickcontroller_library
 https://github.com/UNIT-Electronics-MX/unit_devlab_mpu6050_library
 https://github.com/UNIT-Electronics-MX/unit_devlab_tcan1051hvd_library
+https://github.com/UNIT-Electronics-MX/unit_devlab_ddp_library
 https://github.com/jmwanderer/tlv.arduino
 https://github.com/PaulNTU/MoonMin-Scanner-Arduino-Library
 https://gitlab.com/Vishal1695/mvswifi_esp32


### PR DESCRIPTION
## Summary

Register a new library by adding one URL to `repositories.txt`.

- **Library name:** DevLabDDP
- **Repository:** https://github.com/UNIT-Electronics-MX/unit_devlab_ddp_library
- **Author:** UNIT Electronics MX
- **License:** GPL-3.0
- **Latest release tag:** v1.0.1
- **Target architectures:** `*` (architecture-independent)

## What the library does

DevLabDDP is an I2C master implementation of the DevLab Device Protocol (DDP),
a register-style command map shared by PY32-based sensor and actuator modules.
Rather than driving a single part, it discovers nodes on the bus and validates
each one's protocol version, device ID and capability bitmap before issuing any
device-specific operation, so address changes and resets cannot be applied to
the wrong node.

The API exposes a `Master` class (`identify`, `readAdc`, `readGpio0`,
`getI2cAddress`, `setI2cAddress`, `reset`) covering the DDP blocks for device
info, persistent I2C configuration, logical GPIO, analog channels, relays and a
WS12xx/NeoPixel extension, plus an optional serial `Console` front-end for
interactive bus inspection. Registered device IDs include joystick, TEMT6000
ambient light, DS18B20 temperature, PIR motion and WS12xx NeoPixel modules.

It is useful to the Arduino community as the shared dependency that any board
can use to talk to DDP-compliant hardware, and as the base other UNIT DevLab
libraries declare via `depends=`.