### PR TITLE
Add new libraries to repositories .txt, DVI for RP2040

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -9096,6 +9096,7 @@ https://github.com/UNIT-Electronics-MX/unit_cmsis_dap_ch55x_library
 https://github.com/UNIT-Electronics-MX/unit_devlab_joystickcontroller_library
 https://github.com/UNIT-Electronics-MX/unit_devlab_mpu6050_library
 https://github.com/UNIT-Electronics-MX/unit_devlab_tcan1051hvd_library
+https://github.com/UNIT-Electronics-MX/unit_devlab_ddp_library
 https://github.com/jmwanderer/tlv.arduino
 https://github.com/PaulNTU/MoonMin-Scanner-Arduino-Library
 https://gitlab.com/Vishal1695/mvswifi_esp32

--- a/repositories.txt
+++ b/repositories.txt
@@ -9101,6 +9101,8 @@ https://github.com/UNIT-Electronics-MX/unit_devlab_mpu6050_library
 https://github.com/UNIT-Electronics-MX/unit_devlab_tcan1051hvd_library
 https://github.com/UNIT-Electronics-MX/unit_devlab_ddp_library
 https://github.com/UNIT-Electronics-MX/unit_devlab_temt6000_library
+https://github.com/UNIT-Electronics-MX/unit_devlab_dvihstx_graphics_library
+https://github.com/UNIT-Electronics-MX/unit_devlab_dvipio_graphics_library
 https://github.com/jmwanderer/tlv.arduino
 https://github.com/PaulNTU/MoonMin-Scanner-Arduino-Library
 https://gitlab.com/Vishal1695/mvswifi_esp32

--- a/repositories.txt
+++ b/repositories.txt
@@ -9097,6 +9097,7 @@ https://github.com/UNIT-Electronics-MX/unit_devlab_joystickcontroller_library
 https://github.com/UNIT-Electronics-MX/unit_devlab_mpu6050_library
 https://github.com/UNIT-Electronics-MX/unit_devlab_tcan1051hvd_library
 https://github.com/UNIT-Electronics-MX/unit_devlab_ddp_library
+https://github.com/UNIT-Electronics-MX/unit_devlab_temt6000_library
 https://github.com/jmwanderer/tlv.arduino
 https://github.com/PaulNTU/MoonMin-Scanner-Arduino-Library
 https://gitlab.com/Vishal1695/mvswifi_esp32


### PR DESCRIPTION
Adds support for a DVI output library covering both RP2040 (PIO-based) and RP2350 (HSTX-based) implementations.