### PR TITLE
Add Kelvarune SDK

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -9986,3 +9986,4 @@ https://github.com/aschet/tinyolfarve
 https://github.com/panjingwei1945/PWM_Pulse
 https://github.com/thecaptainexe/OLEDAnimator
 https://github.com/ReP64/CH462x
+https://github.com/minervasoft-inc/Kelvarune


### PR DESCRIPTION
Adds the Kelvarune SDK, an Arduino library for ESP32 that lets a device be monitored, debugged, and controlled from the Kelvarune app (iOS/Android) over BLE or Wi-Fi.

- Repository: https://github.com/minervasoft-inc/Kelvarune
- License: MIT
- Tagged release: 1.0.0 (matches `library.properties`)