### PR TITLE
Add shark_pid

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -9933,3 +9933,4 @@ https://github.com/pucheta/Roberto_MPU6050
 https://github.com/argeorun/MODBUS-RTU_Slave_Ardu_Lib
 https://github.com/soosp/HomeAssistantDiscovery
 https://github.com/GUNANAG38/MiniMicroKit_PTL
+https://github.com/nguyenbinh-shark/shark_pid


### PR DESCRIPTION
Submitting `shark_pid` for inclusion in the Library Manager index.

- Repository: https://github.com/nguyenbinh-shark/shark_pid
- Release tag: `1.0.0`
- An embedded 2-DOF PID controller. Its C99 core reimplements the Simulink `PID Controller (2DOF)` block, so a model tuned in simulation matches the controller that runs on the microcontroller.

Arduino Lint runs in the library's own CI with `compliance: strict` and `library-manager: submit`, and passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)