### PR TITLE
Add rp2 dvi hstx library

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -9096,6 +9096,7 @@ https://github.com/UNIT-Electronics-MX/unit_cmsis_dap_ch55x_library
 https://github.com/UNIT-Electronics-MX/unit_devlab_joystickcontroller_library
 https://github.com/UNIT-Electronics-MX/unit_devlab_mpu6050_library
 https://github.com/UNIT-Electronics-MX/unit_devlab_tcan1051hvd_library
+https://github.com/UNIT-Electronics-MX/unit_devlab_ddp_library
 https://github.com/jmwanderer/tlv.arduino
 https://github.com/PaulNTU/MoonMin-Scanner-Arduino-Library
 https://gitlab.com/Vishal1695/mvswifi_esp32

--- a/repositories.txt
+++ b/repositories.txt
@@ -9101,6 +9101,8 @@ https://github.com/UNIT-Electronics-MX/unit_devlab_mpu6050_library
 https://github.com/UNIT-Electronics-MX/unit_devlab_tcan1051hvd_library
 https://github.com/UNIT-Electronics-MX/unit_devlab_ddp_library
 https://github.com/UNIT-Electronics-MX/unit_devlab_temt6000_library
+https://github.com/UNIT-Electronics-MX/unit_devlab_dvihstx_graphics_library
+https://github.com/UNIT-Electronics-MX/unit_devlab_dvipio_graphics_library
 https://github.com/jmwanderer/tlv.arduino
 https://github.com/PaulNTU/MoonMin-Scanner-Arduino-Library
 https://gitlab.com/Vishal1695/mvswifi_esp32

--- a/repositories.txt
+++ b/repositories.txt
@@ -9097,6 +9097,7 @@ https://github.com/UNIT-Electronics-MX/unit_devlab_joystickcontroller_library
 https://github.com/UNIT-Electronics-MX/unit_devlab_mpu6050_library
 https://github.com/UNIT-Electronics-MX/unit_devlab_tcan1051hvd_library
 https://github.com/UNIT-Electronics-MX/unit_devlab_ddp_library
+https://github.com/UNIT-Electronics-MX/unit_devlab_temt6000_library
 https://github.com/jmwanderer/tlv.arduino
 https://github.com/PaulNTU/MoonMin-Scanner-Arduino-Library
 https://gitlab.com/Vishal1695/mvswifi_esp32

--- a/repositories.txt
+++ b/repositories.txt
@@ -9116,6 +9116,7 @@ https://github.com/UNIT-Electronics-MX/unit_devlab_ddp_library
 https://github.com/UNIT-Electronics-MX/unit_devlab_temt6000_library
 https://github.com/UNIT-Electronics-MX/unit_devlab_dvihstx_graphics_library
 https://github.com/UNIT-Electronics-MX/unit_devlab_dvipio_graphics_library
+https://github.com/UNIT-Electronics-MX/unit_devlab_interface_library
 https://github.com/jmwanderer/tlv.arduino
 https://github.com/PaulNTU/MoonMin-Scanner-Arduino-Library
 https://gitlab.com/Vishal1695/mvswifi_esp32

--- a/repositories.txt
+++ b/repositories.txt
@@ -9117,6 +9117,7 @@ https://github.com/UNIT-Electronics-MX/unit_devlab_temt6000_library
 https://github.com/UNIT-Electronics-MX/unit_devlab_dvihstx_graphics_library
 https://github.com/UNIT-Electronics-MX/unit_devlab_dvipio_graphics_library
 https://github.com/UNIT-Electronics-MX/unit_devlab_interface_library
+https://github.com/UNIT-Electronics-MX/unit_rp2_dvi_hstx_library
 https://github.com/jmwanderer/tlv.arduino
 https://github.com/PaulNTU/MoonMin-Scanner-Arduino-Library
 https://gitlab.com/Vishal1695/mvswifi_esp32


### PR DESCRIPTION
Move legacy library from UDVI_HSTX to URP2_DVI_HSTX to match Arduino Library Manager naming requirements, updating the header/source filenames (src/UDVI_HSTX.* → src/URP2_DVI_HSTX.*) and all references across examples and docs
Update library.properties: new library name, author changed to "UNIT Electronics",unit_rp2_dvi_hstx_library, and bump version to 1.0.1