### PR TITLE
Add tinyolfarve

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -9975,3 +9975,4 @@ https://github.com/MaSzyna-EU07/mhp_arduino_library
 https://github.com/ktauchathuranga/CC1101_AnalogFM
 https://github.com/FsBotzTg/SevenSegCountdown
 https://github.com/ristllin/EmbeddedTemporal
+https://github.com/aschet/tinyolfarve


### PR DESCRIPTION
Adding a new library: tinyolfarve — an embedded-friendly port of cppolfarve for rendering SRM/EBC beer color values as sRGB