### PR TITLE
Update repositories.txt

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -9938,3 +9938,4 @@ https://github.com/GUNANAG38/MiniMicroKit_PTL
 https://github.com/nguyenbinh-shark/shark_pid
 https://github.com/NguyenHien-8/ESP32WiFiPortal
 https://github.com/Pyintel/pyintel-lux
+https://github.com/StrayerSQH/IMU406


### PR DESCRIPTION
Add IMU406 to the registry

IMU406 is a non-blocking Arduino library for the IMU406 serial (UART TTL) attitude sensor: 29-byte 0x84 BCD protocol, exposing roll/pitch/yaw plus 3-axis accelerometer and gyroscope. Compatible with AVR, ESP32, SAMD, STM32, RP2040.