### PR TITLE
Add Pyintel Lux repository to repositories.txt

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -9937,3 +9937,4 @@ https://github.com/soosp/HomeAssistantDiscovery
 https://github.com/GUNANAG38/MiniMicroKit_PTL
 https://github.com/nguyenbinh-shark/shark_pid
 https://github.com/NguyenHien-8/ESP32WiFiPortal
+https://github.com/Pyintel/pyintel-lux


### PR DESCRIPTION
This PR adds the repository URL for Pyintel Lux to repositories.txt.

Repository: https://github.com/Pyintel/pyintel-lux
Latest Release: v0.1.0
Specification: Fully compliant with 1.5 Arduino library layout.