### PR TITLE
Add pulsync/pulsync-arduino

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -9963,3 +9963,4 @@ https://github.com/bcan77/CiftPulsar-OTA
 https://github.com/ailagari/LagariMotors
 https://github.com/flova-platform/flova-firmware
 https://github.com/ShadowShahriar/Candle
+https://github.com/pulsync/pulsync-arduino


### PR DESCRIPTION
Adding the Pulsync library — a non-blocking task scheduler + real-time cloud sync for the ESP32.

Repo: https://github.com/pulsync/pulsync-arduino

arduino-lint (`--library-manager submit`) passes with no errors or warnings.