### PR TITLE
Add FlovaSDK library

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -9961,3 +9961,4 @@ https://github.com/Microeden/MyDotLib
 https://github.com/syntax1269/SNMP_Embedded
 https://github.com/bcan77/CiftPulsar-OTA
 https://github.com/ailagari/LagariMotors
+https://github.com/flova-platform/flova-firmware


### PR DESCRIPTION
Adds the FlovaSDK repository to Arduino Library Manager.\n\nThe latest release is v0.2.0 and supports ESP32.