### PR TITLE
Change URL of SnappyXOShield

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -1,4 +1,4 @@
-https://github.com/samar-01/SnappyXOShield
+https://github.com/snappyxo/SnappyXOShield
 https://github.com/DIYables/DIYables_DS18B20
 https://github.com/240974a/FmtTiny
 https://github.com/klenov1900-lang/TM1637_6Easy

--- a/repositories.txt
+++ b/repositories.txt
@@ -1,3 +1,4 @@
+https://github.com/samar-01/SnappyXOShield
 https://github.com/DIYables/DIYables_DS18B20
 https://github.com/240974a/FmtTiny
 https://github.com/klenov1900-lang/TM1637_6Easy


### PR DESCRIPTION
The repo was transferred so now the URL needs to be updated.