### PR TITLE
Add new library: Candle

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -9962,3 +9962,4 @@ https://github.com/syntax1269/SNMP_Embedded
 https://github.com/bcan77/CiftPulsar-OTA
 https://github.com/ailagari/LagariMotors
 https://github.com/flova-platform/flova-firmware
+https://github.com/ShadowShahriar/Candle


### PR DESCRIPTION
I have written a small Arduino library called **Candle** and I'd like to add it to the library registry.