### PR TITLE
Add Poom library

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -9941,3 +9941,4 @@ https://github.com/NguyenHien-8/ESP32WiFiPortal
 https://github.com/Pyintel/pyintel-lux-arduino
 https://github.com/StrayerSQH/IMU406
 https://github.com/msnicklous/DYSV17Fmp3
+https://github.com/The-POOM/poom-arduino


### PR DESCRIPTION
Adds the Poom Arduino library to the Arduino Library Manager registry.

Repository:
https://github.com/The-POOM/poom-arduino

Initial release: 1.0.0