### PR TITLE
Add ZanWifiSetup

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -9989,3 +9989,4 @@ https://github.com/thecaptainexe/OLEDAnimator
 https://github.com/ReP64/CH462x
 https://github.com/minervasoft-inc/Kelvarune
 https://github.com/cmsolomon/lightweight-shell
+https://github.com/ZAN-Tech-bd/esp-wifi-provisioning


### PR DESCRIPTION
## Library submission: ZanWifiSetup

**Repository:** https://github.com/ZAN-Tech-bd/esp-wifi-provisioning

One-time Wi-Fi setup for any ESP32 project - opens a setup hotspot with a web form if no saved (or working) Wi-Fi is found, saves credentials to flash, shows connection status on the onboard LED, and resets via a button hold. Install once, and every future ESP32 project just includes it and never touches Wi-Fi provisioning code again.

### Checklist

- [x] `library.properties` present at repository root, all fields filled in
- [x] At least one tagged release (`v1.0.0`) matching the `library.properties` version
- [x] Examples included (`WifiOnly`, `BlinkWhileConnected`, `CustomConfiguration`), all compiling clean
- [x] MIT license included
- [x] Verified with `arduino-lint --compliance=strict --library-manager=submit`: 0 errors, 0 warnings

ðŸ¤– Generated with [Claude Code](https://claude.com/claude-code)
