### PR TITLE
Update Pyintel Lux library URL to dedicated repository pyintel-lux-arduino

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -9937,4 +9937,4 @@ https://github.com/soosp/HomeAssistantDiscovery
 https://github.com/GUNANAG38/MiniMicroKit_PTL
 https://github.com/nguyenbinh-shark/shark_pid
 https://github.com/NguyenHien-8/ESP32WiFiPortal
-https://github.com/Pyintel/pyintel-lux
+https://github.com/Pyintel/pyintel-lux-arduino


### PR DESCRIPTION
## Maintenance Request: Update Library URL

This PR updates the repository URL for **Pyintel Lux** (Pyintel_Lux) to point to its dedicated standalone Arduino library repository:

- **Old URL**: https://github.com/Pyintel/pyintel-lux
- **New URL**: https://github.com/Pyintel/pyintel-lux-arduino

### Reason for Request
We separated the core specification/desktop tooling repository (pyintel-lux) from the standalone Arduino library repository (pyintel-lux-arduino) to maintain a clean 1.5 Arduino specification layout and avoid non-sketch files.

The new repository is fully compliant, licensed (MIT), and contains the 0.1.1 release.