### PR TITLE
Update URL of "SnappyXOShield"

### DIFF
--- a/registry.txt
+++ b/registry.txt
@@ -9963,7 +9963,7 @@ https://github.com/MaSzyna-EU07/mhp_arduino_library.git|Contributed|MaSzyna Hard
 https://github.com/FsBotzTg/SevenSegCountdown.git|Contributed|SevenSegCountdown
 https://github.com/240974a/FmtTiny.git|Contributed|FmtTiny
 https://github.com/DIYables/DIYables_DS18B20.git|Contributed|DIYables_DS18B20
-https://github.com/samar-01/SnappyXOShield.git|Contributed|SnappyXOShield
+https://github.com/snappyxo/SnappyXOShield.git|Contributed|SnappyXOShield
 https://github.com/franzbischoff/mpx-arduino-cpp17.git|Contributed|MpxCpp17
 https://github.com/franzbischoff/mpx-arduino.git|Contributed|Mpx
 https://github.com/ristllin/EmbeddedTemporal.git|Contributed|EmbeddedTemporal


### PR DESCRIPTION
Companion to https://github.com/arduino/library-registry/pull/9085