### PR TITLE
remove my lib RingBufferStream

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -8211,6 +8211,7 @@ https://gitlab.com/arduino-libraries/stackstring
 https://gitlab.com/arduino-libraries/stens-timer
 https://gitlab.com/arduino23/ExtendedTouchEvent
 https://gitlab.com/atesin/minimallinkedlist_arduino
+https://gitlab.com/atesin/ringbufferstream
 https://gitlab.com/atesin/XxHash_arduino
 https://gitlab.com/ben-bartholomew/adafruit_max9744_library
 https://gitlab.com/chatpeth/nx2003

--- a/repositories.txt
+++ b/repositories.txt
@@ -8222,7 +8222,6 @@ https://gitlab.com/arduino-libraries/stackstring
 https://gitlab.com/arduino-libraries/stens-timer
 https://gitlab.com/arduino23/ExtendedTouchEvent
 https://gitlab.com/atesin/minimallinkedlist_arduino
-https://gitlab.com/atesin/ringbufferstream
 https://gitlab.com/atesin/XxHash_arduino
 https://gitlab.com/ben-bartholomew/adafruit_max9744_library
 https://gitlab.com/chatpeth/nx2003


### PR DESCRIPTION
please remove my lib RingBufferStream because i want to relicense and fix some bugs... i was researching and realized wtfpl could be risky in some cases so want to put under a more serious license, and also take the chance to fix some bugs i found... so i want to delete and rollback everything, thanks