### PR TITLE
Add DS1682 repository link to repositories.txt

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -6291,6 +6291,7 @@ https://github.com/RobTillaart/DHTstable
 https://github.com/RobTillaart/DistanceTable
 https://github.com/RobTillaart/DMM
 https://github.com/RobTillaart/DRV8825
+https://github.com/RobTillaart/DS1682
 https://github.com/RobTillaart/DS1804
 https://github.com/RobTillaart/DS1821
 https://github.com/RobTillaart/DS18B20


### PR DESCRIPTION
Arduino library for the I2C DS1682 elapsed time monitor.