### PR TITLE
Add ristllin/EmbeddedTemporal

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -4673,9 +4673,7 @@ https://github.com/Lynxmotion/LSS_Library_Arduino
 https://github.com/lyriarte/StripDisplay
 https://github.com/lysek01/ModbusPowerMeter/
 https://github.com/lysek01/PulseFlowMeter/
-
 https://github.com/lysek01/ENS22/
-
 https://github.com/lyvewave/arduino-serial-data-exporter
 https://github.com/M-Reimer/EncoderStepCounter
 https://github.com/M-Reimer/IwitVolumeKnob
@@ -9973,3 +9971,4 @@ https://github.com/pulsync/pulsync-arduino
 https://github.com/MaSzyna-EU07/mhp_arduino_library
 https://github.com/ktauchathuranga/CC1101_AnalogFM
 https://github.com/FsBotzTg/SevenSegCountdown
+https://github.com/ristllin/EmbeddedTemporal


### PR DESCRIPTION
Adding a new library: **EmbeddedTemporal** — a Temporal / Mistral Workflows activity worker for ESP32.

- Repository: https://github.com/ristllin/EmbeddedTemporal
- Passes `arduino-lint --compliance strict --library-manager submit` with no errors or warnings.
- Tagged `v0.1.1`; `library.properties` at the repo root; `architectures=esp32`.
- Generated from the monorepo https://github.com/ristllin/embedded-temporal.