### PR TITLE
Added new library for bus interface in DevLab Ecosystems

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -9096,6 +9096,7 @@ https://github.com/UNIT-Electronics-MX/unit_cmsis_dap_ch55x_library
 https://github.com/UNIT-Electronics-MX/unit_devlab_joystickcontroller_library
 https://github.com/UNIT-Electronics-MX/unit_devlab_mpu6050_library
 https://github.com/UNIT-Electronics-MX/unit_devlab_tcan1051hvd_library
+https://github.com/UNIT-Electronics-MX/unit_devlab_ddp_library
 https://github.com/jmwanderer/tlv.arduino
 https://github.com/PaulNTU/MoonMin-Scanner-Arduino-Library
 https://gitlab.com/Vishal1695/mvswifi_esp32

--- a/repositories.txt
+++ b/repositories.txt
@@ -9101,6 +9101,8 @@ https://github.com/UNIT-Electronics-MX/unit_devlab_mpu6050_library
 https://github.com/UNIT-Electronics-MX/unit_devlab_tcan1051hvd_library
 https://github.com/UNIT-Electronics-MX/unit_devlab_ddp_library
 https://github.com/UNIT-Electronics-MX/unit_devlab_temt6000_library
+https://github.com/UNIT-Electronics-MX/unit_devlab_dvihstx_graphics_library
+https://github.com/UNIT-Electronics-MX/unit_devlab_dvipio_graphics_library
 https://github.com/jmwanderer/tlv.arduino
 https://github.com/PaulNTU/MoonMin-Scanner-Arduino-Library
 https://gitlab.com/Vishal1695/mvswifi_esp32

--- a/repositories.txt
+++ b/repositories.txt
@@ -9097,6 +9097,7 @@ https://github.com/UNIT-Electronics-MX/unit_devlab_joystickcontroller_library
 https://github.com/UNIT-Electronics-MX/unit_devlab_mpu6050_library
 https://github.com/UNIT-Electronics-MX/unit_devlab_tcan1051hvd_library
 https://github.com/UNIT-Electronics-MX/unit_devlab_ddp_library
+https://github.com/UNIT-Electronics-MX/unit_devlab_temt6000_library
 https://github.com/jmwanderer/tlv.arduino
 https://github.com/PaulNTU/MoonMin-Scanner-Arduino-Library
 https://gitlab.com/Vishal1695/mvswifi_esp32

--- a/repositories.txt
+++ b/repositories.txt
@@ -9116,6 +9116,7 @@ https://github.com/UNIT-Electronics-MX/unit_devlab_ddp_library
 https://github.com/UNIT-Electronics-MX/unit_devlab_temt6000_library
 https://github.com/UNIT-Electronics-MX/unit_devlab_dvihstx_graphics_library
 https://github.com/UNIT-Electronics-MX/unit_devlab_dvipio_graphics_library
+https://github.com/UNIT-Electronics-MX/unit_devlab_interface_library
 https://github.com/jmwanderer/tlv.arduino
 https://github.com/PaulNTU/MoonMin-Scanner-Arduino-Library
 https://gitlab.com/Vishal1695/mvswifi_esp32


### PR DESCRIPTION
Adds a generic, reusable I2C communication interface (DevLab_BusIO, DevLab_I2C_Interface) for DevLab and external sensors, along with new examples (BusIO_Basic, BusIO_WhoAmI) and updated library.properties.