### PR TITLE
Rename PedroRobot repository to PedroFirmware

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -9071,7 +9071,7 @@ https://github.com/dac1e/RcSwitchTransmitter
 https://github.com/ennio64/StepperHAL_STM32F4x1-Library
 https://github.com/AymenTurki0/Aerobotix_Arduino_navigation
 https://github.com/Chanatip112/HanumanMini
-https://github.com/almtzr/PedroRobot
+https://github.com/almtzr/PedroFirmware
 https://github.com/Alteriom/EByte_LoRa_E220_Series_Library
 https://github.com/SvenRosvall/VLCB-Arduino
 https://github.com/SvenRosvall/VCAN2515


### PR DESCRIPTION
Hi,

I would like to rename my repository library.
Sorry I didn't know if it's possible to rename my repository library by a pull request.

Waiting for you for the correct process if it is needed.

Thanks