### PR TITLE
Update name and URL of "PedroFirmware"

### DIFF
--- a/registry.txt
+++ b/registry.txt
@@ -8419,7 +8419,7 @@ https://github.com/mathieucarbou/MycilaDimmer.git|Contributed|MycilaDimmer
 https://github.com/gvp-257/DietSerial.git|Contributed|DietSerial
 https://github.com/dejwk/roo_blink.git|Contributed|roo_blink
 https://github.com/Chanatip112/HanumanMini.git|Contributed|HanumanMini
-https://github.com/almtzr/PedroRobot.git|Contributed|PedroRobot
+https://github.com/almtzr/PedroRobot.git|Contributed|PedroFirmware
 https://github.com/PubInv/SFM3X00.git|Contributed|SFM3X00
 https://github.com/TEXHOUM/TEXHOUM_US.git|Contributed|TEXHOUM_US
 https://github.com/TEXHOUM/TEXHOUM_MOTOR.git|Contributed|TEXHOUM_MOTOR

--- a/registry.txt
+++ b/registry.txt
@@ -8419,7 +8419,7 @@ https://github.com/mathieucarbou/MycilaDimmer.git|Contributed|MycilaDimmer
 https://github.com/gvp-257/DietSerial.git|Contributed|DietSerial
 https://github.com/dejwk/roo_blink.git|Contributed|roo_blink
 https://github.com/Chanatip112/HanumanMini.git|Contributed|HanumanMini
-https://github.com/almtzr/PedroRobot.git|Contributed|PedroFirmware
+https://github.com/almtzr/PedroFirmware.git|Contributed|PedroFirmware
 https://github.com/PubInv/SFM3X00.git|Contributed|SFM3X00
 https://github.com/TEXHOUM/TEXHOUM_US.git|Contributed|TEXHOUM_US
 https://github.com/TEXHOUM/TEXHOUM_MOTOR.git|Contributed|TEXHOUM_MOTOR


### PR DESCRIPTION
This PR consists of two changes:

- Change URL from `https://github.com/almtzr/PedroRobot.git` to `https://github.com/almtzr/PedroFirmware.git` (companion to https://github.com/arduino/library-registry/pull/9039).
- Change name from `PedroRobot` to `PedroFirmware`

Since the name change operation on the database is actually a removal followed by automated re-indexing of the updated registry entry on the next job run, the URL update will occur as a matter of course. For this reason, the only operation required from the backend maintainer is a standard name change procedure.