### PR TITLE
Add new repository link for SNMP_Embedded

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -9954,3 +9954,4 @@ https://github.com/sukanta0011/DAC8568
 https://github.com/nahomyirga787-spec/Biovo1020A.git
 https://github.com/Microeden/MicroedenConnect
 https://github.com/Microeden/MyDotLib
+https://github.com/syntax1269/SNMP_Embedded


### PR DESCRIPTION
Adds https://github.com/syntax1269/SNMP_Embedded to the Library Manager index.

**Name (library.properties):** `SNMP_Embedded` — unique in the index (checked against
library_index.json; the legacy `SNMP_Agent` name is intentionally avoided as it is
already taken by the upstream original).

**What it is:** a memory-safe SNMPv2c agent library for ESP32/ESP8266 with
compile-time derived resource sizing (packet budget → varbind cap → pool size),
boot-time arena lock-in, stateless trap/inform sends, and loud RFC 3416 `tooBig`
rejection instead of silent drops.

**Why it's valuable to the community:** it is the maintained continuation of
Arduino_SNMP (0neblock, v2.1.0, MIT — last upstream release ~2022), which remains
widely used but unmaintained. SNMP_Embedded carries a hardware-validated reliability
campaign: 30+ minute soak and flood tests on a 1 MB ESP8266 with zero pool alarms,
zero reboots, and flat heap. The original author has been notified via an open
issue on the upstream repo; the MIT license is preserved with dual copyright
(attribution retained in LICENSE).

**Compliance:** arduino-lint (specification, recursive) passes in the repo's own CI
(.github/workflows/test.yml) alongside a host Catch2 test suite (175 assertions /
17 cases) and an ESP8266 + ESP32 example compile matrix. The `v3.3.3` tag exists and
is compliant: library.properties in root, sentence ≤ 63 chars, no `.development`
file, no executables, no symlinks, no name collision, name does not start with
"Arduino".
```
